### PR TITLE
Added Sukebei to available torrent sites to search and browse

### DIFF
--- a/JMMClient/Downloads/DownloadHelper.cs
+++ b/JMMClient/Downloads/DownloadHelper.cs
@@ -117,7 +117,44 @@ namespace JMMClient.Downloads
 					links.AddRange(dictLinks.Values);
 				}
 
-				if (src.TorrentSource == TorrentSourceType.AnimeSuki)
+                if (src.TorrentSource == TorrentSourceType.Sukebei)
+                {
+                    TorrentsSukebei sukebei = new TorrentsSukebei();
+                    List<TorrentLinkVM> ttLinks = null;
+                    Dictionary<string, TorrentLinkVM> dictLinks = new Dictionary<string, TorrentLinkVM>();
+
+                    foreach (string grp in episodeGroupParms)
+                    {
+                        List<string> tempParms = new List<string>();
+                        foreach (string parmTemp in parms)
+                            tempParms.Add(parmTemp);
+                        tempParms.Insert(0, grp);
+                        ttLinks = sukebei.GetTorrents(tempParms);
+
+                        logger.Trace("Searching for: " + search.ToString() + "(" + grp + ")");
+
+                        // only use the first 10
+                        int x = 0;
+                        foreach (TorrentLinkVM link in ttLinks)
+                        {
+                            if (x == 10) break;
+                            dictLinks[link.TorrentDownloadLink] = link;
+                            logger.Trace("Adding link: " + link.ToString());
+                        }
+                    }
+
+                    logger.Trace("Searching for: " + search.ToString());
+                    ttLinks = sukebei.GetTorrents(parms);
+                    foreach (TorrentLinkVM link in ttLinks)
+                    {
+                        dictLinks[link.TorrentDownloadLink] = link;
+                        //logger.Trace("Adding link: " + link.ToString());
+                    }
+
+                    links.AddRange(dictLinks.Values);
+                }
+
+                if (src.TorrentSource == TorrentSourceType.AnimeSuki)
 				{
 					TorrentsAnimeSuki suki = new TorrentsAnimeSuki();
 					List<TorrentLinkVM> sukiLinks = suki.GetTorrents(parms);

--- a/JMMClient/Downloads/TorrentSourceVM.cs
+++ b/JMMClient/Downloads/TorrentSourceVM.cs
@@ -102,7 +102,14 @@ namespace JMMClient.Downloads
 				links.AddRange(ttLinks);
 			}
 
