### PR TITLE
Additional options for the 'Remove Missing Files' action

### DIFF
--- a/JMMClient/Enums.cs
+++ b/JMMClient/Enums.cs
@@ -43,7 +43,10 @@ namespace JMMClient
 	{
 		Delete = 0,
 		MarkDeleted = 1,
-        MarkExternalStorage = 2
+        MarkExternalStorage = 2,
+        MarkUnknown = 3,
+        DeleteLocalOnly = 4
+		
 	}
 
 	public enum RatingCollectionState

--- a/JMMClient/UserControls/Settings/AniDBMyListSettings.xaml.cs
+++ b/JMMClient/UserControls/Settings/AniDBMyListSettings.xaml.cs
@@ -33,6 +33,8 @@ namespace JMMClient.UserControls
 			cboDeleteAction.Items.Add("Delete File");
 			cboDeleteAction.Items.Add("Mark Deleted");
             cboDeleteAction.Items.Add("Mark External (CD/DVD)");
+			cboDeleteAction.Items.Add("Mark Unknown");
+			cboDeleteAction.Items.Add("Delete locally only");
 			cboDeleteAction.SelectedIndex = 0;
 
 			this.Loaded += new RoutedEventHandler(AniDBMyListSettings_Loaded);


### PR DESCRIPTION
Mark Unknown - Sets anidb mylist status of missing files to Unknown
Delete locally only - Missing files are only removed from local DB, no anidb
mylist action is taken