-			if (TorrentSource == TorrentSourceType.TokyoToshokanAnime)
+            if (TorrentSource == TorrentSourceType.Sukebei)
+            {
+                TorrentsSukebei sukebei = new TorrentsSukebei();
+                List<TorrentLinkVM> ttLinks = sukebei.BrowseTorrents();
+                links.AddRange(ttLinks);
+            }
+
+            if (TorrentSource == TorrentSourceType.TokyoToshokanAnime)
 			{
 				TorrentsTokyoToshokan tt = new TorrentsTokyoToshokan(TorrentSourceType.TokyoToshokanAnime);
 				List<TorrentLinkVM> ttLinks = tt.BrowseTorrents();

--- a/JMMClient/Downloads/TorrentsSukebei.cs
+++ b/JMMClient/Downloads/TorrentsSukebei.cs
@@ -1,0 +1,288 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NLog;
+using System.Web;
+
+namespace JMMClient.Downloads
+{
+    public class TorrentsSukebei : ITorrentSource
+    {
+        private static Logger logger = LogManager.GetCurrentClassLogger();
+        private TorrentSourceType SourceType = TorrentSourceType.Sukebei;
+
+        #region ITorrentSource Members
+
+        public string TorrentSourceName
+        {
+            get
+            {
+                return EnumTranslator.TorrentSourceTranslated(SourceType);
+            }
+        }
+
+        public string TorrentSourceNameShort
+        {
+            get
+            {
+                return EnumTranslator.TorrentSourceTranslatedShort(SourceType);
+            }
+        }
+
+        public string GetSourceName()
+        {
+            return TorrentSourceName;
+        }
+
+        public string GetSourceNameShort()
+        {
+            return TorrentSourceNameShort;
+        }
+
+        public bool SupportsSearching()
+        {
+            return true;
+        }
+
+        public bool SupportsBrowsing()
+        {
+            return true;
+        }
+
+        public bool SupportsCRCMatching()
+        {
+            return true;
+        }
+
+
+        private List<TorrentLinkVM> ParseSource(string output)
+        {
+            List<TorrentLinkVM> torLinks = new List<TorrentLinkVM>();
+
+            char q = (char)34;
+            string quote = q.ToString();
+
+            //class="tlistthone">Category
+            //string startBlock = @"https://sukebei.nyaa.eu/?page=torrentinfo";
+            string startBlock = @"class=" + quote + "tlistthone" + quote + ">Category";
+
+            //<td class="tlistname">
+            string nameStart1 = @"<td class=" + quote + "tlistname" + quote + "><a href=";
+
+            string nameStart2 = ">";
+            string nameEnd2 = "</a>";
+
+            string torStart = "href=" + quote;
+            string torEnd = quote;
+
+
+
+            string sizeStart = "tlistsize" + quote + ">";
+            string sizeEnd = "</td>";
+
+            string seedStart = "tlistsn" + quote + ">";
+            string seedEnd = "</td>";
+
+            string leechStart = "tlistln" + quote + ">";
+            string leechEnd = "</td>";
+
+            int pos = output.IndexOf(startBlock, 0);
+            while (pos > 0)
+            {
+
+                if (pos <= 0) break;
+
+                // find the start of the torrent
+                int posBegin = output.IndexOf(nameStart1, pos + 1);
+                if (posBegin <= 0) break;
+
+                int posNameStart = output.IndexOf(nameStart2, posBegin + nameStart1.Length + 1);
+                int posNameEnd = output.IndexOf(nameEnd2, posNameStart + nameStart2.Length + 1);
+
+                string torName = output.Substring(posNameStart + nameStart2.Length, posNameEnd - posNameStart - nameStart2.Length);
+
+                int posTorStart = output.IndexOf(torStart, posNameEnd);
+                int posTorEnd = output.IndexOf(torEnd, posTorStart + torStart.Length + 1);
+
+                string torLink = output.Substring(posTorStart + torStart.Length, posTorEnd - posTorStart - torStart.Length);
+                torLink = DownloadHelper.FixNyaaTorrentLink(torLink);
+
+                // remove html codes
+                torLink = HttpUtility.HtmlDecode(torLink);
+
+                string torSize = "";
+                int posSizeStart = output.IndexOf(sizeStart, posNameEnd);
+                int posSizeEnd = 0;
+                if (posSizeStart > 0)
+                {
+                    posSizeEnd = output.IndexOf(sizeEnd, posSizeStart + sizeStart.Length + 1);
+
+                    torSize = output.Substring(posSizeStart + sizeStart.Length, posSizeEnd - posSizeStart - sizeStart.Length);
+                }
+
+                string torSeed = "";
+                int posSeedStart = output.IndexOf(seedStart, posSizeEnd);
+                int posSeedEnd = 0;
+                if (posSeedStart > 0)
+                {
+                    posSeedEnd = output.IndexOf(seedEnd, posSeedStart + seedStart.Length + 1);
+
+                    torSeed = output.Substring(posSeedStart + seedStart.Length, posSeedEnd - posSeedStart - seedStart.Length);
+                }
+
+                string torLeech = "";
+                int posLeechStart = output.IndexOf(leechStart, posSeedStart + 3);
+                int posLeechEnd = 0;
+                if (posLeechStart > 0)
+                {
+                    posLeechEnd = output.IndexOf(leechEnd, posLeechStart + leechStart.Length + 1);
+
+                    torLeech = output.Substring(posLeechStart + leechStart.Length, posLeechEnd - posLeechStart - leechStart.Length);
+                }
+
+                TorrentLinkVM torrentLink = new TorrentLinkVM(SourceType);
+                torrentLink.TorrentDownloadLink = torLink;
+                torrentLink.TorrentName = torName;
+                torrentLink.Size = torSize.Trim();
+                torrentLink.Seeders = torSeed.Trim();
+                torrentLink.Leechers = torLeech.Trim();
+                torLinks.Add(torrentLink);
+
+                pos = output.IndexOf(nameStart1, pos + 1);
+
+            }
+            //Console.ReadLine();
+
+            return torLinks;
+        }
+
+        private List<TorrentLinkVM> ParseSourceSingleResult(string output)
+        {
+            List<TorrentLinkVM> torLinks = new List<TorrentLinkVM>();
+
+            char q = (char)34;
+            string quote = q.ToString();
+
+            // Name:</td><td class="tinfotorrentname">
+            string startBlock = @"Name:";
+
+            // class="thead">Name:</td><td class="tinfotorrentname">[Hadena] Koi to Senkyo to Chocolate - 03 [720p] [9CD64623].mkv</td>
+            string nameStart = "tinfotorrentname" + quote + ">";
+            string nameEnd = "</td>";
+
+            // Seeders:</td><td class="vtop"><span class="tinfosn">17</span>
+            string seedStart = "Seeders:</td><td class=" + quote + "vtop" + quote + "><span class=" + quote + "tinfosn" + quote + ">";
+            string seedEnd = "</span>";
+
+            // Leechers:</td><td class="vtop"><span class="tinfoln">
+            string leechStart = "Leechers:</td><td class=" + quote + "vtop" + quote + "><span class=" + quote + "tinfoln" + quote + ">";
+            string leechEnd = "</span>";
+
+            // File size:</td><td class="vtop">193.8 MiB</td>
+            string sizeStart = "File size:</td><td class=" + quote + "vtop" + quote + ">";
+            string sizeEnd = "</td>";
+
+            // class="tinfodownloadbutton"><a href="https://sukebei.nyaa.eu/?page=download&#38;tid=334194"
+            string torStart = "class=" + quote + "tinfodownloadbutton" + quote + "><a href=" + quote;
+            string torEnd = quote;
+
+
+            int pos = output.IndexOf(startBlock, 0);
+            while (pos > 0)
+            {
+
+                if (pos <= 0) break;
+
+                int posNameStart = output.IndexOf(nameStart, pos + 1);
+                int posNameEnd = output.IndexOf(nameEnd, posNameStart + nameStart.Length + 1);
+
+                string torName = output.Substring(posNameStart + nameStart.Length, posNameEnd - posNameStart - nameStart.Length);
+
+                string torSeed = "";
+                int posSeedStart = output.IndexOf(seedStart, posNameEnd);
+                int posSeedEnd = 0;
+                if (posSeedStart > 0)
+                {
+                    posSeedEnd = output.IndexOf(seedEnd, posSeedStart + seedStart.Length + 1);
+                    torSeed = output.Substring(posSeedStart + seedStart.Length, posSeedEnd - posSeedStart - seedStart.Length);
+                }
+
+                string torLeech = "";
+                int posLeechStart = output.IndexOf(leechStart, posSeedEnd + 3);
+                int posLeechEnd = 0;
+                if (posLeechStart > 0)
+                {
+                    posLeechEnd = output.IndexOf(leechEnd, posLeechStart + leechStart.Length + 1);
+                    torLeech = output.Substring(posLeechStart + leechStart.Length, posLeechEnd - posLeechStart - leechStart.Length);
+                }
+
+                string torSize = "";
+                int posSizeStart = output.IndexOf(sizeStart, posLeechEnd);
+                int posSizeEnd = 0;
+                if (posSizeStart > 0)
+                {
+                    posSizeEnd = output.IndexOf(sizeEnd, posSizeStart + sizeStart.Length + 1);
+                    torSize = output.Substring(posSizeStart + sizeStart.Length, posSizeEnd - posSizeStart - sizeStart.Length);
+                }
+
+
+                int posTorStart = output.IndexOf(torStart, posSizeEnd);
+                int posTorEnd = output.IndexOf(torEnd, posTorStart + torStart.Length + 1);
+
+                string torLink = output.Substring(posTorStart + torStart.Length, posTorEnd - posTorStart - torStart.Length);
+                torLink = DownloadHelper.FixNyaaTorrentLink(torLink);
+
+                // remove html codes
+                torLink = HttpUtility.HtmlDecode(torLink);
+
+                TorrentLinkVM torrentLink = new TorrentLinkVM(SourceType);
+                torrentLink.TorrentDownloadLink = torLink;
+                torrentLink.TorrentName = torName;
+                torrentLink.Size = torSize.Trim();
+                torrentLink.Seeders = torSeed.Trim();
+                torrentLink.Leechers = torLeech.Trim();
+                torLinks.Add(torrentLink);
+
+                pos = output.IndexOf(startBlock, pos + 1);
+
+            }
+            //Console.ReadLine();
+
+            return torLinks;
+        }
+
+        public List<TorrentLinkVM> GetTorrents(List<string> searchParms)
+        {
+            string urlBase = "https://sukebei.nyaa.eu/?page=search&cats=1_37&filter=0&term={0}";
+
+            string searchCriteria = "";
+            foreach (string parm in searchParms)
+            {
+                if (searchCriteria.Length > 0) searchCriteria += "+";
+                searchCriteria += parm.Trim();
+            }
+
+            string url = string.Format(urlBase, searchCriteria);
+            string output = Utils.DownloadWebPage(url);
+
+            logger.Trace("GetTorrents Search: " + url);
+
+            // on nyaa if you search and there is only one result it goes straight to the dedicated torrent page
+            if (output.Contains("Searching torrents"))
+                return ParseSource(output);
+            else
+                return ParseSourceSingleResult(output);
+        }
+
+        public List<TorrentLinkVM> BrowseTorrents()
+        {
+            string url = "https://sukebei.nyaa.eu/?page=torrents&cats=1_37";
+            string output = Utils.DownloadWebPage(url);
+
+            return ParseSource(output);
+        }
+
+        #endregion
+    }
+}

--- a/JMMClient/Enums.cs
+++ b/JMMClient/Enums.cs
@@ -466,8 +466,9 @@ namespace JMMClient
 		BakaBT = 3,
 		Nyaa = 4,
 		AnimeSuki = 5,
-		AnimeBytes = 6
-	}
+		AnimeBytes = 6,
+        Sukebei = 7
+    }
 
 	public enum DownloadSearchType
 	{
@@ -528,7 +529,8 @@ namespace JMMClient
 				case TorrentSourceType.TokyoToshokanAll: return "Tokyo Toshokan (All)";
 				case TorrentSourceType.BakaBT: return "BakaBT";
 				case TorrentSourceType.Nyaa: return "Nyaa";
-				case TorrentSourceType.AnimeSuki: return "Anime Suki";
+                case TorrentSourceType.Sukebei: return "Sukebei Nyaa";
+                case TorrentSourceType.AnimeSuki: return "Anime Suki";
 				case TorrentSourceType.AnimeBytes: return "Anime Byt.es";
 				default: return "Tokyo Toshokan (Anime)";
 			}
@@ -542,7 +544,8 @@ namespace JMMClient
 				case TorrentSourceType.TokyoToshokanAll: return "TT";
 				case TorrentSourceType.BakaBT: return "BakaBT";
 				case TorrentSourceType.Nyaa: return "Nyaa";
-				case TorrentSourceType.AnimeSuki: return "Suki";
+                case TorrentSourceType.Sukebei: return "Suke Nyaa";
+                case TorrentSourceType.AnimeSuki: return "Suki";
 				case TorrentSourceType.AnimeBytes: return "AByt.es";
 				default: return "TT";
 			}
@@ -554,7 +557,8 @@ namespace JMMClient
 			if (tsType == "Tokyo Toshokan (All)") return TorrentSourceType.TokyoToshokanAll;
 			if (tsType == "BakaBT") return TorrentSourceType.BakaBT;
 			if (tsType == "Nyaa") return TorrentSourceType.Nyaa;
-			if (tsType == "Anime Suki") return TorrentSourceType.AnimeSuki;
+            if (tsType == "Sukebei Nyaa") return TorrentSourceType.Sukebei;
+            if (tsType == "Anime Suki") return TorrentSourceType.AnimeSuki;
 			if (tsType == "Anime Byt.es") return TorrentSourceType.AnimeBytes;
 
 			return TorrentSourceType.TokyoToshokanAnime;

--- a/JMMClient/JMMForWindows.csproj
+++ b/JMMClient/JMMForWindows.csproj
@@ -197,6 +197,7 @@
     <Compile Include="DataTemplateSelectors\RecDownloadTemplateSelector.cs" />
     <Compile Include="DataTemplateSelectors\RecWatchTemplateSelector.cs" />
     <Compile Include="DataTemplateSelectors\WatchingEpisodeTemplateSelector.cs" />
+    <Compile Include="Downloads\TorrentsSukebei.cs" />
     <Compile Include="Downloads\CsvParser.cs" />
     <Compile Include="Downloads\CsvStream.cs" />
     <Compile Include="Downloads\DownloadHelper.cs" />

--- a/JMMClient/ViewModel/UserSettingsVM.cs
+++ b/JMMClient/ViewModel/UserSettingsVM.cs
@@ -53,7 +53,8 @@ namespace JMMClient
 			sources.Add(new TorrentSourceVM(TorrentSourceType.TokyoToshokanAnime, true));
 			sources.Add(new TorrentSourceVM(TorrentSourceType.TokyoToshokanAll, true));
 			sources.Add(new TorrentSourceVM(TorrentSourceType.Nyaa, true));
-			sources.Add(new TorrentSourceVM(TorrentSourceType.AnimeSuki, true));
+            sources.Add(new TorrentSourceVM(TorrentSourceType.Sukebei, true));
+            sources.Add(new TorrentSourceVM(TorrentSourceType.AnimeSuki, true));
 			sources.Add(new TorrentSourceVM(TorrentSourceType.BakaBT, true));
 			sources.Add(new TorrentSourceVM(TorrentSourceType.AnimeBytes, true));
 


### PR DESCRIPTION
Added Sukebei, the adult tracker of Nyaa to the list of available sites for Searching and Browsing under Downloads as requested in #288. I added it as a separate entry so adult and non-adult content from Nyaa are not mixed together unless both sites are selected by the user. 