### PR TITLE
Replacing Hardcoded Text - Part 1

### DIFF
--- a/JMMClient/Enums.cs
+++ b/JMMClient/Enums.cs
@@ -530,7 +530,7 @@ namespace JMMClient
 				case TorrentSourceType.Nyaa: return "Nyaa";
                 case TorrentSourceType.Sukebei: return "Sukebei Nyaa";
                 case TorrentSourceType.AnimeSuki: return "Anime Suki";
-				case TorrentSourceType.AnimeBytes: return "Anime Byt.es";
+				case TorrentSourceType.AnimeBytes: return "AnimeBytes";
 				default: return "Tokyo Toshokan (Anime)";
 			}
 		}
@@ -558,7 +558,7 @@ namespace JMMClient
 			if (tsType == "Nyaa") return TorrentSourceType.Nyaa;
             if (tsType == "Sukebei Nyaa") return TorrentSourceType.Sukebei;
             if (tsType == "Anime Suki") return TorrentSourceType.AnimeSuki;
-			if (tsType == "Anime Byt.es") return TorrentSourceType.AnimeBytes;
+			if (tsType == "AnimeBytes") return TorrentSourceType.AnimeBytes;
 
 			return TorrentSourceType.TokyoToshokanAnime;
 		}

--- a/JMMClient/Forms/AboutForm.xaml
+++ b/JMMClient/Forms/AboutForm.xaml
@@ -41,7 +41,7 @@
             <StackPanel Orientation="Horizontal"  Margin="0,0,0,5">
                 <Image Height="24" Width="24" Source="/Images/32_WebDatabase.png" Margin="0,0,5,0"/>
 
-                <TextBlock Margin="5,0,0,0" FontWeight="DemiBold" Text="JMM Desktop" FontSize="20" VerticalAlignment="Center"/>
+                <TextBlock Margin="5,0,0,0" FontWeight="DemiBold" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=JMMDesktop}" FontSize="20" VerticalAlignment="Center"/>
                 <TextBlock Margin="10,0,0,0" FontWeight="DemiBold" FontSize="20" Foreground="DarkGray" Text="{Binding Source={x:Static local:JMMServerVM.Instance},Path=ApplicationVersion}" VerticalAlignment="Center"/>
     
 

--- a/JMMClient/Forms/AdminMessagesForm.xaml
+++ b/JMMClient/Forms/AdminMessagesForm.xaml
@@ -45,7 +45,7 @@
                         <StackPanel Orientation="Horizontal"  HorizontalAlignment="Left" Margin="10,10,5,5" Grid.Column="1" Grid.Row="0" VerticalAlignment="Top">
 
                             <TextBlock Text="{Binding Path=MessageDateAsDate}" FontWeight="Bold" FontSize="14" Foreground="DarkBlue" VerticalAlignment="Center"/>
-                            <usercontrols:HyperLinkStandard VerticalAlignment="Center" DisplayText="More Information" URL="{Binding Path=MessageURL}" Margin="10,0,0,0"
+                            <usercontrols:HyperLinkStandard VerticalAlignment="Center" DisplayText="{Resx ResxName=JMMClient.Properties.Resources, Key=MoreInformation}" URL="{Binding Path=MessageURL}" Margin="10,0,0,0"
                                                      Visibility="{Binding Path=HasMessageURL, Converter={StaticResource BooleanToVisibilityConverter}}"/>
 
                         </StackPanel>

--- a/JMMClient/Forms/ChangePasswordForm.xaml
+++ b/JMMClient/Forms/ChangePasswordForm.xaml
@@ -31,15 +31,15 @@
         </Grid.RowDefinitions>
 
         <StackPanel Orientation="Horizontal" Grid.Row="0" Grid.Column="0" Margin="0,10,10,10" Grid.ColumnSpan="2">
-            <TextBlock  VerticalAlignment="Center" Text="Changing password for" Margin="0,0,5,0"/>
+            <TextBlock  VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=ChangingPassword}" Margin="0,0,5,0"/>
             <TextBlock  VerticalAlignment="Center" Text="Username" Name="txtUsername" FontWeight="Bold" Margin="0,0,5,0"/>
         </StackPanel>
 
-        <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Text="Password" Margin="0,0,5,0"/>
+        <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Password}" Margin="0,0,5,0"/>
         <PasswordBox Grid.Row="1" Grid.Column="1" Width="200" Margin="5,10,2,0" VerticalAlignment="Center" BorderThickness="1" x:Name="txtPassword" local:PasswordBoxAssistant.BindPassword="true" />
 
 
-        <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Text="Re-enter Password" Margin="0,10,5,0"/>
+        <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=ReenterPassword}" Margin="0,10,5,0"/>
         <PasswordBox Grid.Row="2" Grid.Column="1" Width="200" Margin="5,10,2,0" VerticalAlignment="Center" BorderThickness="1" x:Name="txtPasswordConfirm" local:PasswordBoxAssistant.BindPassword="true" />
 
         <!-- save button -->
@@ -47,7 +47,7 @@
             <Button Name="btnSave"  Margin="5,10,2,2" Style="{DynamicResource RoundButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" IsDefault="True">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                     <Image Height="16" Width="16" Source="/Images/32_save.png" Margin="0,0,5,0"/>
-                    <TextBlock VerticalAlignment="Center" Text="Change Password" Margin="0,0,0,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=ChangePassword}" Margin="0,0,0,0"/>
                 </StackPanel>
             </Button>
             <TextBlock VerticalAlignment="Center" Name="txtStatus" Text="" Margin="10,8,0,0"/>

--- a/JMMClient/Forms/GroupFilterConditionForm.xaml
+++ b/JMMClient/Forms/GroupFilterConditionForm.xaml
@@ -74,9 +74,9 @@
 
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Grid.Column="2" Grid.Row="0">
                     <Image Height="16" Width="16" Source="/Images/32_help.png" Margin="0,0,0,0"/>
-                        
-                       
-                    <usercontrols:HyperLinkStandard VerticalAlignment="Center" Margin="5,0,0,0" DisplayText="What does this mean?" Grid.Column="1"
+
+
+                    <usercontrols:HyperLinkStandard VerticalAlignment="Center" Margin="5,0,0,0" DisplayText="{Resx ResxName=JMMClient.Properties.Resources, Key=WhatDoesThisMean}" Grid.Column="1"
                                                                     URL="{Resx ResxName=JMMClient.Properties.Resources, Key=Link_GroupFilters}"/>
                 </StackPanel>
             </Grid>

--- a/JMMClient/Forms/ImportFolder.xaml
+++ b/JMMClient/Forms/ImportFolder.xaml
@@ -47,7 +47,7 @@
 
                         <Image Height="16" Width="16" Source="/Images/32_info.png" Margin="5,2,5,0" Grid.Column="0" VerticalAlignment="Top"/>
 
-                        <usercontrols:HyperLinkStandard Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" Margin="0,3,5,5" DisplayText="Detailed explanation of options"
+                        <usercontrols:HyperLinkStandard Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" Margin="0,3,5,5" DisplayText="{Resx ResxName=JMMClient.Properties.Resources, Key=DetailedExplanations}"
                                                                         URL="{Resx ResxName=JMMClient.Properties.Resources, Key=Link_ImportFolders}"/>
                     </Grid>
                 </Border>
@@ -62,7 +62,7 @@
                 <TextBlock Grid.Column="0" Grid.Row="4" Margin="0,0,10,5" FontWeight="DemiBold" Padding="5" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=DropDestination}"/>
                 <CheckBox Name="chkDropDestination" Grid.Column="1" Grid.Row="4" VerticalAlignment="Center"></CheckBox>
 
-                <TextBlock Grid.Column="0" Grid.Row="5" Margin="0,0,10,5" FontWeight="DemiBold" Padding="5" Text="Watch For New Files"/>
+                <TextBlock Grid.Column="0" Grid.Row="5" Margin="0,0,10,5" FontWeight="DemiBold" Padding="5" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=ImportSettings_WatchFiles}"/>
                 <CheckBox Name="chkIsWatched" Grid.Column="1" Grid.Row="5" VerticalAlignment="Center"></CheckBox>
 
             </Grid>

--- a/JMMClient/Forms/ManageCustomTags.xaml
+++ b/JMMClient/Forms/ManageCustomTags.xaml
@@ -84,16 +84,16 @@
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
 
-                    <TextBlock VerticalAlignment="Center" Text="Tag Name" Margin="5" Grid.Column="0" Grid.Row="0" HorizontalAlignment="Left"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CustomTag_Name}" Margin="5" Grid.Column="0" Grid.Row="0" HorizontalAlignment="Left"/>
                     <TextBox Name="txtTagName" Width="300" Margin="5,2,2,2" BorderThickness="1" Grid.Column="1" Grid.Row="0" HorizontalAlignment="Left" />
-                    <TextBlock VerticalAlignment="Center" Text="Tag Description" Margin="5" Grid.Column="0" Grid.Row="1" HorizontalAlignment="Left"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CustomTag_Description}" Margin="5" Grid.Column="0" Grid.Row="1" HorizontalAlignment="Left"/>
                     <TextBox Name="txtTagDescription" Width="500" Margin="5,2,2,2" BorderThickness="1" Grid.Column="1" Grid.Row="1" HorizontalAlignment="Left"/>
 
                     <!-- Add Tag -->
                     <Button Name="btnAddCustomTag" Margin="5" Style="{DynamicResource RoundButtonStyle}" Grid.Column="0" Grid.Row="2">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                             <Image Height="16" Width="16" Source="/Images/16_plus.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Add" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Add}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
                 </Grid>

--- a/JMMClient/Forms/MissingEpsColumnsForm.xaml
+++ b/JMMClient/Forms/MissingEpsColumnsForm.xaml
@@ -23,28 +23,28 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-         <TextBlock Text="Anime Name"  VerticalAlignment="Center" Grid.Column="0" Grid.Row="0" Margin="10,5,15,0"></TextBlock>
+        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=MissingEpisodes_AnimeName}"  VerticalAlignment="Center" Grid.Column="0" Grid.Row="0" Margin="10,5,15,0"></TextBlock>
          <CheckBox Name="chkAnimeName" VerticalAlignment="Center" Grid.Column="1" Grid.Row="0" Margin="0,5,5,0"/>
 
-        <TextBlock Text="Anime ID"  VerticalAlignment="Center" Grid.Column="0" Grid.Row="1" Margin="10,5,15,0"></TextBlock>
+        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=MissingEpisodes_AnimeID}"  VerticalAlignment="Center" Grid.Column="0" Grid.Row="1" Margin="10,5,15,0"></TextBlock>
         <CheckBox Name="chkAnimeID" VerticalAlignment="Center" Grid.Column="1" Grid.Row="1" Margin="0,5,5,0"/>
 
-        <TextBlock Text="Episode Number"  VerticalAlignment="Center" Grid.Column="0" Grid.Row="2" Margin="10,5,15,0"></TextBlock>
+        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=MissingEpisodes_EpisodeNumber}"  VerticalAlignment="Center" Grid.Column="0" Grid.Row="2" Margin="10,5,15,0"></TextBlock>
         <CheckBox Name="chkEpisodeNumber" VerticalAlignment="Center" Grid.Column="1" Grid.Row="2" Margin="0,5,5,0"/>
 
-        <TextBlock Text="Episode ID"  VerticalAlignment="Center" Grid.Column="0" Grid.Row="3" Margin="10,5,15,0"></TextBlock>
+        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=MissingEpisodes_EpisodeID}"  VerticalAlignment="Center" Grid.Column="0" Grid.Row="3" Margin="10,5,15,0"></TextBlock>
         <CheckBox Name="chkEpisodeID" VerticalAlignment="Center" Grid.Column="1" Grid.Row="3" Margin="0,5,5,0"/>
 
-        <TextBlock Text="File Summary"  VerticalAlignment="Center" Grid.Column="0" Grid.Row="4" Margin="10,5,15,0"></TextBlock>
+        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=MissingEpisodes_FileSummary}"  VerticalAlignment="Center" Grid.Column="0" Grid.Row="4" Margin="10,5,15,0"></TextBlock>
         <CheckBox Name="chkFileSummary" VerticalAlignment="Center" Grid.Column="1" Grid.Row="4" Margin="0,5,5,0"/>
 
-        <TextBlock Text="Group Summary"  VerticalAlignment="Center" Grid.Column="0" Grid.Row="5" Margin="10,5,15,0"></TextBlock>
+        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=MissingEpisodes_GroupSummary}"  VerticalAlignment="Center" Grid.Column="0" Grid.Row="5" Margin="10,5,15,0"></TextBlock>
         <CheckBox Name="chkGroupSummary" VerticalAlignment="Center" Grid.Column="1" Grid.Row="5" Margin="0,5,5,0"/>
 
-        <TextBlock Text="Link to Anime"  VerticalAlignment="Center" Grid.Column="0" Grid.Row="6" Margin="10,5,15,0"></TextBlock>
+        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=MissingEpisodes_AnimeLink}"  VerticalAlignment="Center" Grid.Column="0" Grid.Row="6" Margin="10,5,15,0"></TextBlock>
         <CheckBox Name="chkLinktoAnime" VerticalAlignment="Center" Grid.Column="1" Grid.Row="6" Margin="0,5,5,0"/>
 
-        <TextBlock Text="Link to Episode"  VerticalAlignment="Center" Grid.Column="0" Grid.Row="7" Margin="10,5,15,0"></TextBlock>
+        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=MissingEpisodes_EpisodeLink}"  VerticalAlignment="Center" Grid.Column="0" Grid.Row="7" Margin="10,5,15,0"></TextBlock>
         <CheckBox Name="chkLinktoEpisode" VerticalAlignment="Center" Grid.Column="1" Grid.Row="7" Margin="0,5,5,0"/>
 
         <StackPanel Orientation="Horizontal" Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="2" Margin="5,10,0,10">

--- a/JMMClient/Forms/NewSeries.xaml
+++ b/JMMClient/Forms/NewSeries.xaml
@@ -52,7 +52,7 @@
                         <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="1"
                                     Visibility="{Binding Path=SeriesExists, Converter={StaticResource BooleanToVisibilityConverter}}">
 
-                            <TextBlock Text="A series is already attached to this anime:" FontSize="12" HorizontalAlignment="Left"  Margin="7,0,0,0" Foreground="DarkRed" VerticalAlignment="Center" />
+                            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=NewSeries_AlreadyAttached}" FontSize="12" HorizontalAlignment="Left"  Margin="7,0,0,0" Foreground="DarkRed" VerticalAlignment="Center" />
                             <TextBlock Text="{Binding Path=AnimeSeriesName}" FontSize="12" HorizontalAlignment="Left"  Margin="7,0,0,0" Foreground="DarkRed" VerticalAlignment="Center" />
 
                         </StackPanel>
@@ -101,7 +101,7 @@
             <DockPanel >
 
                 <StackPanel Orientation="Horizontal"  Margin="0,0,0,5" DockPanel.Dock="Top">
-                    <TextBlock VerticalAlignment="Center" Text="Step 1 - Select an Anime" Margin="5,0,0,0" FontWeight="Bold" FontSize="14" />
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=NewSeries_Step1}" Margin="5,0,0,0" FontWeight="Bold" FontSize="14" />
                 </StackPanel>
 
                 <StackPanel x:Name="pnlAnime1"  Orientation="Horizontal"  Margin="0,0,0,5" DockPanel.Dock="Top"
@@ -109,7 +109,7 @@
 
 
 
-                    <TextBlock VerticalAlignment="Center" Text="Search by title or ID" Margin="5,0,0,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=NewSeries_SearchBy}" Margin="5,0,0,0"/>
                     <TextBox Name="txtAnimeSearch" Width="180" Margin="5,2,2,0" BorderThickness="1" VerticalAlignment="Center"
                              ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=NewSeries_Search}, 
                                                 Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_NewSeries_Search}}"/>
@@ -118,7 +118,7 @@
 
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                             <Image Height="16" Width="16" Source="/Images/MagnifyingGlass7.png" Margin="0,0,3,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Search" Margin="0,0,0,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Search}" Margin="0,0,0,0"/>
                         </StackPanel>
 
 
@@ -150,7 +150,7 @@
             <DockPanel >
 
                 <StackPanel Orientation="Horizontal"  Margin="0,0,0,10" DockPanel.Dock="Top">
-                    <TextBlock VerticalAlignment="Center" Text="Step 2 - Select a Local Group" Margin="5,0,0,0" FontWeight="Bold" FontSize="14" />
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=NewSeries_Step2}" Margin="5,0,0,0" FontWeight="Bold" FontSize="14" />
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal"  Margin="0,0,0,5" DockPanel.Dock="Top" VerticalAlignment="Center"
@@ -164,7 +164,7 @@
 
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                             <Image Height="16" Width="16" Source="/Images/32_redo.png" Margin="0,0,3,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Back To Step 1" Margin="0,0,0,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=NewSeries_BackToStep1}" Margin="0,0,0,0"/>
                         </StackPanel>
 
 

--- a/JMMClient/Forms/RandomEpisodeForm.xaml
+++ b/JMMClient/Forms/RandomEpisodeForm.xaml
@@ -57,15 +57,15 @@
                 <Button Name="btnRandomEpisode" Margin="5,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                         <Image Height="16" Width="16" Source="/Images/32_dice.png" Margin="0,0,3,0"/>
-                        <TextBlock VerticalAlignment="Center" Text="Try Again!" Margin="0,0,0,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=TryAgain}" Margin="0,0,0,0"/>
                     </StackPanel>
                 </Button>
 
 
-                <CheckBox Name="chkWatched" Content="Watched" VerticalAlignment="Center" Margin="10,0,0,0"
+                <CheckBox Name="chkWatched" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=Random_Watched}" VerticalAlignment="Center" Margin="10,0,0,0"
                                   IsChecked="True"/>
 
-                <CheckBox Name="chkUnwatched" Content="Unwatched" VerticalAlignment="Center" Margin="10,0,0,0"
+                <CheckBox Name="chkUnwatched" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=Random_Unwatched}" VerticalAlignment="Center" Margin="10,0,0,0"
                                   IsChecked="True"/>
 
 
@@ -84,11 +84,11 @@
                     <Button Name="btnEditTags" Margin="5,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                             <Image Height="16" Width="16" Source="/Images/32_folder_edit.png" Margin="0,0,3,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Edit" Margin="0,0,0,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Edit}" Margin="0,0,0,0"/>
                         </StackPanel>
                     </Button>
 
-                    <TextBlock VerticalAlignment="Center" Text="Tags" FontWeight="DemiBold" Margin="10,0,0,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Random_Tags}" FontWeight="DemiBold" Margin="10,0,0,0"/>
                     
                     <TextBlock VerticalAlignment="Center" Text="(" Margin="5,0,0,0"/>
                     <TextBlock VerticalAlignment="Center" Text="{Binding Path=SelectedTagFilter, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type forms:RandomEpisodeForm}}}" Margin="2,0,0,0"/>
@@ -105,18 +105,18 @@
                         <Button Name="btnEditTagsFinish" Margin="5,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                 <Image Height="16" Width="16" Source="/Images/32_folder_edit.png" Margin="0,0,3,0"/>
-                                <TextBlock VerticalAlignment="Center" Text="Finish" Margin="0,0,0,0"/>
+                                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Finish}" Margin="0,0,0,0"/>
                             </StackPanel>
                         </Button>
 
                         <Button Click="ClearSelectedTags" Margin="5,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                 <Image Height="16" Width="16" Source="/Images/32_delete.png" Margin="0,0,3,0"/>
-                                <TextBlock VerticalAlignment="Center" Text="Clear" Margin="0,0,0,0"/>
+                                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Clear}" Margin="0,0,0,0"/>
                             </StackPanel>
                         </Button>
 
-                        <TextBlock VerticalAlignment="Center" Text="Tags" FontWeight="DemiBold" Margin="10,0,0,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Random_Tags}" FontWeight="DemiBold" Margin="10,0,0,0"/>
                         <ComboBox Margin="7,0,0,0" Name="cboCatFilter" VerticalAlignment="Center"></ComboBox>
                     </StackPanel>
                     <DockPanel>

--- a/JMMClient/Forms/RandomSeriesForm.xaml
+++ b/JMMClient/Forms/RandomSeriesForm.xaml
@@ -57,24 +57,25 @@
                 <Button Name="btnRandomSeries" Margin="5,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                         <Image Height="16" Width="16" Source="/Images/32_dice.png" Margin="0,0,3,0"/>
-                        <TextBlock VerticalAlignment="Center" Text="Try Again!" Margin="0,0,0,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=TryAgain}" Margin="0,0,0,0"/>
                     </StackPanel>
                 </Button>
 
                 <TextBlock VerticalAlignment="Center" Text="(" Margin="10,0,0,0"/>
                 <TextBlock VerticalAlignment="Center" Text="{Binding Path=MatchesFound, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type forms:RandomSeriesForm}}}" Margin="2,0,0,0"/>
-                <TextBlock VerticalAlignment="Center" Text="Matches)" Margin="2,0,0,0"/>
+                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Matches}" Margin="2,0,0,0"/>
+                <TextBlock VerticalAlignment="Center" Text=")" Margin="2,0,0,0"/>
 
-                <CheckBox Name="chkWatched" Content="Watched" VerticalAlignment="Center" Margin="10,0,0,0"
+                <CheckBox Name="chkWatched" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=Random_Watched}" VerticalAlignment="Center" Margin="10,0,0,0"
                                   IsChecked="True"/>
 
-                <CheckBox Name="chkUnwatched" Content="Unwatched" VerticalAlignment="Center" Margin="10,0,0,0"
+                <CheckBox Name="chkUnwatched" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=Random_Unwatched}" VerticalAlignment="Center" Margin="10,0,0,0"
                                   IsChecked="True"/>
 
-                <CheckBox Name="chkPartiallyWatched" Content="Partially Watched" VerticalAlignment="Center" Margin="10,0,0,0"
+                <CheckBox Name="chkPartiallyWatched" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=Random_PartiallyWatched}" VerticalAlignment="Center" Margin="10,0,0,0"
                                   IsChecked="True"/>
 
-                <CheckBox Name="chkComplete" Content="Complete ONLY" VerticalAlignment="Center" Margin="10,0,10,0"
+                <CheckBox Name="chkComplete" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=Random_CompleteOnly}" VerticalAlignment="Center" Margin="10,0,10,0"
                                   IsChecked="False"/>
 
             </StackPanel>
@@ -92,11 +93,11 @@
                     <Button Name="btnEditTags" Margin="5,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                             <Image Height="16" Width="16" Source="/Images/32_folder_edit.png" Margin="0,0,3,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Edit" Margin="0,0,0,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Edit}" Margin="0,0,0,0"/>
                         </StackPanel>
                     </Button>
-                
-                    <TextBlock VerticalAlignment="Center" Text="Tags" FontWeight="DemiBold" Margin="10,0,0,0"/>
+
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Random_Tags}" FontWeight="DemiBold" Margin="10,0,0,0"/>
 
                     <TextBlock VerticalAlignment="Center" Text="(" Margin="5,0,0,0"/>
                     <TextBlock VerticalAlignment="Center" Text="{Binding Path=SelectedTagsFilter, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type forms:RandomSeriesForm}}}" Margin="2,0,0,0"/>
@@ -114,18 +115,18 @@
                         <Button Name="btnEditTagsFinish" Margin="5,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                 <Image Height="16" Width="16" Source="/Images/32_folder_edit.png" Margin="0,0,3,0"/>
-                                <TextBlock VerticalAlignment="Center" Text="Finish" Margin="0,0,0,0"/>
+                                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Finish}" Margin="0,0,0,0"/>
                             </StackPanel>
                         </Button>
 
                         <Button Click="ClearSelectedTags" Margin="5,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                 <Image Height="16" Width="16" Source="/Images/32_delete.png" Margin="0,0,3,0"/>
-                                <TextBlock VerticalAlignment="Center" Text="Clear" Margin="0,0,0,0"/>
+                                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Clear}" Margin="0,0,0,0"/>
                             </StackPanel>
                         </Button>
 
-                        <TextBlock VerticalAlignment="Center" Text="Tags" FontWeight="DemiBold" Margin="10,0,0,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Random_Tags}" FontWeight="DemiBold" Margin="10,0,0,0"/>
                         <ComboBox Margin="7,0,0,0" Name="cboCatFilter" VerticalAlignment="Center"></ComboBox>
                     </StackPanel>
                     <DockPanel>
@@ -240,7 +241,7 @@
         <Button Name="btnSelectSeries" Grid.Row="3" Grid.Column="1" Margin="5,2,2,10" Style="{DynamicResource RoundButtonStyle}">
             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                 <Image Height="16" Width="16" Source="/Images/16_windows.png" Margin="0,0,3,0"/>
-                <TextBlock VerticalAlignment="Center" Text="View This Series" Margin="0,0,0,0"/>
+                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Random_View}" Margin="0,0,0,0"/>
             </StackPanel>
         </Button>
 

--- a/JMMClient/Forms/RateSeriesForm.xaml
+++ b/JMMClient/Forms/RateSeriesForm.xaml
@@ -53,7 +53,7 @@
 
             <StackPanel Orientation="Horizontal" >
 
-                <TextBlock Text="Rate Series:" FontSize="14" Margin="0,0,10,5"  />
+                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=RateSeries_Rate}" FontSize="14" Margin="0,0,10,5"  />
 
                 <TextBlock Text="{Binding Path=Series.SeriesName, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type forms:RateSeriesForm}}}" 
                        FontWeight="Bold" FontSize="14" Margin="0,0,0,5"  />
@@ -129,7 +129,7 @@
 
                 <StackPanel Orientation="Vertical">
 
-                    <TextBlock Padding="5,10,5,10" FontWeight="Heavy" Text="Have your say on Trakt" VerticalAlignment="Center"/>
+                    <TextBlock Padding="5,10,5,10" FontWeight="Heavy" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=RateSeries_TraktShout}" VerticalAlignment="Center"/>
 
                     <usercontrols:TraktCommentsShowControl x:Name="ucTraktComments"  />
 

--- a/JMMClient/Forms/SearchMALForm.xaml
+++ b/JMMClient/Forms/SearchMALForm.xaml
@@ -55,7 +55,7 @@
 
                         <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="1" Margin="0,0,0,5">
 
-                            <TextBlock VerticalAlignment="Center" Text="Episodes:" Margin="10,0,0,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Search_Episodes}" Margin="10,0,0,0"/>
                             <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=episodes}" Margin="5,0,0,0"/>
 
 
@@ -94,7 +94,7 @@
                             <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=MALTitle}" Margin="5,0,0,0"/>
                             <usercontrols:HyperLinkStandard DisplayText="{Resx ResxName=JMMClient.Properties.Resources, Key=MALShow}" VerticalAlignment="Center" URL="{Binding Path=SiteURL}" Margin="10,0,0,0"/>
 
-                            <TextBlock VerticalAlignment="Center" Text="Starting at:" Margin="10,0,0,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Search_StartingAt}" Margin="10,0,0,0"/>
                             <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=StartEpisodeTypeString}" Margin="5,0,0,0"/>
                             <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=StartEpisodeNumber}" Margin="5,0,0,0"/>
 
@@ -153,9 +153,9 @@
         <Border Grid.Row="1" Grid.Column="0" Margin="5,5,5,5" Padding="5" Background="FloralWhite" BorderBrush="LightGray" BorderThickness="1"
                 Visibility="{Binding Path=IsExisting, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type forms:SearchMALForm}}, Converter={StaticResource BooleanToVisibilityConverter}}">
             <StackPanel Orientation="Horizontal"  Margin="0,0,0,0" DockPanel.Dock="Top">
-                <TextBlock VerticalAlignment="Center" Text="ID" Margin="5,0,0,0"/>
+                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Search_ID}" Margin="5,0,0,0"/>
                 <TextBox Name="txtMALID" Width="70" Margin="5,2,2,0" BorderThickness="1" />
-                <TextBlock VerticalAlignment="Center" Text="Title" Margin="5,0,0,0"/>
+                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Seatch_Title}" Margin="5,0,0,0"/>
                 <TextBox Name="txtMALTitle" Width="200" Margin="5,2,2,0" BorderThickness="1" />
                 <StackPanel Orientation="Horizontal" Margin="5,0,5,0" VerticalAlignment="Center">
                     <TextBlock VerticalAlignment="Center">

--- a/JMMClient/Forms/SearchTraktForm.xaml
+++ b/JMMClient/Forms/SearchTraktForm.xaml
@@ -71,18 +71,18 @@
                             
                             <usercontrols:HyperLinkStandard DisplayText="{Binding Path=TraktTitle}" VerticalAlignment="Center" URL="{Binding Path=ShowURL}" Margin="5,0,0,0"/>
 
-                            <TextBlock VerticalAlignment="Center" Text="AniDB Start:" Margin="10,0,0,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Search_AniDBStart}" Margin="10,0,0,0"/>
                             <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=AniDBStartEpisodeTypeString}" Margin="5,0,0,0"/>
                             <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=AniDBStartEpisodeNumber}" Margin="5,0,0,0"/>
 
-                            <TextBlock VerticalAlignment="Center" Text="Trakt: " Margin="10,0,0,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Search_Trakt}" Margin="10,0,0,0"/>
                             <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=TraktSeasonNumberString}" Margin="5,0,0,0"/>
                             <TextBlock VerticalAlignment="Center" Text="/" Margin="5,0,0,0"/>
                             <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=TraktStartEpisodeNumberString}" Margin="5,0,0,0"/>
 
                             <StackPanel Orientation="Horizontal" Visibility="{Binding Path=AdminApproved, Converter={StaticResource BooleanToVisibilityConverter}}">
                                 <Image Margin="25,0,0,0" Height="16" Width="16" Source="/Images/vote_up2.png" VerticalAlignment="Center"/>
-                                <TextBlock VerticalAlignment="Center" Text="Admin Approved" Margin="5,0,0,0"/>
+                                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Search_Approved}" Margin="5,0,0,0"/>
                             </StackPanel>
 
                         </StackPanel>

--- a/JMMClient/Forms/SearchTvDBForm.xaml
+++ b/JMMClient/Forms/SearchTvDBForm.xaml
@@ -70,11 +70,11 @@
 
                             <usercontrols:HyperLinkStandard DisplayText="{Binding Path=TvDBTitle}" VerticalAlignment="Center" URL="{Binding Path=SeriesURL}" Margin="5,0,0,0"/>
 
-                            <TextBlock VerticalAlignment="Center" Text="AniDB Start:" Margin="10,0,0,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Search_AniDBStart}" Margin="10,0,0,0"/>
                             <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=AniDBStartEpisodeTypeString}" Margin="5,0,0,0"/>
                             <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=AniDBStartEpisodeNumber}" Margin="5,0,0,0"/>
 
-                            <TextBlock VerticalAlignment="Center" Text="TvDB: " Margin="10,0,0,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Search_TvDB}" Margin="10,0,0,0"/>
                             <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=TvDBSeasonNumberString}" Margin="5,0,0,0"/>
                             <TextBlock VerticalAlignment="Center" Text="/" Margin="5,0,0,0"/>
                             <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=TvDBStartEpisodeNumberString}" Margin="5,0,0,0"/>

--- a/JMMClient/Forms/SelectAniDBTitleForm.xaml
+++ b/JMMClient/Forms/SelectAniDBTitleForm.xaml
@@ -83,7 +83,7 @@
 
                 <Image Grid.Row="0" Grid.Column="0" Height="16" Width="16" Source="/Images/32_info.png" Margin="5,0,5,0"/>
 
-                <TextBlock Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" TextWrapping="Wrap" Text="Select an override name" Margin="0,0,0,3" />
+                <TextBlock Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" TextWrapping="Wrap" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SelectAniDBTitle_SelectName}" Margin="0,0,0,3" />
             </Grid>
 
 

--- a/JMMClient/Forms/SelectGroupSeriesForm.xaml
+++ b/JMMClient/Forms/SelectGroupSeriesForm.xaml
@@ -110,7 +110,7 @@
 
                 <StackPanel Orientation="Horizontal"  Margin="0,0,0,5" DockPanel.Dock="Top">
                     <Image Height="16" Width="16" Source="/Images/32_folder.png" Margin="5,0,5,0"/>
-                    <TextBlock VerticalAlignment="Center" Text="Select a " Margin="0,0,0,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SelectGroupSeries_Select}" Margin="0,0,0,0"/>
                     <RadioButton Name="rbGroup" Content="Group" Margin="5,0,0,0"/>
                     <RadioButton Name="rbSeries" Content="Series" Margin="5,0,0,0"/>
                 </StackPanel>
@@ -155,7 +155,7 @@
             <Button Name="btnCancel" Margin="0,0,2,2" Style="{DynamicResource FlatButtonStyle}" HorizontalAlignment="Left">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                     <Image Height="16" Width="16" Source="/Images/32_cancel.png" Margin="0,0,5,0"/>
-                    <TextBlock VerticalAlignment="Center" Text="Close" Margin="0,0,5,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Close}" Margin="0,0,5,0"/>
                 </StackPanel>
             </Button>
         </StackPanel>

--- a/JMMClient/Forms/SelectMALStartForm.xaml
+++ b/JMMClient/Forms/SelectMALStartForm.xaml
@@ -55,7 +55,7 @@
 
                 <StackPanel Orientation="Horizontal"  Margin="0,0,0,0" DockPanel.Dock="Top">
                     <Image Margin="5,0,0,0" Height="16" Width="16" Source="/Images/myanimelist.ico" VerticalAlignment="Center"/>
-                    <TextBlock VerticalAlignment="Center" Text="MyAnimeList" Margin="5,0,0,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Select_MyAnimeList}" Margin="5,0,0,0"/>
                     <TextBlock VerticalAlignment="Center" Text="[" Margin="5,0,0,0"/>
                     <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=MALTitle, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type forms:SelectMALStartForm}}}" Margin="5,0,0,0"/>
                     <TextBlock VerticalAlignment="Center" Text="]" Margin="5,0,0,0"/>
@@ -64,10 +64,10 @@
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal"  Margin="0,5,0,0" DockPanel.Dock="Top">
-                    
-                    <TextBlock VerticalAlignment="Center" Text="Episode Type:" Margin="25,0,0,0"/>
+
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Select_EpisodeType}" Margin="25,0,0,0"/>
                     <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" Name="cboEpisodeType"></ComboBox>
-                    <TextBlock VerticalAlignment="Center" Text="Starting Episode #" Margin="5,0,0,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Select_StartingEpisode}" Margin="5,0,0,0"/>
                     <TextBox VerticalAlignment="Center" Name="txtEpNumber" Width="50" Margin="5,2,2,0" BorderThickness="1" Text="1" />
 
 

--- a/JMMClient/Forms/SelectTraktSeasonForm.xaml
+++ b/JMMClient/Forms/SelectTraktSeasonForm.xaml
@@ -95,9 +95,9 @@
 
                 <StackPanel Orientation="Horizontal"  Margin="0,5,0,0" DockPanel.Dock="Top">
 
-                    <TextBlock VerticalAlignment="Center" Text="Episode Type:" Margin="25,0,0,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Select_EpisodeType}" Margin="25,0,0,0"/>
                     <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" Name="cboEpisodeType"></ComboBox>
-                    <TextBlock VerticalAlignment="Center" Text="Starting Episode #" Margin="5,0,0,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Select_StartingEpisode}" Margin="5,0,0,0"/>
                     <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" Name="cboAniDBEpisodeNumber"
                               ItemTemplate="{StaticResource AniDBEpisodeTemplate}"/>
                 </StackPanel>
@@ -114,7 +114,7 @@
 
                 <StackPanel Orientation="Horizontal"  Margin="0,0,0,0" DockPanel.Dock="Top">
                     <Image Margin="5,0,0,0" Height="16" Width="16" Source="/Images/trakttv.ico" VerticalAlignment="Center"/>
-                    <TextBlock VerticalAlignment="Center" Text="Trakt TV" Margin="5,0,0,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Select_TraktTV}" Margin="5,0,0,0"/>
 
                     <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=TraktID, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type forms:SelectTraktSeasonForm}}}" Margin="15,0,0,0"/>
 
@@ -127,7 +127,7 @@
 
                     <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeasonNumber}" Margin="25,0,0,0"/>
                     <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" Name="cboSeasonNumber"></ComboBox>
-                    <TextBlock VerticalAlignment="Center" Text="Starting Episode #" Margin="5,0,0,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Select_StartingEpisode}" Margin="5,0,0,0"/>
                     <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" Name="cboEpisodeNumber"
                               ItemTemplate="{StaticResource EpisodeTemplate}"/>
 

--- a/JMMClient/Forms/SelectTvDBEpisodeForm.xaml
+++ b/JMMClient/Forms/SelectTvDBEpisodeForm.xaml
@@ -112,11 +112,11 @@
         <Border Grid.Row="0" Grid.Column="0" Margin="5,5,5,5" Padding="5" Background="#F1F1F1" BorderBrush="LightGray" BorderThickness="1">
             <StackPanel Orientation="Horizontal"  Margin="0,0,0,5" DockPanel.Dock="Top">
                 <Image Height="16" Width="16" Source="/Images/tvdb.ico" Margin="5,0,5,0"/>
-                <TextBlock VerticalAlignment="Center" Text="Select TvDB Details" Margin="0,0,10,0"/>
+                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Select_TvDBDetails}" Margin="0,0,10,0"/>
                 <ComboBox Name="cboSeries" VerticalAlignment="Center" Margin="0,0,20,0"
                           ItemTemplate="{StaticResource SeriesSelectionTemplate}"/>
 
-                <TextBlock VerticalAlignment="Center" Text="Season" Margin="0,0,10,0"/>
+                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Select_Season}" Margin="0,0,10,0"/>
                 <ComboBox Name="cboSeason" VerticalAlignment="Center" Margin="0,0,20,0"/>
             </StackPanel>
         </Border>

--- a/JMMClient/Forms/SelectTvDBLanguage.xaml
+++ b/JMMClient/Forms/SelectTvDBLanguage.xaml
@@ -87,7 +87,7 @@
 
                 <Image Grid.Row="0" Grid.Column="0" Height="16" Width="16" Source="/Images/32_info.png" Margin="5,0,5,0"/>
 
-                <TextBlock Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" TextWrapping="Wrap" Text="Select a default language" Margin="0,0,0,3" />
+                <TextBlock Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" TextWrapping="Wrap" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Select_DefaultLanguage}" Margin="0,0,0,3" />
             </Grid>
 
 

--- a/JMMClient/Forms/SelectTvDBSeasonForm.xaml
+++ b/JMMClient/Forms/SelectTvDBSeasonForm.xaml
@@ -94,9 +94,9 @@
 
                 <StackPanel Orientation="Horizontal"  Margin="0,5,0,0" DockPanel.Dock="Top">
 
-                    <TextBlock VerticalAlignment="Center" Text="Episode Type:" Margin="25,0,0,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Select_EpisodeType}" Margin="25,0,0,0"/>
                     <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" Name="cboEpisodeType"></ComboBox>
-                    <TextBlock VerticalAlignment="Center" Text="Starting Episode #" Margin="5,0,0,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Select_StartingEpisode}" Margin="5,0,0,0"/>
                     <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" Name="cboAniDBEpisodeNumber"
                               ItemTemplate="{StaticResource AniDBEpisodeTemplate}"/>
                 </StackPanel>
@@ -126,7 +126,7 @@
 
                     <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeasonNumber}" Margin="25,0,0,0"/>
                     <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" Name="cboSeasonNumber"></ComboBox>
-                    <TextBlock VerticalAlignment="Center" Text="Starting Episode #" Margin="5,0,0,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Select_StartingEpisode}" Margin="5,0,0,0"/>
                     <ComboBox VerticalAlignment="Center" Margin="5,0,0,0" Name="cboEpisodeNumber"
                               ItemTemplate="{StaticResource EpisodeTemplate}"/>
 

--- a/JMMClient/Forms/UpdateForm.xaml
+++ b/JMMClient/Forms/UpdateForm.xaml
@@ -43,7 +43,7 @@
             <StackPanel Orientation="Horizontal"  Margin="0,0,0,5">
                 <Image Height="24" Width="24" Source="/Images/32_WebDatabase.png" Margin="5,0,5,0"/>
 
-                <TextBlock Margin="5,0,0,0" FontWeight="DemiBold" Text="JMM Desktop Update Available!" FontSize="20" VerticalAlignment="Center"/>
+                <TextBlock Margin="5,0,0,0" FontWeight="DemiBold" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Update_Update}" FontSize="20" VerticalAlignment="Center"/>
                 
             </StackPanel>
         </Border>
@@ -62,19 +62,19 @@
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
-                <TextBlock Grid.Row="0" Grid.Column="0" Margin="10,6"  Text="Download Page"  VerticalAlignment="Center"/>
+                <TextBlock Grid.Row="0" Grid.Column="0" Margin="10,6"  Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Update_DownloadPage}"  VerticalAlignment="Center"/>
                 <usercontrols:HyperLinkStandard Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" Margin="10,6,10,5" DisplayText="{Resx ResxName=JMMClient.Properties.Resources, Key=Link_Download}"
                                                                         URL="{Resx ResxName=JMMClient.Properties.Resources, Key=Link_Download}"/>
 
-                <TextBlock Grid.Row="1" Grid.Column="0" Margin="10,4.864,10,6"  Text="Changelog"  VerticalAlignment="Center"/>
+                <TextBlock Grid.Row="1" Grid.Column="0" Margin="10,4.864,10,6"  Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Update_Changelog}"  VerticalAlignment="Center"/>
                 <usercontrols:HyperLinkStandard Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" Margin="10,4.864,10,5" DisplayText="{Resx ResxName=JMMClient.Properties.Resources, Key=Link_Changelog}"
                                                                         URL="{Resx ResxName=JMMClient.Properties.Resources, Key=Link_Changelog}"/>
 
-                <TextBlock Grid.Row="2" Grid.Column="0" Margin="10,4.864,10,6"  Text="Available Version"  VerticalAlignment="Center"/>
+                <TextBlock Grid.Row="2" Grid.Column="0" Margin="10,4.864,10,6"  Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Update_AvailableVersion}"  VerticalAlignment="Center"/>
                 <TextBlock Grid.Row="2" Grid.Column="1" VerticalAlignment="Center" Margin="10,4.864,10,5" FontWeight="DemiBold" 
                            Text="{Binding Source={x:Static local:JMMServerVM.Instance},Path=ApplicationVersionLatest}" />
 
-                <TextBlock Grid.Row="3" Grid.Column="0" Margin="10,4.864,10,6"  Text="Your Version"  VerticalAlignment="Center"/>
+                <TextBlock Grid.Row="3" Grid.Column="0" Margin="10,4.864,10,6"  Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Update_YourVersion}"  VerticalAlignment="Center"/>
                 <TextBlock Grid.Row="3" Grid.Column="1" VerticalAlignment="Center" Margin="10,4.864,10,5" FontWeight="DemiBold" 
                            Text="{Binding Source={x:Static local:JMMServerVM.Instance},Path=ApplicationVersion}" />
 

--- a/JMMClient/Forms/ViewCommentForm.xaml
+++ b/JMMClient/Forms/ViewCommentForm.xaml
@@ -46,15 +46,15 @@
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
-                <TextBlock Grid.Column="0" Grid.Row="0"  Margin="5" Text="From Trakt" FontSize="14" Foreground="DarkGreen"  x:Name="txtFrom"
+                <TextBlock Grid.Column="0" Grid.Row="0"  Margin="5" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=ViewComments_FromTrakt}" FontSize="14" Foreground="DarkGreen"  x:Name="txtFrom"
                                    VerticalAlignment="Center" FontWeight="Bold"/>
 
-                
 
-                <TextBlock Grid.Column="0" Grid.Row="1" Margin="5" Grid.ColumnSpan="2" Text="Username" VerticalAlignment="Top" FontSize="14" FontWeight="Bold" x:Name="txtUsername"
+
+                <TextBlock Grid.Column="0" Grid.Row="1" Margin="5" Grid.ColumnSpan="2" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=ViewComments_Username}" VerticalAlignment="Top" FontSize="14" FontWeight="Bold" x:Name="txtUsername"
                                    Foreground="Black" ToolTipService.ShowDuration="60000"/>
 
-                <TextBlock Grid.Column="1" Grid.Row="1" Margin="15,5,5,5" Text="Comment Date" FontSize="12" HorizontalAlignment="Left" x:Name="txtDate" 
+                <TextBlock Grid.Column="1" Grid.Row="1" Margin="15,5,5,5" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=ViewComments_CommentDate}" FontSize="12" HorizontalAlignment="Left" x:Name="txtDate" 
                                    Foreground="DarkGray" VerticalAlignment="Center" ToolTipService.ShowDuration="60000">
                 </TextBlock>
             </Grid>
@@ -63,7 +63,7 @@
 
         <Border Grid.Row="1" Grid.Column="0" Margin="5" Padding="5" Background="White" BorderBrush="LightGray" BorderThickness="1">
             <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" Name="ScrollerComments" Grid.Column="0" Grid.Row="0" Margin="0,0,0,0">
-                <TextBlock Grid.Column="0" Grid.Row="2" Margin="5" Text="Comments" FontSize="14" TextWrapping="Wrap" Grid.ColumnSpan="2" HorizontalAlignment="Left" x:Name="txtComment"
+                <TextBlock Grid.Column="0" Grid.Row="2" Margin="5" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=ViewComments_Comments}" FontSize="14" TextWrapping="Wrap" Grid.ColumnSpan="2" HorizontalAlignment="Left" x:Name="txtComment"
                                        Foreground="Black" VerticalAlignment="Top" ToolTipService.ShowDuration="60000">
                
                 </TextBlock>
@@ -71,7 +71,7 @@
         </Border>
 
         <Border Grid.Row="2" Grid.Column="0" Margin="5,5,5,5" Padding="5" Background="FloralWhite" BorderBrush="LightGray" BorderThickness="1">
-            <usercontrols:HyperLinkStandard x:Name="urlWebsite" VerticalAlignment="Center" DisplayText="View on Website" URL="" Margin="0,0,0,0"/>    
+            <usercontrols:HyperLinkStandard x:Name="urlWebsite" VerticalAlignment="Center" DisplayText="{Resx ResxName=JMMClient.Properties.Resources, Key=ViewComments_Website}" URL="" Margin="0,0,0,0"/>    
         </Border>
         
 

--- a/JMMClient/JMMForWindows.csproj
+++ b/JMMClient/JMMForWindows.csproj
@@ -1257,6 +1257,9 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
+    <EmbeddedResource Include="Properties\Resources.es.resx" />
+    <EmbeddedResource Include="Properties\Resources.fr.resx" />
+    <EmbeddedResource Include="Properties\Resources.it.resx" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <SubType>Designer</SubType>
@@ -1266,7 +1269,10 @@
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.de.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <EmbeddedResource Include="Properties\Resources.en-gb.resx" />
+    <EmbeddedResource Include="Properties\Resources.en-gb.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Properties\Resources.ru.resx" />
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>

--- a/JMMClient/Languages.cs
+++ b/JMMClient/Languages.cs
@@ -43,7 +43,7 @@ namespace JMMClient
 				case "EN": return @"/Images/Flags/uk_unitedkingdom.gif";
 				case "X-JAT": return @"/Images/Flags/jp.gif";
 				case "JA": return @"/Images/Flags/jp.gif";
-				case "AR": return @"/Images/Flags/ar.gif"; // arabic
+				case "AR": return @"/Images/Flags/ar.gif"; // Arabic
 				case "BD": return @"/Images/Flags/bd.gif"; // Bangladesh
 				case "BG": return @"/Images/Flags/bg.gif"; // Bulgarian
 				case "CA": return @"/Images/Flags/ca.gif"; // Canadian
@@ -51,9 +51,9 @@ namespace JMMClient
 				case "CZ": return @"/Images/Flags/cz.gif"; // Czech
 				case "DA": return @"/Images/Flags/dk.gif"; // Danish
 				case "DK": return @"/Images/Flags/dk.gif"; // Danish
-				case "DE": return @"/Images/Flags/de_germany.gif"; // german
+				case "DE": return @"/Images/Flags/de_germany.gif"; // German
 				case "EL": return @"/Images/Flags/gr.gif"; // Greek
-				case "ES": return @"/Images/Flags/es.gif"; // spanish
+				case "ES": return @"/Images/Flags/es.gif"; // Spanish
 				case "ET": return @"/Images/Flags/et.gif"; // Estonian
 				case "FI": return @"/Images/Flags/fi.gif"; // Finnish
 				case "FR": return @"/Images/Flags/fr.gif"; // french
@@ -85,10 +85,10 @@ namespace JMMClient
 				case "UK": return @"/Images/Flags/ua.gif"; // Ukrainian
 				case "UA": return @"/Images/Flags/ua.gif"; // Ukrainian
 				case "VI": return @"/Images/Flags/vi.gif"; // Vietnamese
-				case "ZH": return @"/Images/Flags/cn.gif"; // chinese
-				case "ZH-HANS": return @"/Images/Flags/cn.gif"; // chinese
-				case "ZH-HANT": return @"/Images/Flags/cn.gif"; // chinese
-				default: return @"/Images/32_warning.png";
+				case "ZH": return @"/Images/Flags/cn.gif"; // Chinese
+				case "ZH-HANS": return @"/Images/Flags/cn.gif"; // Chinese (Simplified)
+                case "ZH-HANT": return @"/Images/Flags/cn.gif"; // Chinese (Traditional)
+                default: return @"/Images/32_warning.png";
 
 			}
 		}

--- a/JMMClient/MainWindow.xaml
+++ b/JMMClient/MainWindow.xaml
@@ -108,7 +108,7 @@
             <DataTemplate x:Key="groupCountTemplate">
                 <StackPanel Orientation="Horizontal">
                     <TextBlock Text="{Binding Path=GroupCount}" />
-                    <TextBlock Text=" Groups" />
+                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Group_GroupCount}" />
                 </StackPanel>
             </DataTemplate>
 
@@ -407,7 +407,7 @@
                      Visibility="{Binding Source={x:Static local:JMMServerVM.Instance}, Path=ServerOnline, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <TabItem.Header>
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="Playlists" Margin="2,0,0,0" VerticalAlignment="Center" Foreground="White" FontWeight="Bold"/>
+                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Tab_Playlists}" Margin="2,0,0,0" VerticalAlignment="Center" Foreground="White" FontWeight="Bold"/>
                     </StackPanel>
                 </TabItem.Header>
 
@@ -456,7 +456,7 @@
                             <Button  Name="btnAddPlaylist" Margin="3,2,2,2" Style="{DynamicResource FlatButtonStyle}" Command="{DynamicResource AddPlaylistCommand}">
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                     <Image Height="16" Width="16" Source="/Images/32_folder_add.png" Margin="0,0,3,0"/>
-                                    <TextBlock VerticalAlignment="Center" Text="New Playlist" Margin="0,0,0,0"/>
+                                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Playlist_NewPlaylist}" Margin="0,0,0,0"/>
                                 </StackPanel>
                             </Button>
 
@@ -480,7 +480,7 @@
                      Visibility="{Binding Source={x:Static local:JMMServerVM.Instance}, Path=ServerOnline, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <TabItem.Header>
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="Bookmarks" Margin="2,0,0,0" VerticalAlignment="Center" Foreground="White" FontWeight="Bold"/>
+                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Tab_Bookmarks}" Margin="2,0,0,0" VerticalAlignment="Center" Foreground="White" FontWeight="Bold"/>
                     </StackPanel>
                 </TabItem.Header>
 
@@ -533,13 +533,13 @@
                         </Grid.RowDefinitions>
 
                         <Border BorderBrush="LightGray" BorderThickness="1" Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="6" Background="#FFE9ECEF" Margin="0,0,0,5">
-                            <TextBlock Text="Import Folders" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
+                            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=JMMServer_ImportFolders}" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
                         </Border>
 
                         <usercontrols:ImportFolderAdmin Grid.Row="1" Grid.ColumnSpan="6"/>
 
                         <Border BorderBrush="LightGray" BorderThickness="1" Grid.Column="0" Grid.Row="2" Grid.ColumnSpan="6" Background="#FFE9ECEF" Margin="0,10,0,5">
-                            <TextBlock Text="Server Status" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
+                            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=JMMServer_ServerStatus}" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
                         </Border>
 
 
@@ -549,7 +549,7 @@
                                 <Image Height="16" Width="16" Source="/Images/32_delete.png" Margin="0,0,0,0"/>
                             </StackPanel>
                             <Button.ToolTip>
-                                <TextBlock Text="Clear all queued hash commands" Foreground="Black" FontWeight="DemiBold"/>
+                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_ClearHash}" Foreground="Black" FontWeight="DemiBold"/>
                             </Button.ToolTip>
                         </Button>
 
@@ -573,9 +573,9 @@
                             <Image Height="16" Width="16" Source="Images/16_server_hash.png" Margin="10,0,5,0" VerticalAlignment="Center"/>
                             <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=QueueHasher}" Margin="0,0,0,0"/>
                             <TextBlock VerticalAlignment="Center" Text=" - " Margin="0,0,0,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Running" Margin="0,0,5,0"
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=JMMServer_Running}" Margin="0,0,5,0"
                                         Visibility="{Binding Source={x:Static local:JMMServerVM.Instance}, Path=HasherQueueRunning, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                            <TextBlock VerticalAlignment="Center" Text="Paused" Margin="0,0,5,0"
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=JMMServer_Paused}" Margin="0,0,5,0"
                                        Visibility="{Binding Source={x:Static local:JMMServerVM.Instance}, Path=HasherQueuePaused, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                         </StackPanel>
 
@@ -592,7 +592,7 @@
                                 <Image Height="16" Width="16" Source="/Images/32_delete.png" Margin="0,0,0,0"/>
                             </StackPanel>
                             <Button.ToolTip>
-                                <TextBlock Text="Clear all queued general commands" Foreground="Black" FontWeight="DemiBold"/>
+                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_ClearGeneral}" Foreground="Black" FontWeight="DemiBold"/>
                             </Button.ToolTip>
                         </Button>
 
@@ -616,9 +616,9 @@
                             <Image Height="16" Width="16" Source="Images/16_server_connect.png" Margin="10,0,5,0" VerticalAlignment="Center"/>
                             <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=QueueGeneral}" Margin="0,0,0,0"/>
                             <TextBlock VerticalAlignment="Center" Text=" - " Margin="0,0,0,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Running" Margin="0,0,5,0"
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=JMMServer_Running}" Margin="0,0,5,0"
                                     Visibility="{Binding Source={x:Static local:JMMServerVM.Instance}, Path=GeneralQueueRunning, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                            <TextBlock VerticalAlignment="Center" Text="Paused" Margin="0,0,5,0"
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=JMMServer_Paused}" Margin="0,0,5,0"
                                     Visibility="{Binding Source={x:Static local:JMMServerVM.Instance}, Path=GeneralQueuePaused, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                         </StackPanel>
 
@@ -635,7 +635,7 @@
                                 <Image Height="16" Width="16" Source="/Images/32_delete.png" Margin="0,0,0,0"/>
                             </StackPanel>
                             <Button.ToolTip>
-                                <TextBlock Text="Clear all queued server image download commands" Foreground="Black" FontWeight="DemiBold"/>
+                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_ClearGeneral}" Foreground="Black" FontWeight="DemiBold"/>
                             </Button.ToolTip>
                         </Button>
 
@@ -657,11 +657,11 @@
                         <!-- Server Images status -->
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Grid.Column="2" Grid.Row="5">
                             <Image Height="16" Width="16" Source="Images/32_Image.png" Margin="10,0,5,0" VerticalAlignment="Center"/>
-                            <TextBlock VerticalAlignment="Center" Text="Server Images Queue" Margin="0,0,0,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=JMMServer_ServerImage}" Margin="0,0,0,0"/>
                             <TextBlock VerticalAlignment="Center" Text=" - " Margin="0,0,0,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Running" Margin="0,0,5,0"
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=JMMServer_Running}" Margin="0,0,5,0"
                                 Visibility="{Binding Source={x:Static local:JMMServerVM.Instance}, Path=ServerImageQueueRunning, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                            <TextBlock VerticalAlignment="Center" Text="Paused" Margin="0,0,5,0"
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=JMMServer_Paused}" Margin="0,0,5,0"
                                 Visibility="{Binding Source={x:Static local:JMMServerVM.Instance}, Path=ServerImageQueuePaused, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                         </StackPanel>
 
@@ -809,32 +809,32 @@
                         <usercontrols:IgnoredAnimeControl x:Name="ignoredAnime"/>
                     </TabItem>
 
-                    <TabItem Header="AniDB AV Dump" Name="tabAvdump">
+                    <TabItem Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Tab_AniDBAVDump}" Name="tabAvdump">
 
                         <usercontrols:AvdumpBatchControl x:Name="avdumpBatch"/>
                     </TabItem>
 
-                    <TabItem Header="File Search" Name="tabFileSearch">
+                    <TabItem Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Tab_FileSearch}" Name="tabFileSearch">
 
                         <usercontrols:FileSearchControl x:Name="fileSearch"/>
                     </TabItem>
 
-                    <TabItem Header="File Renaming" Name="tabFileRenaming">
+                    <TabItem Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Tab_FileRename}" Name="tabFileRenaming">
 
                         <usercontrols:FileRenameControl x:Name="fileRenaming"/>
                     </TabItem>
 
-                    <TabItem Header="Update AniDB Data" Name="tabUpdateAniDBData">
+                    <TabItem Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Tab_UpdateAniDB}" Name="tabUpdateAniDBData">
 
                         <usercontrols:UpdateAniDBDataControl x:Name="updateAniDBData"/>
                     </TabItem>
 
-                    <TabItem Header="Community Data" Name="tabCommMaint">
+                    <TabItem Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Tab_CommunityData}" Name="tabCommMaint">
 
                         <usercontrols:CommunityMaint x:Name="commMaint"/>
                     </TabItem>
 
-                    <TabItem Header="My Votes" Name="tabRankings">
+                    <TabItem Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Tab_MyVotes}" Name="tabRankings">
 
                         <usercontrols:RankingsControl x:Name="rankings"/>
                     </TabItem>
@@ -1063,7 +1063,7 @@
 
                                         <Image Height="16" Width="16" Source="/Images/32_info.png" Margin="5,2,5,0" Grid.Column="0" VerticalAlignment="Top"/>
                                         <usercontrols:HyperLinkStandard VerticalAlignment="Center" DisplayText="{Resx ResxName=JMMClient.Properties.Resources, Key=DetailedInformationLink}" Grid.Column="1"
-                                                                        URL="http://japanesemediamanager.github.io/wiki_usermanual.html"/>
+                                                                        URL="{Resx ResxName=JMMClient.Properties.Resources, Key=Link_AniDBSettings}"/>
                                     </Grid>
                                 </Border>
 
@@ -1170,7 +1170,7 @@
                                 <Border BorderBrush="LightGray" BorderThickness="1" Grid.Column="0" Grid.Row="6" Background="#FFE9ECEF" Padding="5" Margin="0,0,0,5">
                                     <StackPanel Orientation="Horizontal">
                                         <Image Height="16" Width="16" Source="/Images/myanimelist.ico" Margin="5,2,5,0" Grid.Column="0" VerticalAlignment="Center"/>
-                                        <TextBlock Text="MyAnimeList" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
+                                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=TAB_SettingsOnlineDB_MAL}" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
                                         <usercontrols:HyperLinkStandard VerticalAlignment="Center" Margin="5,0,0,0" DisplayText="{Resx ResxName=JMMClient.Properties.Resources, Key=WhatsThis}"
                                                                         URL="{Resx ResxName=JMMClient.Properties.Resources, Key=Link_MAL}"/>
                                     </StackPanel>
@@ -1240,7 +1240,7 @@
 
                                         <Image Height="16" Width="16" Source="/Images/32_info.png" Margin="5,2,5,0" Grid.Column="0" VerticalAlignment="Top"/>
                                         <usercontrols:HyperLinkStandard VerticalAlignment="Center" DisplayText="{Resx ResxName=JMMClient.Properties.Resources, Key=DetailedInformationLink}" Grid.Column="1"
-                                                                        URL="http://japanesemediamanager.github.io/wiki_usermanual.html"/>
+                                                                        URL="{Resx ResxName=JMMClient.Properties.Resources, Key=Link_WebCache}"/>
                                     </Grid>
                                 </Border>
 
@@ -1376,7 +1376,7 @@
                                 <!-- Media Player Classic -->
 
                                 <Border BorderBrush="LightGray" BorderThickness="1" Grid.Column="0" Grid.Row="0" Background="#FFE9ECEF" Margin="0,0,0,5">
-                                    <TextBlock Text="Media Player Classic Integration" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_MPCI}" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
                                 </Border>
 
 
@@ -1384,7 +1384,7 @@
                                 <usercontrols:VideoPlayerSettingsControl Grid.Column="0" Grid.Row="1" Margin="5,0,0,10"/>
 
                                 <Border BorderBrush="LightGray" BorderThickness="1" Grid.Column="0" Grid.Row="2" Background="#FFE9ECEF" Margin="0,0,0,5">
-                                    <TextBlock Text="Automatic File Selection" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_AutoFile}" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
                                 </Border>
 
 
@@ -1417,7 +1417,7 @@
 
                 <TabItem.Header>
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="Downloads" Margin="2,0,0,0" VerticalAlignment="Center" Foreground="White" FontWeight="Bold"/>
+                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Tab_Downloads}" Margin="2,0,0,0" VerticalAlignment="Center" Foreground="White" FontWeight="Bold"/>
                     </StackPanel>
                 </TabItem.Header>
 
@@ -1432,32 +1432,32 @@
 
 
 
-                    <TabItem Header="uTorrent" Name="tabuTorrent">
+                    <TabItem Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Tab_uTorrent}" Name="tabuTorrent">
                         <usercontrols:DownloadsTorrentMonitorControl/>
 
                     </TabItem>
 
-                    <TabItem Header="Search Torrents" Name="tabSearchTorrents">
+                    <TabItem Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Tab_SearchTorrents}" Name="tabSearchTorrents">
                         <usercontrols:DownloadsSearchTorrentsControl x:Name="ucTorrentSearch"/>
 
                     </TabItem>
 
-                    <TabItem Header="Browse Torrents" Name="tabBrowseTorrents">
+                    <TabItem Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Tab_BrowseTorrents}" Name="tabBrowseTorrents">
                         <usercontrols:DownloadsBrowseTorrentsControl/>
 
                     </TabItem>
 
-                    <TabItem Header="Missing Episodes" Name="tabDownloadsMissingEpisodes">
+                    <TabItem Header="{Resx ResxName=JMMClient.Properties.Resources, Key=TAB_MissingEpisodes}" Name="tabDownloadsMissingEpisodes">
                         <usercontrols:MissingEpisodesControl/>
 
                     </TabItem>
 
-                    <TabItem Header="Recommendations" Name="tabRecommendations">
+                    <TabItem Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Tab_Recommendations}" Name="tabRecommendations">
                         <usercontrols:DownloadRecommendationsControl Width="{Binding Source={x:Static local:MainListHelperVM.Instance},Path=DownloadRecScrollerWidth}"/>
 
                     </TabItem>
 
-                    <TabItem Header="Settings" Name="tabDownloadSettings">
+                    <TabItem Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Tab_Settings}" Name="tabDownloadSettings">
 
                         <ScrollViewer>
                             <Grid>
@@ -1499,7 +1499,7 @@
                                         </Grid.ColumnDefinitions>
 
                                         <Image Height="16" Width="16" Source="/Images/32_info.png" Margin="5,2,5,0" Grid.Column="0" VerticalAlignment="Top"/>
-                                        <TextBlock VerticalAlignment="Center" Text="This uses the uTorrent WebUI API, which you need to enable in your uTorrent client first" Margin="0,0,5,0" TextWrapping="Wrap" Grid.Column="1"/>
+                                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Downloads_uTorrentInfo}" Margin="0,0,5,0" TextWrapping="Wrap" Grid.Column="1"/>
 
                                         <usercontrols:HyperLinkStandard Margin="5,0,20,0" VerticalAlignment="Center" DisplayText="{Resx ResxName=JMMClient.Properties.Resources, Key=MoreInfo}"  Grid.Column="2"
                                                                         URL="{Resx ResxName=JMMClient.Properties.Resources, Key=Link_uTorrent}"/>
@@ -1507,25 +1507,25 @@
                                 </Border>
 
                                 <Border BorderBrush="LightGray" BorderThickness="1" Grid.Column="0" Grid.Row="1" Background="#FFE9ECEF" Margin="0,0,0,5">
-                                    <TextBlock Text="uTorrent WebUI details" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Downloads_uTorrentWebUI}" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
                                 </Border>
 
                                 <usercontrols:DownloadsSettingsControl Grid.Column="0" Grid.Row="2" Margin="5,0,0,10"/>
 
                                 <Border BorderBrush="LightGray" BorderThickness="1" Grid.Column="0" Grid.Row="3" Background="#FFE9ECEF" Margin="0,0,0,5">
-                                    <TextBlock Text="Torrent Black Hole Settings" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Downloads_TorrentBlackHole}" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
                                 </Border>
 
                                 <usercontrols:DownloadsTorrentBlackHole Grid.Column="0" Grid.Row="4" Margin="5,0,0,10"/>
 
                                 <Border BorderBrush="LightGray" BorderThickness="1" Grid.Column="0" Grid.Row="5" Background="#FFE9ECEF" Margin="0,0,0,5">
-                                    <TextBlock Text="Default Torrent Sources for Searching" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Downloads_TorrentDefault}" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
                                 </Border>
 
                                 <usercontrols:DownloadSettingsTorSources Grid.Column="0" Grid.Row="6" Margin="5,0,0,10"/>
 
                                 <Border BorderBrush="LightGray" BorderThickness="1" Grid.Column="0" Grid.Row="7" Background="#FFE9ECEF" Margin="0,0,0,5">
-                                    <TextBlock Text="BakaBT Settings" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Downloads_BakaBT}" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
                                 </Border>
 
                                 <Border Style="{DynamicResource ToolbarBorderControlStyle}" Grid.Column="0" Grid.Row="8"  Background="#F1F1F1" Margin="0,0,0,5" Padding="5">
@@ -1542,9 +1542,9 @@
                                         </Grid.ColumnDefinitions>
 
                                         <Image Height="16" Width="16" Source="/Images/32_info.png" Margin="5,2,5,0" Grid.Column="0" VerticalAlignment="Top"/>
-                                        <TextBlock VerticalAlignment="Center" Text="BakaBT is  an anime torrent site which specializes in full series downloads, however it requires an account first" Margin="0,0,5,0" TextWrapping="Wrap" Grid.Column="1"/>
+                                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Downloads_BakaBTInfo}" Margin="0,0,5,0" TextWrapping="Wrap" Grid.Column="1"/>
 
-                                        <usercontrols:HyperLinkStandard Margin="5,0,20,0" VerticalAlignment="Center" DisplayText="Go to Website"  Grid.Column="2"
+                                        <usercontrols:HyperLinkStandard Margin="5,0,20,0" VerticalAlignment="Center" DisplayText="{Resx ResxName=JMMClient.Properties.Resources, Key=Downloads_GoTo}"  Grid.Column="2"
                                                                         URL="http://bakabt.me"/>
                                     </Grid>
                                 </Border>
@@ -1552,7 +1552,7 @@
                                 <usercontrols:DownloadSettingsBakaBT Grid.Column="0" Grid.Row="9" Margin="5,0,0,10"/>
 
                                 <Border BorderBrush="LightGray" BorderThickness="1" Grid.Column="0" Grid.Row="10" Background="#FFE9ECEF" Margin="0,0,0,5">
-                                    <TextBlock Text="Anime Byt.es Settings" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Downloads_AnimeBytes}" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
                                 </Border>
 
                                 <Border Style="{DynamicResource ToolbarBorderControlStyle}" Grid.Column="0" Grid.Row="11"  Background="#F1F1F1" Margin="0,0,0,5" Padding="5">
@@ -1569,10 +1569,10 @@
                                         </Grid.ColumnDefinitions>
 
                                         <Image Height="16" Width="16" Source="/Images/32_info.png" Margin="5,2,5,0" Grid.Column="0" VerticalAlignment="Top"/>
-                                        <TextBlock VerticalAlignment="Center" Text="Anime Byt.es is an anime torrent site which specializes in full series downloads, however it requires an account first" Margin="0,0,5,0" TextWrapping="Wrap" Grid.Column="1"/>
+                                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Downloads_AnimeBytesInfo}" Margin="0,0,5,0" TextWrapping="Wrap" Grid.Column="1"/>
 
-                                        <usercontrols:HyperLinkStandard Margin="5,0,20,0" VerticalAlignment="Center" DisplayText="Go to Website"  Grid.Column="2"
-                                                                        URL="http://animebyt.es"/>
+                                        <usercontrols:HyperLinkStandard Margin="5,0,20,0" VerticalAlignment="Center" DisplayText="{Resx ResxName=JMMClient.Properties.Resources, Key=Downloads_GoTo}"  Grid.Column="2"
+                                                                        URL="http://animebytes.tv"/>
                                     </Grid>
                                 </Border>
 
@@ -1596,7 +1596,7 @@
                 <TabItem.Header>
                     <StackPanel Orientation="Horizontal" Margin="5,0,0,0">
                         <Image Height="20" Source="/Images/MagnifyingGlass6.png" Margin="0,0,0,0"/>
-                        <TextBlock Text="Search" Margin="2,0,0,0" VerticalAlignment="Center" Foreground="White" FontWeight="Bold"/>
+                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Tab_Search}" Margin="2,0,0,0" VerticalAlignment="Center" Foreground="White" FontWeight="Bold"/>
                     </StackPanel>
                 </TabItem.Header>
 
@@ -1609,7 +1609,7 @@
                      Visibility="{Binding Source={x:Static local:JMMServerVM.Instance}, Path=ShowCommunity, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <TabItem.Header>
                     <StackPanel Orientation="Horizontal" Margin="5,0,0,0">
-                        <TextBlock Text="Community" Margin="2,0,0,0" VerticalAlignment="Center" Foreground="White" FontWeight="Bold"/>
+                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Tab_Community}" Margin="2,0,0,0" VerticalAlignment="Center" Foreground="White" FontWeight="Bold"/>
                     </StackPanel>
                 </TabItem.Header>
 
@@ -1694,7 +1694,7 @@
                         Visibility="{Binding Source={x:Static local:JMMServerVM.Instance}, Path=AdminMessagesAvailable, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                             <Image Height="16" Width="16" Source="/Images/32_mail.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Messages" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Main_Messages}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
 
@@ -1703,12 +1703,12 @@
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="20,4,0,4"
                                 Visibility="{Binding Source={x:Static local:JMMServerVM.Instance}, Path=IsBanned, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <Image Height="16" Width="16" Source="/Images/16_exclamation.png" Margin="0,0,5,0"/>
-                        <TextBlock VerticalAlignment="Center" Text="Paused due to BAN from AniDB (" Margin="0,0,0,0" FontWeight="Bold"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Main_Paused}" Margin="0,0,0,0" FontWeight="Bold"/>
                         <TextBlock VerticalAlignment="Center" Text="{Binding Source={x:Static local:JMMServerVM.Instance},Path=BanOrigin}" FontWeight="Bold"/>
                         <TextBlock VerticalAlignment="Center" Margin="0,0,0,0" Text=")" FontWeight="Bold"/>
                         <TextBlock VerticalAlignment="Center" Margin="10,0,0,0" Text="{Binding Source={x:Static local:JMMServerVM.Instance},Path=BanReason}"/>
                         <usercontrols:HyperLinkStandard VerticalAlignment="Center" Margin="10,0,0,0" DisplayText="What does this mean?" Grid.Column="1"
-                                                                        URL="http://japanesemediamanager.github.io/wiki_usermanual.html"/>
+                                                                        URL="{Resx ResxName=JMMClient.Properties.Resources, Key=Link_AniDBBanned}"/>
                     </StackPanel>
 
 
@@ -1722,7 +1722,7 @@
                     <Button Name="btnSwitchUser"  Margin="2" Style="{DynamicResource RoundButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                             <Image Height="16" Width="16" Source="/Images/64_user.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="User" FontWeight="Bold" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Main_User}" FontWeight="Bold" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
 
@@ -1739,13 +1739,13 @@
                     <Button x:Name="btnFeed"  Margin="2,2,2,0" Style="{DynamicResource FlatButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Top">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                             <Image Height="16" Width="16" Source="Images/32_feed.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Feed" Margin="0,0,0,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Main_Feed}" Margin="0,0,0,0"/>
                         </StackPanel>
                     </Button>
                     <Button x:Name="btnAbout"  Margin="2" Style="{DynamicResource FlatButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                             <Image Height="16" Width="16" Source="Images/32_info.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="About" Margin="0,0,0,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Main_About}" Margin="0,0,0,0"/>
                         </StackPanel>
                     </Button>
 

--- a/JMMClient/Properties/Resources.Designer.cs
+++ b/JMMClient/Properties/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add.
+        /// </summary>
+        public static string Add {
+            get {
+                return ResourceManager.GetString("Add", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to New Sub Group.
         /// </summary>
         public static string AddSubGroup {
@@ -111,6 +120,87 @@ namespace JMMClient.Properties {
         public static string AniDB {
             get {
                 return ResourceManager.GetString("AniDB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Collecting:.
+        /// </summary>
+        public static string AniDB_Collecting {
+            get {
+                return ResourceManager.GetString("AniDB_Collecting", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Data Missing.
+        /// </summary>
+        public static string AniDB_DataMissing {
+            get {
+                return ResourceManager.GetString("AniDB_DataMissing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Files:.
+        /// </summary>
+        public static string AniDB_Files {
+            get {
+                return ResourceManager.GetString("AniDB_Files", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to For Fans.
+        /// </summary>
+        public static string AniDB_ForFans {
+            get {
+                return ResourceManager.GetString("AniDB_ForFans", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Got vids for anime from service:.
+        /// </summary>
+        public static string AniDB_GotVids {
+            get {
+                return ResourceManager.GetString("AniDB_GotVids", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to in.
+        /// </summary>
+        public static string AniDB_In {
+            get {
+                return ResourceManager.GetString("AniDB_In", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Must See.
+        /// </summary>
+        public static string AniDB_MustSee {
+            get {
+                return ResourceManager.GetString("AniDB_MustSee", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Recommended.
+        /// </summary>
+        public static string AniDB_Recommended {
+            get {
+                return ResourceManager.GetString("AniDB_Recommended", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Votes.
+        /// </summary>
+        public static string AniDB_Votes {
+            get {
+                return ResourceManager.GetString("AniDB_Votes", resourceCulture);
             }
         }
         
@@ -376,7 +466,88 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Reset the cookie if you are not getting any results from AnimeByt.es when you should be. This will force a login to AnimeByt.es again..
+        ///   Looks up a localized string similar to Got episode contracts:.
+        /// </summary>
+        public static string Anime_Contracts {
+            get {
+                return ResourceManager.GetString("Anime_Contracts", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Got episode data from service:.
+        /// </summary>
+        public static string Anime_GotEpisodes {
+            get {
+                return ResourceManager.GetString("Anime_GotEpisodes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Got vids for anime from service:.
+        /// </summary>
+        public static string Anime_GotVids {
+            get {
+                return ResourceManager.GetString("Anime_GotVids", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Group name must be populated.
+        /// </summary>
+        public static string Anime_GroupName {
+            get {
+                return ResourceManager.GetString("Anime_GroupName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Groups.
+        /// </summary>
+        public static string Anime_Groups {
+            get {
+                return ResourceManager.GetString("Anime_Groups", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to in.
+        /// </summary>
+        public static string Anime_In {
+            get {
+                return ResourceManager.GetString("Anime_In", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Series.
+        /// </summary>
+        public static string Anime_Series {
+            get {
+                return ResourceManager.GetString("Anime_Series", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sorted episode contracts:.
+        /// </summary>
+        public static string Anime_Sorted {
+            get {
+                return ResourceManager.GetString("Anime_Sorted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sort name must be populated.
+        /// </summary>
+        public static string Anime_SortName {
+            get {
+                return ResourceManager.GetString("Anime_SortName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Reset the cookie if you are not getting any results from AnimeBytes when you should be. This will force a login to AnimeBytes again..
         /// </summary>
         public static string AnimeBytesResetBody {
             get {
@@ -394,7 +565,7 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to When searching for a series, AnimeByt.es (and BakaBT) will be the only torrent source used in the initial search.
+        ///   Looks up a localized string similar to When searching for a series, AnimeBytes (and BakaBT) will be the only torrent source used in the initial search.
         /// </summary>
         public static string AnimeBytesSeriesBody {
             get {
@@ -403,11 +574,65 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to AnimeByt.es (and BakaBT) Only.
+        ///   Looks up a localized string similar to AnimeBytes (and BakaBT) Only.
         /// </summary>
         public static string AnimeBytesSeriesTitle {
             get {
                 return ResourceManager.GetString("AnimeBytesSeriesTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Next Episode.
+        /// </summary>
+        public static string AnimeEpisode_Next {
+            get {
+                return ResourceManager.GetString("AnimeEpisode_Next", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Episode Overview Not Available.
+        /// </summary>
+        public static string AnimeEpisode_NoOverview {
+            get {
+                return ResourceManager.GetString("AnimeEpisode_NoOverview", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Previous Episode.
+        /// </summary>
+        public static string AnimeEpisode_Previous {
+            get {
+                return ResourceManager.GetString("AnimeEpisode_Previous", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to All Series.
+        /// </summary>
+        public static string AnimeGroup_AllSeries {
+            get {
+                return ResourceManager.GetString("AnimeGroup_AllSeries", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Double click on a series to view it directly.
+        /// </summary>
+        public static string AnimeGroup_DoubleClick {
+            get {
+                return ResourceManager.GetString("AnimeGroup_DoubleClick", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Random Episode.
+        /// </summary>
+        public static string AnimeGroup_Random {
+            get {
+                return ResourceManager.GetString("AnimeGroup_Random", resourceCulture);
             }
         }
         
@@ -520,11 +745,56 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Available.
+        /// </summary>
+        public static string Available {
+            get {
+                return ResourceManager.GetString("Available", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Avdump2.
         /// </summary>
         public static string Avdump {
             get {
                 return ResourceManager.GetString("Avdump", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Clear list.
+        /// </summary>
+        public static string AvDump_Clear {
+            get {
+                return ResourceManager.GetString("AvDump_Clear", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Dump files.
+        /// </summary>
+        public static string AvDump_Dump {
+            get {
+                return ResourceManager.GetString("AvDump_Dump", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove from list.
+        /// </summary>
+        public static string AvDump_Remove {
+            get {
+                return ResourceManager.GetString("AvDump_Remove", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To be processed.
+        /// </summary>
+        public static string AVDump_ToBe {
+            get {
+                return ResourceManager.GetString("AVDump_ToBe", resourceCulture);
             }
         }
         
@@ -619,7 +889,7 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to When searching for a series, BakaBT (and AnimeByt.es) will be the only torrent source used in the initial search.
+        ///   Looks up a localized string similar to When searching for a series, BakaBT (and AnimeBytes) will be the only torrent source used in the initial search.
         /// </summary>
         public static string BakaBTSeriesBody {
             get {
@@ -628,11 +898,29 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to BakaBT (and AnimeByt.es) Only.
+        ///   Looks up a localized string similar to BakaBT (and AnimeBytes) Only.
         /// </summary>
         public static string BakaBTSeriesTitle {
             get {
                 return ResourceManager.GetString("BakaBTSeriesTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Downloading.
+        /// </summary>
+        public static string Bookmarks_Downloading {
+            get {
+                return ResourceManager.GetString("Bookmarks_Downloading", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Not Downloading.
+        /// </summary>
+        public static string Bookmarks_NotDownloading {
+            get {
+                return ResourceManager.GetString("Bookmarks_NotDownloading", resourceCulture);
             }
         }
         
@@ -673,11 +961,38 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Change Password.
+        /// </summary>
+        public static string ChangePassword {
+            get {
+                return ResourceManager.GetString("ChangePassword", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Changing Password For: .
+        /// </summary>
+        public static string ChangingPassword {
+            get {
+                return ResourceManager.GetString("ChangingPassword", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Check For Updates.
         /// </summary>
         public static string CheckForUpdate {
             get {
                 return ResourceManager.GetString("CheckForUpdate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Clear.
+        /// </summary>
+        public static string Clear {
+            get {
+                return ResourceManager.GetString("Clear", resourceCulture);
             }
         }
         
@@ -700,6 +1015,195 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Check if my links are different from the community recommendations.
+        /// </summary>
+        public static string Community_CommunityCheck {
+            get {
+                return ResourceManager.GetString("Community_CommunityCheck", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Community Link.
+        /// </summary>
+        public static string Community_CommunityLink {
+            get {
+                return ResourceManager.GetString("Community_CommunityLink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Filter:.
+        /// </summary>
+        public static string Community_Filter {
+            get {
+                return ResourceManager.GetString("Community_Filter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Has Trakt Link.
+        /// </summary>
+        public static string Community_HasTraktLink {
+            get {
+                return ResourceManager.GetString("Community_HasTraktLink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Links Match?.
+        /// </summary>
+        public static string Community_Match {
+            get {
+                return ResourceManager.GetString("Community_Match", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Stop after finding this many problems.
+        /// </summary>
+        public static string Community_ProblemStop {
+            get {
+                return ResourceManager.GetString("Community_ProblemStop", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Refresh data for this series.
+        /// </summary>
+        public static string Community_Refresh {
+            get {
+                return ResourceManager.GetString("Community_Refresh", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Series Name.
+        /// </summary>
+        public static string Community_SeriesName {
+            get {
+                return ResourceManager.GetString("Community_SeriesName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Status.
+        /// </summary>
+        public static string Community_Status {
+            get {
+                return ResourceManager.GetString("Community_Status", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Automatically remove bad information from the database (highly recommended).
+        /// </summary>
+        public static string Community_TraktRemoveBad {
+            get {
+                return ResourceManager.GetString("Community_TraktRemoveBad", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Check my links are still valid on Trakt.
+        /// </summary>
+        public static string Community_TraktValid {
+            get {
+                return ResourceManager.GetString("Community_TraktValid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Valid Trakt Link.
+        /// </summary>
+        public static string Community_ValidTraktLink {
+            get {
+                return ResourceManager.GetString("Community_ValidTraktLink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to AniDB Start:.
+        /// </summary>
+        public static string CommunityLinks_AniDBStart {
+            get {
+                return ResourceManager.GetString("CommunityLinks_AniDBStart", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto Link.
+        /// </summary>
+        public static string CommunityLinks_AutoLink {
+            get {
+                return ResourceManager.GetString("CommunityLinks_AutoLink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Edit Details.
+        /// </summary>
+        public static string CommunityLinks_Edit {
+            get {
+                return ResourceManager.GetString("CommunityLinks_Edit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to MyAnimeList.
+        /// </summary>
+        public static string CommunityLinks_MAL {
+            get {
+                return ResourceManager.GetString("CommunityLinks_MAL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Start:.
+        /// </summary>
+        public static string CommunityLinks_Start {
+            get {
+                return ResourceManager.GetString("CommunityLinks_Start", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The Movie DB.
+        /// </summary>
+        public static string CommunityLinks_TMDb {
+            get {
+                return ResourceManager.GetString("CommunityLinks_TMDb", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Trakt: .
+        /// </summary>
+        public static string CommunityLinks_Trakt {
+            get {
+                return ResourceManager.GetString("CommunityLinks_Trakt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Trakt TV.
+        /// </summary>
+        public static string CommunityLinks_TraktTV {
+            get {
+                return ResourceManager.GetString("CommunityLinks_TraktTV", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to TvDB: .
+        /// </summary>
+        public static string CommunityLinks_TvDB {
+            get {
+                return ResourceManager.GetString("CommunityLinks_TvDB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Community Recommendation.
         /// </summary>
         public static string CommunityRecommendation {
@@ -718,6 +1222,24 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Continue Watching (SYSTEM).
+        /// </summary>
+        public static string Constants_Continue {
+            get {
+                return ResourceManager.GetString("Constants_Continue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to main character in.
+        /// </summary>
+        public static string Constants_MainCharacter {
+            get {
+                return ResourceManager.GetString("Constants_MainCharacter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Copy ED2K Dump.
         /// </summary>
         public static string CopyED2KClipboard {
@@ -732,6 +1254,24 @@ namespace JMMClient.Properties {
         public static string CrossRefSummary {
             get {
                 return ResourceManager.GetString("CrossRefSummary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tag Description.
+        /// </summary>
+        public static string CustomTag_Description {
+            get {
+                return ResourceManager.GetString("CustomTag_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tag Name.
+        /// </summary>
+        public static string CustomTag_Name {
+            get {
+                return ResourceManager.GetString("CustomTag_Name", resourceCulture);
             }
         }
         
@@ -795,6 +1335,96 @@ namespace JMMClient.Properties {
         public static string Dash_WatchNextEp_Recent {
             get {
                 return ResourceManager.GetString("Dash_WatchNextEp_Recent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Added.
+        /// </summary>
+        public static string Dashboard_Added {
+            get {
+                return ResourceManager.GetString("Dashboard_Added", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Bookmark this anime to download later.
+        /// </summary>
+        public static string Dashboard_Bookmark {
+            get {
+                return ResourceManager.GetString("Dashboard_Bookmark", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Search for downloads for this series.
+        /// </summary>
+        public static string Dashboard_Download {
+            get {
+                return ResourceManager.GetString("Dashboard_Download", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Download your votes now, or vote on an anime to start getting recommendations..
+        /// </summary>
+        public static string Dashboard_DownloadVotes {
+            get {
+                return ResourceManager.GetString("Dashboard_DownloadVotes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Metro Dashboard.
+        /// </summary>
+        public static string Dashboard_Metro {
+            get {
+                return ResourceManager.GetString("Dashboard_Metro", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No recommendations could be found..
+        /// </summary>
+        public static string Dashboard_NoRecommend {
+            get {
+                return ResourceManager.GetString("Dashboard_NoRecommend", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Recent Additions.
+        /// </summary>
+        public static string Dashboard_Recent {
+            get {
+                return ResourceManager.GetString("Dashboard_Recent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sync Votes.
+        /// </summary>
+        public static string Dashboard_SyncVotes {
+            get {
+                return ResourceManager.GetString("Dashboard_SyncVotes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Update Calendar Data.
+        /// </summary>
+        public static string Dashboard_UpdateCalendar {
+            get {
+                return ResourceManager.GetString("Dashboard_UpdateCalendar", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your Vote.
+        /// </summary>
+        public static string Dashboard_YourVote {
+            get {
+                return ResourceManager.GetString("Dashboard_YourVote", resourceCulture);
             }
         }
         
@@ -916,6 +1546,15 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Click for detailed explanation of options.
+        /// </summary>
+        public static string DetailedExplanation {
+            get {
+                return ResourceManager.GetString("DetailedExplanation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Follow this link for an in depth explanation.
         /// </summary>
         public static string DetailedInformationLink {
@@ -930,6 +1569,375 @@ namespace JMMClient.Properties {
         public static string Down {
             get {
                 return ResourceManager.GetString("Down", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to AnimeBytes ONLY for Series.
+        /// </summary>
+        public static string Download_AnimeBytesOnly {
+            get {
+                return ResourceManager.GetString("Download_AnimeBytesOnly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Approval.
+        /// </summary>
+        public static string Download_Approval {
+            get {
+                return ResourceManager.GetString("Download_Approval", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto Refresh.
+        /// </summary>
+        public static string Download_AutoRefresh {
+            get {
+                return ResourceManager.GetString("Download_AutoRefresh", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to BakaBT ONLY for Series.
+        /// </summary>
+        public static string Download_BakaBTOnly {
+            get {
+                return ResourceManager.GetString("Download_BakaBTOnly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Bookmark this anime to download later.
+        /// </summary>
+        public static string Download_Bookmark {
+            get {
+                return ResourceManager.GetString("Download_Bookmark", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Done.
+        /// </summary>
+        public static string Download_Done {
+            get {
+                return ResourceManager.GetString("Download_Done", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Downloaded.
+        /// </summary>
+        public static string Download_Downloaded {
+            get {
+                return ResourceManager.GetString("Download_Downloaded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Down Speed.
+        /// </summary>
+        public static string Download_DownSpeed {
+            get {
+                return ResourceManager.GetString("Download_DownSpeed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please enter your credentials on the setting tab and then return.
+        /// </summary>
+        public static string Download_EnterCred {
+            get {
+                return ResourceManager.GetString("Download_EnterCred", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Extra Info.
+        /// </summary>
+        public static string Download_ExtraInfo {
+            get {
+                return ResourceManager.GetString("Download_ExtraInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Folder Location.
+        /// </summary>
+        public static string Download_FolderLocation {
+            get {
+                return ResourceManager.GetString("Download_FolderLocation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hash.
+        /// </summary>
+        public static string Download_Hash {
+            get {
+                return ResourceManager.GetString("Download_Hash", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You haven&apos;t specified valid uTorrent credentials.
+        /// </summary>
+        public static string Download_InvalidCred {
+            get {
+                return ResourceManager.GetString("Download_InvalidCred", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Leechers.
+        /// </summary>
+        public static string Download_Leechers {
+            get {
+                return ResourceManager.GetString("Download_Leechers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name.
+        /// </summary>
+        public static string Download_Name {
+            get {
+                return ResourceManager.GetString("Download_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Peers.
+        /// </summary>
+        public static string Download_Peers {
+            get {
+                return ResourceManager.GetString("Download_Peers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Priority.
+        /// </summary>
+        public static string Download_Priority {
+            get {
+                return ResourceManager.GetString("Download_Priority", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to #.
+        /// </summary>
+        public static string Download_Queue {
+            get {
+                return ResourceManager.GetString("Download_Queue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ratio.
+        /// </summary>
+        public static string Download_Ratio {
+            get {
+                return ResourceManager.GetString("Download_Ratio", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This utility shows you a list of recommended anime which are not in your collection based on your own ratings and feedback from AniDB users.
+        /// </summary>
+        public static string Download_RecommendPrompt {
+            get {
+                return ResourceManager.GetString("Download_RecommendPrompt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Refresh Interval (seconds).
+        /// </summary>
+        public static string Download_RefreshInterval {
+            get {
+                return ResourceManager.GetString("Download_RefreshInterval", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Reset Cookie.
+        /// </summary>
+        public static string Download_ResetCookie {
+            get {
+                return ResourceManager.GetString("Download_ResetCookie", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Seeders.
+        /// </summary>
+        public static string Download_Seeders {
+            get {
+                return ResourceManager.GetString("Download_Seeders", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Search for downloads for this series.
+        /// </summary>
+        public static string Download_SeriesSearch {
+            get {
+                return ResourceManager.GetString("Download_SeriesSearch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Server.
+        /// </summary>
+        public static string Download_Server {
+            get {
+                return ResourceManager.GetString("Download_Server", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Size.
+        /// </summary>
+        public static string Download_Size {
+            get {
+                return ResourceManager.GetString("Download_Size", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Source.
+        /// </summary>
+        public static string Download_Source {
+            get {
+                return ResourceManager.GetString("Download_Source", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Torrent Folder Location.
+        /// </summary>
+        public static string Download_TorrentFolder {
+            get {
+                return ResourceManager.GetString("Download_TorrentFolder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Upload Speed.
+        /// </summary>
+        public static string Download_UpSpeed {
+            get {
+                return ResourceManager.GetString("Download_UpSpeed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use Torrent Black Hole.
+        /// </summary>
+        public static string Download_UseBlackHole {
+            get {
+                return ResourceManager.GetString("Download_UseBlackHole", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Wrong Series?.
+        /// </summary>
+        public static string Download_WrongSeries {
+            get {
+                return ResourceManager.GetString("Download_WrongSeries", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your Vote.
+        /// </summary>
+        public static string Download_YourVote {
+            get {
+                return ResourceManager.GetString("Download_YourVote", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to AnimeBytes Settings.
+        /// </summary>
+        public static string Downloads_AnimeBytes {
+            get {
+                return ResourceManager.GetString("Downloads_AnimeBytes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to AnimeBytes is an anime torrent site which specializes in full series downloads, however it requires an account first.
+        /// </summary>
+        public static string Downloads_AnimeBytesInfo {
+            get {
+                return ResourceManager.GetString("Downloads_AnimeBytesInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to BakaBT Settings.
+        /// </summary>
+        public static string Downloads_BakaBT {
+            get {
+                return ResourceManager.GetString("Downloads_BakaBT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to BakaBT is an anime torrent site which specializes in full series downloads, however it requires an account first.
+        /// </summary>
+        public static string Downloads_BakaBTInfo {
+            get {
+                return ResourceManager.GetString("Downloads_BakaBTInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Go to Website.
+        /// </summary>
+        public static string Downloads_GoTo {
+            get {
+                return ResourceManager.GetString("Downloads_GoTo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Torrent Black Hole Settings.
+        /// </summary>
+        public static string Downloads_TorrentBlackHole {
+            get {
+                return ResourceManager.GetString("Downloads_TorrentBlackHole", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Default Torrent Sources for Searching.
+        /// </summary>
+        public static string Downloads_TorrentDefault {
+            get {
+                return ResourceManager.GetString("Downloads_TorrentDefault", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This uses the uTorrent WebUI API, which you need to enable in your uTorrent client first.
+        /// </summary>
+        public static string Downloads_uTorrentInfo {
+            get {
+                return ResourceManager.GetString("Downloads_uTorrentInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to uTorrent WebUI details.
+        /// </summary>
+        public static string Downloads_uTorrentWebUI {
+            get {
+                return ResourceManager.GetString("Downloads_uTorrentWebUI", resourceCulture);
             }
         }
         
@@ -957,6 +1965,168 @@ namespace JMMClient.Properties {
         public static string Edit {
             get {
                 return ResourceManager.GetString("Edit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Episode.
+        /// </summary>
+        public static string Episode {
+            get {
+                return ResourceManager.GetString("Episode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Force update information from AniDB.
+        /// </summary>
+        public static string Episode_AniDBForceUpdate {
+            get {
+                return ResourceManager.GetString("Episode_AniDBForceUpdate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Availability.
+        /// </summary>
+        public static string Episode_Availability {
+            get {
+                return ResourceManager.GetString("Episode_Availability", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CRC32.
+        /// </summary>
+        public static string Episode_CRC32 {
+            get {
+                return ResourceManager.GetString("Episode_CRC32", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Search downloads for this episode.
+        /// </summary>
+        public static string Episode_DownloadSearch {
+            get {
+                return ResourceManager.GetString("Episode_DownloadSearch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Force update information from AniDB.
+        /// </summary>
+        public static string Episode_ForceAniDBUpdate {
+            get {
+                return ResourceManager.GetString("Episode_ForceAniDBUpdate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hash.
+        /// </summary>
+        public static string Episode_Hash {
+            get {
+                return ResourceManager.GetString("Episode_Hash", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Less Info...
+        /// </summary>
+        public static string Episode_LessInfo {
+            get {
+                return ResourceManager.GetString("Episode_LessInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Manual Link.
+        /// </summary>
+        public static string Episode_Manual {
+            get {
+                return ResourceManager.GetString("Episode_Manual", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to MD5.
+        /// </summary>
+        public static string Episode_MD5 {
+            get {
+                return ResourceManager.GetString("Episode_MD5", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to More Info...
+        /// </summary>
+        public static string Episode_MoreInfo {
+            get {
+                return ResourceManager.GetString("Episode_MoreInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add to Playlist.
+        /// </summary>
+        public static string Episode_PlaylistAdd {
+            get {
+                return ResourceManager.GetString("Episode_PlaylistAdd", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Re-Calculate Hash.
+        /// </summary>
+        public static string Episode_RecalculateHash {
+            get {
+                return ResourceManager.GetString("Episode_RecalculateHash", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SHA1.
+        /// </summary>
+        public static string Episode_SHA1 {
+            get {
+                return ResourceManager.GetString("Episode_SHA1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Override the TvDB link for this episode.
+        /// </summary>
+        public static string Episode_TvDBOverride {
+            get {
+                return ResourceManager.GetString("Episode_TvDBOverride", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove the TvDB link for this episode.
+        /// </summary>
+        public static string Episode_TvDBRemove {
+            get {
+                return ResourceManager.GetString("Episode_TvDBRemove", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Type.
+        /// </summary>
+        public static string Episode_Type {
+            get {
+                return ResourceManager.GetString("Episode_Type", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Watched State.
+        /// </summary>
+        public static string Episode_WatchedState {
+            get {
+                return ResourceManager.GetString("Episode_WatchedState", resourceCulture);
             }
         }
         
@@ -1213,6 +2383,24 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Force update information from AniDB.
+        /// </summary>
+        public static string FileSearch_AniDBForceUpdate {
+            get {
+                return ResourceManager.GetString("FileSearch_AniDBForceUpdate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rescan.
+        /// </summary>
+        public static string FileSearch_Rescan {
+            get {
+                return ResourceManager.GetString("FileSearch_Rescan", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Files Selected.
         /// </summary>
         public static string FilesSelected {
@@ -1245,6 +2433,15 @@ namespace JMMClient.Properties {
         public static string FilterValue {
             get {
                 return ResourceManager.GetString("FilterValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Finish.
+        /// </summary>
+        public static string Finish {
+            get {
+                return ResourceManager.GetString("Finish", resourceCulture);
             }
         }
         
@@ -1290,6 +2487,33 @@ namespace JMMClient.Properties {
         public static string Group {
             get {
                 return ResourceManager.GetString("Group", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Filter Name must be populated.
+        /// </summary>
+        public static string Group_FilterName {
+            get {
+                return ResourceManager.GetString("Group_FilterName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  Groups.
+        /// </summary>
+        public static string Group_GroupCount {
+            get {
+                return ResourceManager.GetString("Group_GroupCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Groups.
+        /// </summary>
+        public static string Group_Groups {
+            get {
+                return ResourceManager.GetString("Group_Groups", resourceCulture);
             }
         }
         
@@ -1371,6 +2595,24 @@ namespace JMMClient.Properties {
         public static string GroupFilter_Predefined {
             get {
                 return ResourceManager.GetString("GroupFilter_Predefined", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Random Episode.
+        /// </summary>
+        public static string GroupFilter_RandomEpisode {
+            get {
+                return ResourceManager.GetString("GroupFilter_RandomEpisode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Random Series.
+        /// </summary>
+        public static string GroupFilter_RandomSeries {
+            get {
+                return ResourceManager.GetString("GroupFilter_RandomSeries", resourceCulture);
             }
         }
         
@@ -1987,6 +3229,51 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Anime ID:.
+        /// </summary>
+        public static string Ignore_AnimeID {
+            get {
+                return ResourceManager.GetString("Ignore_AnimeID", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Recommendations - Download.
+        /// </summary>
+        public static string Ignore_RecDown {
+            get {
+                return ResourceManager.GetString("Ignore_RecDown", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Recommendations - Watch.
+        /// </summary>
+        public static string Ignore_RecWatch {
+            get {
+                return ResourceManager.GetString("Ignore_RecWatch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Delete this entry.
+        /// </summary>
+        public static string IgnoredAnime_Delete {
+            get {
+                return ResourceManager.GetString("IgnoredAnime_Delete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This utility will show you all the anime you have chosen to ignore from the recommendations. Deleting these records means they may show in recommendations again..
+        /// </summary>
+        public static string IgnoredAnime_Note {
+            get {
+                return ResourceManager.GetString("IgnoredAnime_Note", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Only this image will be used.
         /// </summary>
         public static string Image_Default {
@@ -2104,6 +3391,15 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This folder is being watched for new files.
+        /// </summary>
+        public static string ImportFolder_Watched {
+            get {
+                return ResourceManager.GetString("ImportFolder_Watched", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Import Folder Name.
         /// </summary>
         public static string ImportFolderName {
@@ -2194,7 +3490,7 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Watch for new files.
+        ///   Looks up a localized string similar to Watch For New Files.
         /// </summary>
         public static string ImportSettings_WatchFiles {
             get {
@@ -2284,11 +3580,92 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to JMM Desktop.
+        /// </summary>
+        public static string JMMDesktop {
+            get {
+                return ResourceManager.GetString("JMMDesktop", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to JMM Server.
         /// </summary>
         public static string JMMServer {
             get {
                 return ResourceManager.GetString("JMMServer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error.
+        /// </summary>
+        public static string JMMServer_Error {
+            get {
+                return ResourceManager.GetString("JMMServer_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Import Folders.
+        /// </summary>
+        public static string JMMServer_ImportFolders {
+            get {
+                return ResourceManager.GetString("JMMServer_ImportFolders", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Paused.
+        /// </summary>
+        public static string JMMServer_Paused {
+            get {
+                return ResourceManager.GetString("JMMServer_Paused", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Running.
+        /// </summary>
+        public static string JMMServer_Running {
+            get {
+                return ResourceManager.GetString("JMMServer_Running", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Server Images Queue.
+        /// </summary>
+        public static string JMMServer_ServerImage {
+            get {
+                return ResourceManager.GetString("JMMServer_ServerImage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Server Status.
+        /// </summary>
+        public static string JMMServer_ServerStatus {
+            get {
+                return ResourceManager.GetString("JMMServer_ServerStatus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Success.
+        /// </summary>
+        public static string JMMServer_Success {
+            get {
+                return ResourceManager.GetString("JMMServer_Success", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Trakt Auth.
+        /// </summary>
+        public static string JMMServer_TraktAuth {
+            get {
+                return ResourceManager.GetString("JMMServer_TraktAuth", resourceCulture);
             }
         }
         
@@ -2545,6 +3922,51 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to About.
+        /// </summary>
+        public static string Main_About {
+            get {
+                return ResourceManager.GetString("Main_About", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Feed.
+        /// </summary>
+        public static string Main_Feed {
+            get {
+                return ResourceManager.GetString("Main_Feed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Messages.
+        /// </summary>
+        public static string Main_Messages {
+            get {
+                return ResourceManager.GetString("Main_Messages", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Paused due to BAN from AniDB (.
+        /// </summary>
+        public static string Main_Paused {
+            get {
+                return ResourceManager.GetString("Main_Paused", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to User.
+        /// </summary>
+        public static string Main_User {
+            get {
+                return ResourceManager.GetString("Main_User", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Never Decrease Watched Counts.
         /// </summary>
         public static string MAL_NeverDecrease {
@@ -2572,11 +3994,137 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This group is marked as a favorite.
+        /// </summary>
+        public static string MarkedFavorite {
+            get {
+                return ResourceManager.GetString("MarkedFavorite", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Matches.
+        /// </summary>
+        public static string Matches {
+            get {
+                return ResourceManager.GetString("Matches", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Continue Watching.
+        /// </summary>
+        public static string Metro_Continue {
+            get {
+                return ResourceManager.GetString("Metro_Continue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to General.
+        /// </summary>
+        public static string Metro_General {
+            get {
+                return ResourceManager.GetString("Metro_General", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Image Type.
+        /// </summary>
+        public static string Metro_ImageType {
+            get {
+                return ResourceManager.GetString("Metro_ImageType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Items.
+        /// </summary>
+        public static string Metro_Items {
+            get {
+                return ResourceManager.GetString("Metro_Items", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to New Episodes.
+        /// </summary>
+        public static string Metro_New {
+            get {
+                return ResourceManager.GetString("Metro_New", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Options.
+        /// </summary>
+        public static string Metro_Options {
+            get {
+                return ResourceManager.GetString("Metro_Options", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Random Series.
+        /// </summary>
+        public static string Metro_Random {
+            get {
+                return ResourceManager.GetString("Metro_Random", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Refresh.
+        /// </summary>
+        public static string Metro_Refresh {
+            get {
+                return ResourceManager.GetString("Metro_Refresh", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sections.
+        /// </summary>
+        public static string Metro_Sections {
+            get {
+                return ResourceManager.GetString("Metro_Sections", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Trakt Activity.
+        /// </summary>
+        public static string Metro_Trakt {
+            get {
+                return ResourceManager.GetString("Metro_Trakt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Missing.
         /// </summary>
         public static string Missing {
             get {
                 return ResourceManager.GetString("Missing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Episode.
+        /// </summary>
+        public static string Missing_Episode {
+            get {
+                return ResourceManager.GetString("Missing_Episode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to File.
+        /// </summary>
+        public static string Missing_File {
+            get {
+                return ResourceManager.GetString("Missing_File", resourceCulture);
             }
         }
         
@@ -2590,11 +4138,146 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Airing State:.
+        /// </summary>
+        public static string MissingEpisodes_AiringState {
+            get {
+                return ResourceManager.GetString("MissingEpisodes_AiringState", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Anime ID.
+        /// </summary>
+        public static string MissingEpisodes_AnimeID {
+            get {
+                return ResourceManager.GetString("MissingEpisodes_AnimeID", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Link to Anime.
+        /// </summary>
+        public static string MissingEpisodes_AnimeLink {
+            get {
+                return ResourceManager.GetString("MissingEpisodes_AnimeLink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Anime Name.
+        /// </summary>
+        public static string MissingEpisodes_AnimeName {
+            get {
+                return ResourceManager.GetString("MissingEpisodes_AnimeName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Episode ID.
+        /// </summary>
+        public static string MissingEpisodes_EpisodeID {
+            get {
+                return ResourceManager.GetString("MissingEpisodes_EpisodeID", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Link to Episode.
+        /// </summary>
+        public static string MissingEpisodes_EpisodeLink {
+            get {
+                return ResourceManager.GetString("MissingEpisodes_EpisodeLink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Episode Number.
+        /// </summary>
+        public static string MissingEpisodes_EpisodeNumber {
+            get {
+                return ResourceManager.GetString("MissingEpisodes_EpisodeNumber", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to File Summary.
+        /// </summary>
+        public static string MissingEpisodes_FileSummary {
+            get {
+                return ResourceManager.GetString("MissingEpisodes_FileSummary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Group Summary.
+        /// </summary>
+        public static string MissingEpisodes_GroupSummary {
+            get {
+                return ResourceManager.GetString("MissingEpisodes_GroupSummary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This utility will show you a summary of all your missing episodes..
+        /// </summary>
+        public static string MissingEpisodes_Note {
+            get {
+                return ResourceManager.GetString("MissingEpisodes_Note", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select the columns to be used in the import.
+        /// </summary>
+        public static string MissingEpisodes_SelectColumns {
+            get {
+                return ResourceManager.GetString("MissingEpisodes_SelectColumns", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to View Missing File.
+        /// </summary>
+        public static string MissingMyList_Missing {
+            get {
+                return ResourceManager.GetString("MissingMyList_Missing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This utility will download your list of files from AniDB, and compare it to the files locally. You will then have the chance to remove those files from AniDB if they don&apos;t exist..
+        /// </summary>
+        public static string MissingMyList_Note {
+            get {
+                return ResourceManager.GetString("MissingMyList_Note", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove All Entries From AniDB.
+        /// </summary>
+        public static string MissingMyList_RemoveAll {
+            get {
+                return ResourceManager.GetString("MissingMyList_RemoveAll", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to More Info.
         /// </summary>
         public static string MoreInfo {
             get {
                 return ResourceManager.GetString("MoreInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to More Information.
+        /// </summary>
+        public static string MoreInformation {
+            get {
+                return ResourceManager.GetString("MoreInformation", resourceCulture);
             }
         }
         
@@ -2631,6 +4314,15 @@ namespace JMMClient.Properties {
         public static string MovieDB_FanartCount {
             get {
                 return ResourceManager.GetString("MovieDB_FanartCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Maximum Posters.
+        /// </summary>
+        public static string MovieDB_MaxPosters {
+            get {
+                return ResourceManager.GetString("MovieDB_MaxPosters", resourceCulture);
             }
         }
         
@@ -2878,11 +4570,56 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A series is already attached to this anime.
+        /// </summary>
+        public static string NewSeries_AlreadyAttached {
+            get {
+                return ResourceManager.GetString("NewSeries_AlreadyAttached", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Back to Step 1.
+        /// </summary>
+        public static string NewSeries_BackToStep1 {
+            get {
+                return ResourceManager.GetString("NewSeries_BackToStep1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Search By Title or ID.
         /// </summary>
         public static string NewSeries_Search {
             get {
                 return ResourceManager.GetString("NewSeries_Search", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Search by Title or ID.
+        /// </summary>
+        public static string NewSeries_SearchBy {
+            get {
+                return ResourceManager.GetString("NewSeries_SearchBy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Step 1 - Select an Anime.
+        /// </summary>
+        public static string NewSeries_Step1 {
+            get {
+                return ResourceManager.GetString("NewSeries_Step1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select a Local Group.
+        /// </summary>
+        public static string NewSeries_Step2 {
+            get {
+                return ResourceManager.GetString("NewSeries_Step2", resourceCulture);
             }
         }
         
@@ -2968,11 +4705,83 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Show Simplified View.
+        /// </summary>
+        public static string PinnedSeries_Simple {
+            get {
+                return ResourceManager.GetString("PinnedSeries_Simple", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Play.
         /// </summary>
         public static string Play {
             get {
                 return ResourceManager.GetString("Play", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add to Playlist.
+        /// </summary>
+        public static string Playlist_Add {
+            get {
+                return ResourceManager.GetString("Playlist_Add", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Default Play Order.
+        /// </summary>
+        public static string Playlist_Default {
+            get {
+                return ResourceManager.GetString("Playlist_Default", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Playlist Items.
+        /// </summary>
+        public static string Playlist_Items {
+            get {
+                return ResourceManager.GetString("Playlist_Items", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enter playlist name: .
+        /// </summary>
+        public static string Playlist_Name {
+            get {
+                return ResourceManager.GetString("Playlist_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please enter a playlist name.
+        /// </summary>
+        public static string Playlist_NameBlank {
+            get {
+                return ResourceManager.GetString("Playlist_NameBlank", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to New Playlist.
+        /// </summary>
+        public static string Playlist_NewPlaylist {
+            get {
+                return ResourceManager.GetString("Playlist_NewPlaylist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Random Episode.
+        /// </summary>
+        public static string Playlist_Random {
+            get {
+                return ResourceManager.GetString("Playlist_Random", resourceCulture);
             }
         }
         
@@ -2995,11 +4804,29 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Hidden to prevent spoilers.
+        /// </summary>
+        public static string PlayNext_Hidden {
+            get {
+                return ResourceManager.GetString("PlayNext_Hidden", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Play Next Episode.
         /// </summary>
         public static string PlayNextEpisode {
             get {
                 return ResourceManager.GetString("PlayNextEpisode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Play Video.
+        /// </summary>
+        public static string PlayVideo {
+            get {
+                return ResourceManager.GetString("PlayVideo", resourceCulture);
             }
         }
         
@@ -3067,11 +4894,209 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Complete ONLY.
+        /// </summary>
+        public static string Random_CompleteOnly {
+            get {
+                return ResourceManager.GetString("Random_CompleteOnly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Partially Watched.
+        /// </summary>
+        public static string Random_PartiallyWatched {
+            get {
+                return ResourceManager.GetString("Random_PartiallyWatched", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tags.
+        /// </summary>
+        public static string Random_Tags {
+            get {
+                return ResourceManager.GetString("Random_Tags", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unwatched.
+        /// </summary>
+        public static string Random_Unwatched {
+            get {
+                return ResourceManager.GetString("Random_Unwatched", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to View this Series.
+        /// </summary>
+        public static string Random_View {
+            get {
+                return ResourceManager.GetString("Random_View", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Watched.
+        /// </summary>
+        public static string Random_Watched {
+            get {
+                return ResourceManager.GetString("Random_Watched", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to AniDB Rating.
+        /// </summary>
+        public static string Rankings_AniDB {
+            get {
+                return ResourceManager.GetString("Rankings_AniDB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  Anime.
+        /// </summary>
+        public static string Rankings_Anime {
+            get {
+                return ResourceManager.GetString("Rankings_Anime", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Collection State.
+        /// </summary>
+        public static string Rankings_CollectionState {
+            get {
+                return ResourceManager.GetString("Rankings_CollectionState", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Completed.
+        /// </summary>
+        public static string Rankings_Completed {
+            get {
+                return ResourceManager.GetString("Rankings_Completed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Grouped By Year.
+        /// </summary>
+        public static string Rankings_GroupedByYear {
+            get {
+                return ResourceManager.GetString("Rankings_GroupedByYear", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to My Vote.
+        /// </summary>
+        public static string Rankings_MyVote {
+            get {
+                return ResourceManager.GetString("Rankings_MyVote", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to By Overall User Rating.
+        /// </summary>
+        public static string Rankings_Overall {
+            get {
+                return ResourceManager.GetString("Rankings_Overall", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your Rating.
+        /// </summary>
+        public static string Rankings_User {
+            get {
+                return ResourceManager.GetString("Rankings_User", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to View Series.
+        /// </summary>
+        public static string Rankings_View {
+            get {
+                return ResourceManager.GetString("Rankings_View", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Voted.
+        /// </summary>
+        public static string Rankings_Voted {
+            get {
+                return ResourceManager.GetString("Rankings_Voted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Year.
+        /// </summary>
+        public static string Rankings_Year {
+            get {
+                return ResourceManager.GetString("Rankings_Year", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rate Series:.
+        /// </summary>
+        public static string RateSeries_Rate {
+            get {
+                return ResourceManager.GetString("RateSeries_Rate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Have your say on Trakt.
+        /// </summary>
+        public static string RateSeries_TraktShout {
+            get {
+                return ResourceManager.GetString("RateSeries_TraktShout", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Rating.
         /// </summary>
         public static string Rating {
             get {
                 return ResourceManager.GetString("Rating", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Data Missing.
+        /// </summary>
+        public static string Recommendation_Missing {
+            get {
+                return ResourceManager.GetString("Recommendation_Missing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Overview not available.
+        /// </summary>
+        public static string Recommendation_NoOverview {
+            get {
+                return ResourceManager.GetString("Recommendation_NoOverview", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Re-enter Password.
+        /// </summary>
+        public static string ReenterPassword {
+            get {
+                return ResourceManager.GetString("ReenterPassword", resourceCulture);
             }
         }
         
@@ -3094,6 +5119,15 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Pressing the refresh button can take several minutes, so please be patient.
+        /// </summary>
+        public static string RefreshWait {
+            get {
+                return ResourceManager.GetString("RefreshWait", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Regular Episodes Only.
         /// </summary>
         public static string RegularEpisodesOnly {
@@ -3108,6 +5142,24 @@ namespace JMMClient.Properties {
         public static string Rehash {
             get {
                 return ResourceManager.GetString("Rehash", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Bookmark this anime to download later.
+        /// </summary>
+        public static string Related_Bookmark {
+            get {
+                return ResourceManager.GetString("Related_Bookmark", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Search for downloads for this series.
+        /// </summary>
+        public static string Related_Search {
+            get {
+                return ResourceManager.GetString("Related_Search", resourceCulture);
             }
         }
         
@@ -3144,6 +5196,132 @@ namespace JMMClient.Properties {
         public static string RemoveMissingFiles {
             get {
                 return ResourceManager.GetString("RemoveMissingFiles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add.
+        /// </summary>
+        public static string Rename_Add {
+            get {
+                return ResourceManager.GetString("Rename_Add", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add Files.
+        /// </summary>
+        public static string Rename_AddFiles {
+            get {
+                return ResourceManager.GetString("Rename_AddFiles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Clear.
+        /// </summary>
+        public static string Rename_Clear {
+            get {
+                return ResourceManager.GetString("Rename_Clear", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Delete.
+        /// </summary>
+        public static string Rename_Delete {
+            get {
+                return ResourceManager.GetString("Rename_Delete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Filter:.
+        /// </summary>
+        public static string Rename_Filter {
+            get {
+                return ResourceManager.GetString("Rename_Filter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Run this script when importing files into collection.
+        /// </summary>
+        public static string Rename_ImportRun {
+            get {
+                return ResourceManager.GetString("Rename_ImportRun", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to New.
+        /// </summary>
+        public static string Rename_New {
+            get {
+                return ResourceManager.GetString("Rename_New", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Preview.
+        /// </summary>
+        public static string Rename_Preview {
+            get {
+                return ResourceManager.GetString("Rename_Preview", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename Now.
+        /// </summary>
+        public static string Rename_Rename {
+            get {
+                return ResourceManager.GetString("Rename_Rename", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Save.
+        /// </summary>
+        public static string Rename_Save {
+            get {
+                return ResourceManager.GetString("Rename_Save", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Script.
+        /// </summary>
+        public static string Rename_Script {
+            get {
+                return ResourceManager.GetString("Rename_Script", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Help with scripting.
+        /// </summary>
+        public static string Rename_ScriptingHelp {
+            get {
+                return ResourceManager.GetString("Rename_ScriptingHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tag.
+        /// </summary>
+        public static string Rename_Tag {
+            get {
+                return ResourceManager.GetString("Rename_Tag", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Test.
+        /// </summary>
+        public static string Rename_Test {
+            get {
+                return ResourceManager.GetString("Rename_Test", resourceCulture);
             }
         }
         
@@ -3229,11 +5407,173 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to AniDB Start:.
+        /// </summary>
+        public static string Search_AniDBStart {
+            get {
+                return ResourceManager.GetString("Search_AniDBStart", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Admin Approved.
+        /// </summary>
+        public static string Search_Approved {
+            get {
+                return ResourceManager.GetString("Search_Approved", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Episodes:.
+        /// </summary>
+        public static string Search_Episodes {
+            get {
+                return ResourceManager.GetString("Search_Episodes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ID.
+        /// </summary>
+        public static string Search_ID {
+            get {
+                return ResourceManager.GetString("Search_ID", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to MAL: .
+        /// </summary>
+        public static string Search_MAL {
+            get {
+                return ResourceManager.GetString("Search_MAL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Starting At.
+        /// </summary>
+        public static string Search_StartingAt {
+            get {
+                return ResourceManager.GetString("Search_StartingAt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Title.
+        /// </summary>
+        public static string Search_Title {
+            get {
+                return ResourceManager.GetString("Search_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Title Only.
+        /// </summary>
+        public static string Search_TitleOnly {
+            get {
+                return ResourceManager.GetString("Search_TitleOnly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Trakt: .
+        /// </summary>
+        public static string Search_Trakt {
+            get {
+                return ResourceManager.GetString("Search_Trakt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to TvDB: .
+        /// </summary>
+        public static string Search_TvDB {
+            get {
+                return ResourceManager.GetString("Search_TvDB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Season #.
         /// </summary>
         public static string SeasonNumber {
             get {
                 return ResourceManager.GetString("SeasonNumber", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select the default language.
+        /// </summary>
+        public static string Select_DefaultLanguage {
+            get {
+                return ResourceManager.GetString("Select_DefaultLanguage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Episode Type:.
+        /// </summary>
+        public static string Select_EpisodeType {
+            get {
+                return ResourceManager.GetString("Select_EpisodeType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to MyAnimeList.
+        /// </summary>
+        public static string Select_MyAnimeList {
+            get {
+                return ResourceManager.GetString("Select_MyAnimeList", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Season.
+        /// </summary>
+        public static string Select_Season {
+            get {
+                return ResourceManager.GetString("Select_Season", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Starting Episode #.
+        /// </summary>
+        public static string Select_StartingEpisode {
+            get {
+                return ResourceManager.GetString("Select_StartingEpisode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Trakt TV.
+        /// </summary>
+        public static string Select_TraktTV {
+            get {
+                return ResourceManager.GetString("Select_TraktTV", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select TvDB Details.
+        /// </summary>
+        public static string Select_TvDBDetails {
+            get {
+                return ResourceManager.GetString("Select_TvDBDetails", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select an override name.
+        /// </summary>
+        public static string SelectAniDBTitle_SelectName {
+            get {
+                return ResourceManager.GetString("SelectAniDBTitle_SelectName", resourceCulture);
             }
         }
         
@@ -3256,11 +5596,38 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Selected.
+        /// </summary>
+        public static string Selected {
+            get {
+                return ResourceManager.GetString("Selected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The specified file or folder doesn&apos;t exists : .
+        /// </summary>
+        public static string Selected_DoesNotExist {
+            get {
+                return ResourceManager.GetString("Selected_DoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Select a Group.
         /// </summary>
         public static string SelectGroup {
             get {
                 return ResourceManager.GetString("SelectGroup", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select a .
+        /// </summary>
+        public static string SelectGroupSeries_Select {
+            get {
+                return ResourceManager.GetString("SelectGroupSeries_Select", resourceCulture);
             }
         }
         
@@ -3292,6 +5659,78 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add.
+        /// </summary>
+        public static string Series_Add {
+            get {
+                return ResourceManager.GetString("Series_Add", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Custom Tags.
+        /// </summary>
+        public static string Series_CustomTags {
+            get {
+                return ResourceManager.GetString("Series_CustomTags", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Files.
+        /// </summary>
+        public static string Series_Files {
+            get {
+                return ResourceManager.GetString("Series_Files", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Folder.
+        /// </summary>
+        public static string Series_Folder {
+            get {
+                return ResourceManager.GetString("Series_Folder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Manage Custom Tags.
+        /// </summary>
+        public static string Series_ManageCustom {
+            get {
+                return ResourceManager.GetString("Series_ManageCustom", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to More Information.
+        /// </summary>
+        public static string Series_MoreInfo {
+            get {
+                return ResourceManager.GetString("Series_MoreInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Overview.
+        /// </summary>
+        public static string Series_Overview {
+            get {
+                return ResourceManager.GetString("Series_Overview", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tag.
+        /// </summary>
+        public static string Series_Tag {
+            get {
+                return ResourceManager.GetString("Series_Tag", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Series Name Source.
         /// </summary>
         public static string SeriesNameSourceStyle {
@@ -3306,6 +5745,240 @@ namespace JMMClient.Properties {
         public static string SeriesOverviewSourceStyle {
             get {
                 return ResourceManager.GetString("SeriesOverviewSourceStyle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Aired.
+        /// </summary>
+        public static string SeriesSimple_Aired {
+            get {
+                return ResourceManager.GetString("SeriesSimple_Aired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You already have this anime in your collection.
+        /// </summary>
+        public static string SeriesSimple_AlreadyHave {
+            get {
+                return ResourceManager.GetString("SeriesSimple_AlreadyHave", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You may also like.
+        /// </summary>
+        public static string SeriesSimple_AlsoLike {
+            get {
+                return ResourceManager.GetString("SeriesSimple_AlsoLike", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Characters.
+        /// </summary>
+        public static string SeriesSimple_Characters {
+            get {
+                return ResourceManager.GetString("SeriesSimple_Characters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Comments.
+        /// </summary>
+        public static string SeriesSimple_Comments {
+            get {
+                return ResourceManager.GetString("SeriesSimple_Comments", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Comment on Trakt.
+        /// </summary>
+        public static string SeriesSimple_CommentTrakt {
+            get {
+                return ResourceManager.GetString("SeriesSimple_CommentTrakt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Details:.
+        /// </summary>
+        public static string SeriesSimple_Details {
+            get {
+                return ResourceManager.GetString("SeriesSimple_Details", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Episodes.
+        /// </summary>
+        public static string SeriesSimple_Episodes {
+            get {
+                return ResourceManager.GetString("SeriesSimple_Episodes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to From:.
+        /// </summary>
+        public static string SeriesSimple_From {
+            get {
+                return ResourceManager.GetString("SeriesSimple_From", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to From AniDB.
+        /// </summary>
+        public static string SeriesSimple_FromAniDB {
+            get {
+                return ResourceManager.GetString("SeriesSimple_FromAniDB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to From Trakt.
+        /// </summary>
+        public static string SeriesSimple_FromTrakt {
+            get {
+                return ResourceManager.GetString("SeriesSimple_FromTrakt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Loading....
+        /// </summary>
+        public static string SeriesSimple_Loading {
+            get {
+                return ResourceManager.GetString("SeriesSimple_Loading", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to My Vote.
+        /// </summary>
+        public static string SeriesSimple_MyVote {
+            get {
+                return ResourceManager.GetString("SeriesSimple_MyVote", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to What People Are Saying.
+        /// </summary>
+        public static string SeriesSimple_PeopleSaying {
+            get {
+                return ResourceManager.GetString("SeriesSimple_PeopleSaying", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Play.
+        /// </summary>
+        public static string SeriesSimple_Play {
+            get {
+                return ResourceManager.GetString("SeriesSimple_Play", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Play Next Episode.
+        /// </summary>
+        public static string SeriesSimple_PlayNext {
+            get {
+                return ResourceManager.GetString("SeriesSimple_PlayNext", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Play All UnWatched (.
+        /// </summary>
+        public static string SeriesSimple_PlayUnWatched {
+            get {
+                return ResourceManager.GetString("SeriesSimple_PlayUnWatched", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Spoiler.
+        /// </summary>
+        public static string SeriesSimple_Spoiler {
+            get {
+                return ResourceManager.GetString("SeriesSimple_Spoiler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Go this episode on Trakt.TV.
+        /// </summary>
+        public static string SeriesSimple_TraktLink {
+            get {
+                return ResourceManager.GetString("SeriesSimple_TraktLink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to View.
+        /// </summary>
+        public static string SeriesSimple_View {
+            get {
+                return ResourceManager.GetString("SeriesSimple_View", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Vote Down.
+        /// </summary>
+        public static string SeriesSimple_VoteDown {
+            get {
+                return ResourceManager.GetString("SeriesSimple_VoteDown", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Vote Up.
+        /// </summary>
+        public static string SeriesSimple_Voteup {
+            get {
+                return ResourceManager.GetString("SeriesSimple_Voteup", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Watched:.
+        /// </summary>
+        public static string SeriesSimple_Watched {
+            get {
+                return ResourceManager.GetString("SeriesSimple_Watched", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Have Your Say....
+        /// </summary>
+        public static string SeriesSimple_YourSay {
+            get {
+                return ResourceManager.GetString("SeriesSimple_YourSay", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Delete this series from the database.
+        /// </summary>
+        public static string SeriesWithoutFiles_Delete {
+            get {
+                return ResourceManager.GetString("SeriesWithoutFiles_Delete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This utility will show you all the series which do not have any files. Deleting the series will also delete the group if no other series in that group have files..
+        /// </summary>
+        public static string SeriesWithoutFiles_Note {
+            get {
+                return ResourceManager.GetString("SeriesWithoutFiles_Note", resourceCulture);
             }
         }
         
@@ -3373,11 +6046,137 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Automatically Update Files With Missing Info.
+        /// </summary>
+        public static string Settings_AutoUpdateInfo {
+            get {
+                return ResourceManager.GetString("Settings_AutoUpdateInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Delete Action.
+        /// </summary>
+        public static string Settings_DeleteAction {
+            get {
+                return ResourceManager.GetString("Settings_DeleteAction", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to File Port.
+        /// </summary>
+        public static string Settings_FilePort {
+            get {
+                return ResourceManager.GetString("Settings_FilePort", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hide Episode Download Button When You Already Have Files.
+        /// </summary>
+        public static string Settings_HideDownloadButton {
+            get {
+                return ResourceManager.GetString("Settings_HideDownloadButton", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Image Path.
+        /// </summary>
+        public static string Settings_ImagePath {
+            get {
+                return ResourceManager.GetString("Settings_ImagePath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Recreate All Groups.
+        /// </summary>
+        public static string Settings_RecreateGroups {
+            get {
+                return ResourceManager.GetString("Settings_RecreateGroups", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Scan Drop Folders On Start.
+        /// </summary>
+        public static string Settings_ScanOnStart {
+            get {
+                return ResourceManager.GetString("Settings_ScanOnStart", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select Folder.
+        /// </summary>
+        public static string Settings_SelectFolder {
+            get {
+                return ResourceManager.GetString("Settings_SelectFolder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Similar Anime.
         /// </summary>
         public static string SimilarAnime {
             get {
                 return ResourceManager.GetString("SimilarAnime", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error trying to sort list of .
+        /// </summary>
+        public static string Sort_Error {
+            get {
+                return ResourceManager.GetString("Sort_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Exception in MultiSort while sorting a list of .
+        /// </summary>
+        public static string Sort_Exception {
+            get {
+                return ResourceManager.GetString("Sort_Exception", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to field .
+        /// </summary>
+        public static string Sort_Field {
+            get {
+                return ResourceManager.GetString("Sort_Field", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to MultiSort parameter rgSortBy was passed an empty field name in rgSortBy[.
+        /// </summary>
+        public static string Sort_PassedEmpty {
+            get {
+                return ResourceManager.GetString("Sort_PassedEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to property .
+        /// </summary>
+        public static string Sort_Property {
+            get {
+                return ResourceManager.GetString("Sort_Property", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  using .
+        /// </summary>
+        public static string Sort_Using {
+            get {
+                return ResourceManager.GetString("Sort_Using", resourceCulture);
             }
         }
         
@@ -3400,11 +6199,29 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Start.
+        /// </summary>
+        public static string Start {
+            get {
+                return ResourceManager.GetString("Start", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Starting Episode Number.
         /// </summary>
         public static string StartingEpisodeNumber {
             get {
                 return ResourceManager.GetString("StartingEpisodeNumber", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Stop.
+        /// </summary>
+        public static string Stop {
+            get {
+                return ResourceManager.GetString("Stop", resourceCulture);
             }
         }
         
@@ -3499,6 +6316,60 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to AniDB AV Dump.
+        /// </summary>
+        public static string Tab_AniDBAVDump {
+            get {
+                return ResourceManager.GetString("Tab_AniDBAVDump", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Bookmarks.
+        /// </summary>
+        public static string Tab_Bookmarks {
+            get {
+                return ResourceManager.GetString("Tab_Bookmarks", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Browse Torrents.
+        /// </summary>
+        public static string Tab_BrowseTorrents {
+            get {
+                return ResourceManager.GetString("Tab_BrowseTorrents", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Comments From Users.
+        /// </summary>
+        public static string Tab_Comments {
+            get {
+                return ResourceManager.GetString("Tab_Comments", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Community.
+        /// </summary>
+        public static string Tab_Community {
+            get {
+                return ResourceManager.GetString("Tab_Community", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Community Data.
+        /// </summary>
+        public static string Tab_CommunityData {
+            get {
+                return ResourceManager.GetString("Tab_CommunityData", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Config.
         /// </summary>
         public static string TAB_Config {
@@ -3513,6 +6384,15 @@ namespace JMMClient.Properties {
         public static string TAB_Dashboard {
             get {
                 return ResourceManager.GetString("TAB_Dashboard", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Downloads.
+        /// </summary>
+        public static string Tab_Downloads {
+            get {
+                return ResourceManager.GetString("Tab_Downloads", resourceCulture);
             }
         }
         
@@ -3540,6 +6420,33 @@ namespace JMMClient.Properties {
         public static string TAB_FileManager {
             get {
                 return ResourceManager.GetString("TAB_FileManager", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to File Renaming.
+        /// </summary>
+        public static string Tab_FileRename {
+            get {
+                return ResourceManager.GetString("Tab_FileRename", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Files.
+        /// </summary>
+        public static string Tab_Files {
+            get {
+                return ResourceManager.GetString("Tab_Files", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to File Search.
+        /// </summary>
+        public static string Tab_FileSearch {
+            get {
+                return ResourceManager.GetString("Tab_FileSearch", resourceCulture);
             }
         }
         
@@ -3607,11 +6514,38 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to My Votes.
+        /// </summary>
+        public static string Tab_MyVotes {
+            get {
+                return ResourceManager.GetString("Tab_MyVotes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Pinned.
         /// </summary>
         public static string TAB_Pinned {
             get {
                 return ResourceManager.GetString("TAB_Pinned", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Playlists.
+        /// </summary>
+        public static string Tab_Playlists {
+            get {
+                return ResourceManager.GetString("Tab_Playlists", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Recommendations.
+        /// </summary>
+        public static string Tab_Recommendations {
+            get {
+                return ResourceManager.GetString("Tab_Recommendations", resourceCulture);
             }
         }
         
@@ -3625,11 +6559,38 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Search.
+        /// </summary>
+        public static string Tab_Search {
+            get {
+                return ResourceManager.GetString("Tab_Search", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Search Torrents.
+        /// </summary>
+        public static string Tab_SearchTorrents {
+            get {
+                return ResourceManager.GetString("Tab_SearchTorrents", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Collection.
         /// </summary>
         public static string TAB_SeriesEpisodes {
             get {
                 return ResourceManager.GetString("TAB_SeriesEpisodes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Series Info.
+        /// </summary>
+        public static string Tab_SeriesInfo {
+            get {
+                return ResourceManager.GetString("Tab_SeriesInfo", resourceCulture);
             }
         }
         
@@ -3648,6 +6609,15 @@ namespace JMMClient.Properties {
         public static string TAB_Server {
             get {
                 return ResourceManager.GetString("TAB_Server", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Settings.
+        /// </summary>
+        public static string Tab_Settings {
+            get {
+                return ResourceManager.GetString("Tab_Settings", resourceCulture);
             }
         }
         
@@ -3711,6 +6681,15 @@ namespace JMMClient.Properties {
         public static string TAB_SettingsOnlineDB {
             get {
                 return ResourceManager.GetString("TAB_SettingsOnlineDB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to My Anime List.
+        /// </summary>
+        public static string TAB_SettingsOnlineDB_MAL {
+            get {
+                return ResourceManager.GetString("TAB_SettingsOnlineDB_MAL", resourceCulture);
             }
         }
         
@@ -3787,11 +6766,29 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Update AniDB Data.
+        /// </summary>
+        public static string Tab_UpdateAniDB {
+            get {
+                return ResourceManager.GetString("Tab_UpdateAniDB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Utilities.
         /// </summary>
         public static string TAB_Utilities {
             get {
                 return ResourceManager.GetString("TAB_Utilities", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to uTorrent.
+        /// </summary>
+        public static string Tab_uTorrent {
+            get {
+                return ResourceManager.GetString("Tab_uTorrent", resourceCulture);
             }
         }
         
@@ -4026,6 +7023,141 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Auto linking from this anime to a MAL series is currently disabled.
+        /// </summary>
+        public static string Tooltip_AutoLinkDisabledMAL {
+            get {
+                return ResourceManager.GetString("Tooltip_AutoLinkDisabledMAL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto Linking Disabled.
+        /// </summary>
+        public static string Tooltip_AutoLinkDisabledTitle {
+            get {
+                return ResourceManager.GetString("Tooltip_AutoLinkDisabledTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto linking from this anime to a MovieDB series is currently disabled.
+        /// </summary>
+        public static string Tooltip_AutoLinkDisabledTMDb {
+            get {
+                return ResourceManager.GetString("Tooltip_AutoLinkDisabledTMDb", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto linking from this anime to a Trakt series is currently disabled.
+        /// </summary>
+        public static string Tooltip_AutoLinkDisabledTrakt {
+            get {
+                return ResourceManager.GetString("Tooltip_AutoLinkDisabledTrakt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto linking from this anime to a TvDB series is currently disabled.
+        /// </summary>
+        public static string Tooltip_AutoLinkDisabledTvDB {
+            get {
+                return ResourceManager.GetString("Tooltip_AutoLinkDisabledTvDB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto linking from this anime to a MAL series is currently enabled. If JMM Server finds a close match or community recommendation it will automatically create a link.
+        /// </summary>
+        public static string Tooltip_AutoLinkEnabledMAL {
+            get {
+                return ResourceManager.GetString("Tooltip_AutoLinkEnabledMAL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto Linking Enabled.
+        /// </summary>
+        public static string Tooltip_AutoLinkEnabledTitle {
+            get {
+                return ResourceManager.GetString("Tooltip_AutoLinkEnabledTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto linking from this anime to a MovieDB series is currently enabled. If JMM Server finds a close match or community recommendation it will automatically create a link.
+        /// </summary>
+        public static string Tooltip_AutoLinkEnabledTMDb {
+            get {
+                return ResourceManager.GetString("Tooltip_AutoLinkEnabledTMDb", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto linking from this anime to a Trakt series is currently enabled. If JMM Server finds a close match or community recommendation it will automatically create a link.
+        /// </summary>
+        public static string Tooltip_AutoLinkEnabledTrakt {
+            get {
+                return ResourceManager.GetString("Tooltip_AutoLinkEnabledTrakt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto linking from this anime to a TvDB series is currently enabled. If JMM Server finds a close match or community recommendation it will automatically create a link.
+        /// </summary>
+        public static string Tooltip_AutoLinkEnabledTvDB {
+            get {
+                return ResourceManager.GetString("Tooltip_AutoLinkEnabledTvDB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Clear all queued general commands.
+        /// </summary>
+        public static string Tooltip_ClearGeneral {
+            get {
+                return ResourceManager.GetString("Tooltip_ClearGeneral", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Clear all queued hash commands.
+        /// </summary>
+        public static string Tooltip_ClearHash {
+            get {
+                return ResourceManager.GetString("Tooltip_ClearHash", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Clear all queued server image download commands.
+        /// </summary>
+        public static string Tooltip_ClearImages {
+            get {
+                return ResourceManager.GetString("Tooltip_ClearImages", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Go to the Community admin tab and edit the recommended links for this anime.
+        /// </summary>
+        public static string Tooltip_CommunityAdminInfo {
+            get {
+                return ResourceManager.GetString("Tooltip_CommunityAdminInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Community Admin.
+        /// </summary>
+        public static string Tooltip_CommunityAdminTitle {
+            get {
+                return ResourceManager.GetString("Tooltip_CommunityAdminTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Copy the ED2K Dump to the Clipboard.
         /// </summary>
         public static string Tooltip_CopyED2KClipboard {
@@ -4062,11 +7194,47 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Delete this Link.
+        /// </summary>
+        public static string Tooltip_DeleteInfo {
+            get {
+                return ResourceManager.GetString("Tooltip_DeleteInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Remove link between this file and the episode..
         /// </summary>
         public static string Tooltip_DeleteLink {
             get {
                 return ResourceManager.GetString("Tooltip_DeleteLink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Delete.
+        /// </summary>
+        public static string Tooltip_DeleteTitle {
+            get {
+                return ResourceManager.GetString("Tooltip_DeleteTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Edit the details of this Link.
+        /// </summary>
+        public static string Tooltip_EditInfo {
+            get {
+                return ResourceManager.GetString("Tooltip_EditInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Edit.
+        /// </summary>
+        public static string Tooltip_EditTitle {
+            get {
+                return ResourceManager.GetString("Tooltip_EditTitle", resourceCulture);
             }
         }
         
@@ -4368,6 +7536,24 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to If this is linked to the wrong series click here to let the developers know.
+        /// </summary>
+        public static string Tooltip_ReportLinkInfo {
+            get {
+                return ResourceManager.GetString("Tooltip_ReportLinkInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Report Linking Error.
+        /// </summary>
+        public static string Tooltip_ReportLinkTitle {
+            get {
+                return ResourceManager.GetString("Tooltip_ReportLinkTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Preferred source of information when displaying the series name for an anime.
         /// </summary>
         public static string Tooltip_SeriesNameSourceStyle {
@@ -4404,6 +7590,15 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Sync.
+        /// </summary>
+        public static string Tooltip_Sync {
+            get {
+                return ResourceManager.GetString("Tooltip_Sync", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Download watched states from MAL, and update your local collection and AniDB..
         /// </summary>
         public static string Tooltip_SyncMalDown {
@@ -4418,6 +7613,15 @@ namespace JMMClient.Properties {
         public static string Tooltip_SyncMalUp {
             get {
                 return ResourceManager.GetString("Tooltip_SyncMalUp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sync your collection and history data with Trakt.
+        /// </summary>
+        public static string Tooltip_SyncTrakt {
+            get {
+                return ResourceManager.GetString("Tooltip_SyncTrakt", resourceCulture);
             }
         }
         
@@ -4490,6 +7694,33 @@ namespace JMMClient.Properties {
         public static string Tooltip_UpdateMediaInfo {
             get {
                 return ResourceManager.GetString("Tooltip_UpdateMediaInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Update.
+        /// </summary>
+        public static string Tooltip_UpdateTitle {
+            get {
+                return ResourceManager.GetString("Tooltip_UpdateTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Download fresh data from Trakt and update the local database.
+        /// </summary>
+        public static string Tooltip_UpdateTrakt {
+            get {
+                return ResourceManager.GetString("Tooltip_UpdateTrakt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Download fresh data from The TvDB and update the local database.
+        /// </summary>
+        public static string Tooltip_UpdateTvDB {
+            get {
+                return ResourceManager.GetString("Tooltip_UpdateTvDB", resourceCulture);
             }
         }
         
@@ -4593,11 +7824,38 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This is JMMs attempt to guess which series you are looking at so you can compare to your local collection. If you do not have the series in your collection it will be incorrect..
+        /// </summary>
+        public static string Tooltip_WrongSeries {
+            get {
+                return ResourceManager.GetString("Tooltip_WrongSeries", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There are no files available for this episode.
         /// </summary>
         public static string Tooltip_ZeroFiles {
             get {
                 return ResourceManager.GetString("Tooltip_ZeroFiles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Torrent.
+        /// </summary>
+        public static string Torrent {
+            get {
+                return ResourceManager.GetString("Torrent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Torrents.
+        /// </summary>
+        public static string Torrents {
+            get {
+                return ResourceManager.GetString("Torrents", resourceCulture);
             }
         }
         
@@ -4611,11 +7869,92 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Trakt.
+        /// </summary>
+        public static string Trakt {
+            get {
+                return ResourceManager.GetString("Trakt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Authorize JMM.
+        /// </summary>
+        public static string Trakt_Authorize {
+            get {
+                return ResourceManager.GetString("Trakt_Authorize", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto Download Episode Images.
+        /// </summary>
+        public static string Trakt_AutoEpisodeImages {
+            get {
+                return ResourceManager.GetString("Trakt_AutoEpisodeImages", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto Download Fanart.
+        /// </summary>
+        public static string Trakt_AutoFanart {
+            get {
+                return ResourceManager.GetString("Trakt_AutoFanart", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto Download Posters.
+        /// </summary>
+        public static string Trakt_AutoPosters {
+            get {
+                return ResourceManager.GetString("Trakt_AutoPosters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Current token is valid until:.
+        /// </summary>
+        public static string Trakt_CurrentToken {
+            get {
+                return ResourceManager.GetString("Trakt_CurrentToken", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable Trakt.
+        /// </summary>
+        public static string Trakt_Enable {
+            get {
+                return ResourceManager.GetString("Trakt_Enable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Get Pin.
+        /// </summary>
+        public static string Trakt_GetPIN {
+            get {
+                return ResourceManager.GetString("Trakt_GetPIN", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Password.
         /// </summary>
         public static string Trakt_Password {
             get {
                 return ResourceManager.GetString("Trakt_Password", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Trakt PIN.
+        /// </summary>
+        public static string Trakt_PIN {
+            get {
+                return ResourceManager.GetString("Trakt_PIN", resourceCulture);
             }
         }
         
@@ -4656,6 +7995,51 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Comments.
+        /// </summary>
+        public static string TraktShouts_Comments {
+            get {
+                return ResourceManager.GetString("TraktShouts_Comments", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to From AniDB.
+        /// </summary>
+        public static string TraktShouts_FromAniDB {
+            get {
+                return ResourceManager.GetString("TraktShouts_FromAniDB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Loading....
+        /// </summary>
+        public static string TraktShouts_Loading {
+            get {
+                return ResourceManager.GetString("TraktShouts_Loading", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Spoiler.
+        /// </summary>
+        public static string TraktShouts_Spoiler {
+            get {
+                return ResourceManager.GetString("TraktShouts_Spoiler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to View.
+        /// </summary>
+        public static string TraktShouts_View {
+            get {
+                return ResourceManager.GetString("TraktShouts_View", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Go To Trakt.
         /// </summary>
         public static string TraktShow {
@@ -4670,6 +8054,15 @@ namespace JMMClient.Properties {
         public static string TraktSyncFrequency {
             get {
                 return ResourceManager.GetString("TraktSyncFrequency", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Try Again!.
+        /// </summary>
+        public static string TryAgain {
+            get {
+                return ResourceManager.GetString("TryAgain", resourceCulture);
             }
         }
         
@@ -4701,6 +8094,15 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Maximum Posters.
+        /// </summary>
+        public static string TvDB_PostersMax {
+            get {
+                return ResourceManager.GetString("TvDB_PostersMax", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Update Info every 12 hours.
         /// </summary>
         public static string TvDB_Schedule_Updates {
@@ -4719,6 +8121,15 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Maximum Wide Banners.
+        /// </summary>
+        public static string TvDB_WideBannerMax {
+            get {
+                return ResourceManager.GetString("TvDB_WideBannerMax", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Search on the TvDB or enter TvDB Series ID.
         /// </summary>
         public static string TvDBSearchPrompt {
@@ -4733,6 +8144,87 @@ namespace JMMClient.Properties {
         public static string TvDBShow {
             get {
                 return ResourceManager.GetString("TvDBShow", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CRC32.
+        /// </summary>
+        public static string Unrecognized_CRC32 {
+            get {
+                return ResourceManager.GetString("Unrecognized_CRC32", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Force update information from AniDB.
+        /// </summary>
+        public static string Unrecognized_ForceAniDB {
+            get {
+                return ResourceManager.GetString("Unrecognized_ForceAniDB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hash.
+        /// </summary>
+        public static string Unrecognized_Hash {
+            get {
+                return ResourceManager.GetString("Unrecognized_Hash", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Logs.
+        /// </summary>
+        public static string Unrecognized_Logs {
+            get {
+                return ResourceManager.GetString("Unrecognized_Logs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to NA.
+        /// </summary>
+        public static string Unrecognized_NA {
+            get {
+                return ResourceManager.GetString("Unrecognized_NA", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Refresh Series List.
+        /// </summary>
+        public static string Unrecognized_RefreshSeries {
+            get {
+                return ResourceManager.GetString("Unrecognized_RefreshSeries", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Re-hash All.
+        /// </summary>
+        public static string Unrecognized_Rehash {
+            get {
+                return ResourceManager.GetString("Unrecognized_Rehash", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rescan.
+        /// </summary>
+        public static string Unrecognized_Rescan {
+            get {
+                return ResourceManager.GetString("Unrecognized_Rescan", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to to.
+        /// </summary>
+        public static string Unrecognized_To {
+            get {
+                return ResourceManager.GetString("Unrecognized_To", resourceCulture);
             }
         }
         
@@ -4760,6 +8252,132 @@ namespace JMMClient.Properties {
         public static string Update {
             get {
                 return ResourceManager.GetString("Update", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Available Version.
+        /// </summary>
+        public static string Update_AvailableVersion {
+            get {
+                return ResourceManager.GetString("Update_AvailableVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Changelog.
+        /// </summary>
+        public static string Update_Changelog {
+            get {
+                return ResourceManager.GetString("Update_Changelog", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to JMM Desktop Update Available!.
+        /// </summary>
+        public static string Update_Update {
+            get {
+                return ResourceManager.GetString("Update_Update", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Update Page.
+        /// </summary>
+        public static string Update_UpdatePage {
+            get {
+                return ResourceManager.GetString("Update_UpdatePage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your Version.
+        /// </summary>
+        public static string Update_YourVersion {
+            get {
+                return ResourceManager.GetString("Update_YourVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to How Many Commands Will Be Queued?.
+        /// </summary>
+        public static string UpdateAniDB_HowManyQueued {
+            get {
+                return ResourceManager.GetString("UpdateAniDB_HowManyQueued", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Data relating to files is downloaded from AniDB and then stored in your local database when you first import a file. In some cases this data may not be complete when you first download it. Or extra data may be downloaded but newer versions of JMM. This utility will allow you to get a fresh copy of that information from AniDB.
+        /// </summary>
+        public static string UpdateAniDB_Info1 {
+            get {
+                return ResourceManager.GetString("UpdateAniDB_Info1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Missing data usually relates to missing codec and resolution information. You may see Resolution: 0x0 next to these files.
+        /// </summary>
+        public static string UpdateAniDB_Info2 {
+            get {
+                return ResourceManager.GetString("UpdateAniDB_Info2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Internal Version 2 added the following information - File version (v2, v3 etc), Is Censored, Is Deprecated.
+        /// </summary>
+        public static string UpdateAniDB_Info3 {
+            get {
+                return ResourceManager.GetString("UpdateAniDB_Info3", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sending too many commands to AniDB, may cause a temporary ban. Use at your own risk.
+        /// </summary>
+        public static string UpdateAniDB_Info4 {
+            get {
+                return ResourceManager.GetString("UpdateAniDB_Info4", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Update Files with Missing Info.
+        /// </summary>
+        public static string UpdateAniDB_MissingInfo {
+            get {
+                return ResourceManager.GetString("UpdateAniDB_MissingInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Queue Commands.
+        /// </summary>
+        public static string UpdateAniDB_Queued {
+            get {
+                return ResourceManager.GetString("UpdateAniDB_Queued", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Update Local AniDB File Data.
+        /// </summary>
+        public static string UpdateAniDB_UpdateLocal {
+            get {
+                return ResourceManager.GetString("UpdateAniDB_UpdateLocal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Update files to Internal Version 2.
+        /// </summary>
+        public static string UpdateAniDB_Version {
+            get {
+                return ResourceManager.GetString("UpdateAniDB_Version", resourceCulture);
             }
         }
         
@@ -4863,6 +8481,15 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Change Password.
+        /// </summary>
+        public static string User_ChangePassword {
+            get {
+                return ResourceManager.GetString("User_ChangePassword", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Edit Server Settings.
         /// </summary>
         public static string User_EditSettings {
@@ -4877,6 +8504,15 @@ namespace JMMClient.Properties {
         public static string User_HideCategories {
             get {
                 return ResourceManager.GetString("User_HideCategories", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hide Tags.
+        /// </summary>
+        public static string User_HideTags {
+            get {
+                return ResourceManager.GetString("User_HideTags", resourceCulture);
             }
         }
         
@@ -4953,11 +8589,65 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Connecting....
+        /// </summary>
+        public static string uTorrent_Connecting {
+            get {
+                return ResourceManager.GetString("uTorrent_Connecting", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Not Connected.
+        /// </summary>
+        public static string uTorrent_NotConnected {
+            get {
+                return ResourceManager.GetString("uTorrent_NotConnected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Field name .
+        /// </summary>
+        public static string ValueCompare_FieldName {
+            get {
+                return ResourceManager.GetString("ValueCompare_FieldName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  not found while trying to compare objects of type .
+        /// </summary>
+        public static string ValueCompare_NotFound {
+            get {
+                return ResourceManager.GetString("ValueCompare_NotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Property name .
+        /// </summary>
+        public static string ValueCompare_PropertyName {
+            get {
+                return ResourceManager.GetString("ValueCompare_PropertyName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Bluray.
         /// </summary>
         public static string Video_Bluray {
             get {
                 return ResourceManager.GetString("Video_Bluray", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Complete.
+        /// </summary>
+        public static string Video_Complete {
+            get {
+                return ResourceManager.GetString("Video_Complete", resourceCulture);
             }
         }
         
@@ -4980,6 +8670,15 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to has changed to.
+        /// </summary>
+        public static string Video_HasChanged {
+            get {
+                return ResourceManager.GetString("Video_HasChanged", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to HD.
         /// </summary>
         public static string Video_HD {
@@ -4994,6 +8693,357 @@ namespace JMMClient.Properties {
         public static string Video_Hi10P {
             get {
                 return ResourceManager.GetString("Video_Hi10P", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Video position for.
+        /// </summary>
+        public static string Video_Position {
+            get {
+                return ResourceManager.GetString("Video_Position", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Updating to watched by media player: .
+        /// </summary>
+        public static string Video_Updating {
+            get {
+                return ResourceManager.GetString("Video_Updating", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to parse URI in VLC ini file.
+        /// </summary>
+        public static string Video_VLCError1 {
+            get {
+                return ResourceManager.GetString("Video_VLCError1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The count of Recent Files and Timestamps in the VLC ini file differ.
+        /// </summary>
+        public static string Video_VLCError2 {
+            get {
+                return ResourceManager.GetString("Video_VLCError2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Automatic File Selection.
+        /// </summary>
+        public static string VideoPlayer_AutoFile {
+            get {
+                return ResourceManager.GetString("VideoPlayer_AutoFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable auto file selection on single episodes.
+        /// </summary>
+        public static string VideoPlayer_AutoFileEnable {
+            get {
+                return ResourceManager.GetString("VideoPlayer_AutoFileEnable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Automatic File Selection - First episode in series.
+        /// </summary>
+        public static string VideoPlayer_AutoFileFirstEpisode {
+            get {
+                return ResourceManager.GetString("VideoPlayer_AutoFileFirstEpisode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Automatic File Selection - Subsequent episodes in series.
+        /// </summary>
+        public static string VideoPlayer_AutoFileNextEpisode {
+            get {
+                return ResourceManager.GetString("VideoPlayer_AutoFileNextEpisode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Automatic File Selection Preferences - this refers to when you have more than file for an episode.
+        /// </summary>
+        public static string VideoPlayer_AutoFileNote1 {
+            get {
+                return ResourceManager.GetString("VideoPlayer_AutoFileNote1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to For a playlist it needs to choose one file, which will be based on you preferences below..
+        /// </summary>
+        public static string VideoPlayer_AutoFileNote2 {
+            get {
+                return ResourceManager.GetString("VideoPlayer_AutoFileNote2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to For a single episode you can enable auto file selection or have JMM prompt you to select a file whenever you have more than one.
+        /// </summary>
+        public static string VideoPlayer_AutoFileNote3 {
+            get {
+                return ResourceManager.GetString("VideoPlayer_AutoFileNote3", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to If you select &apos;Release Group From Previously Played Episode&apos; in the above setting you also need to do the following.
+        /// </summary>
+        public static string VideoPlayer_AutoFileNote4 {
+            get {
+                return ResourceManager.GetString("VideoPlayer_AutoFileNote4", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Uncheck &apos;Set file as watched if episode is watched&apos; Under Settings - Essential - Import Settings.
+        /// </summary>
+        public static string VideoPlayer_AutoFileNote5 {
+            get {
+                return ResourceManager.GetString("VideoPlayer_AutoFileNote5", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Always Mark a File as watched and not an episode.
+        /// </summary>
+        public static string VideoPlayer_AutoFileNote6 {
+            get {
+                return ResourceManager.GetString("VideoPlayer_AutoFileNote6", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Automatically mark files as watched when the following percentage is watched.
+        /// </summary>
+        public static string VideoPlayer_AutoMark {
+            get {
+                return ResourceManager.GetString("VideoPlayer_AutoMark", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Media Player Classic.
+        /// </summary>
+        public static string VideoPlayer_MPC {
+            get {
+                return ResourceManager.GetString("VideoPlayer_MPC", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to MPC INI Folder.
+        /// </summary>
+        public static string VideoPlayer_MPCFolder {
+            get {
+                return ResourceManager.GetString("VideoPlayer_MPCFolder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Media Player Classic Integration.
+        /// </summary>
+        public static string VideoPlayer_MPCI {
+            get {
+                return ResourceManager.GetString("VideoPlayer_MPCI", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select MPC INI Folder.
+        /// </summary>
+        public static string VideoPlayer_MPCINI {
+            get {
+                return ResourceManager.GetString("VideoPlayer_MPCINI", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to For MPC Integration you must enable two options (1) Store settings to .ini file and (2) Keep history of recently watched files. See the following screenshot for more details. The location of MPC is usually something like C:\Program Files (x86)\Combined Community Codec Pack\MPC.
+        /// </summary>
+        public static string VideoPlayer_MPCNote {
+            get {
+                return ResourceManager.GetString("VideoPlayer_MPCNote", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to MPC Options.
+        /// </summary>
+        public static string VideoPlayer_MPCOptions {
+            get {
+                return ResourceManager.GetString("VideoPlayer_MPCOptions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Test MPC File.
+        /// </summary>
+        public static string VideoPlayer_MPCTest {
+            get {
+                return ResourceManager.GetString("VideoPlayer_MPCTest", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PotPlayer.
+        /// </summary>
+        public static string VideoPlayer_PotPlayer {
+            get {
+                return ResourceManager.GetString("VideoPlayer_PotPlayer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PotPlayer INI Folder.
+        /// </summary>
+        public static string VideoPlayer_PotPlayerFolder {
+            get {
+                return ResourceManager.GetString("VideoPlayer_PotPlayerFolder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select PotPlayer INI Folder.
+        /// </summary>
+        public static string VideoPlayer_PotPlayerINI {
+            get {
+                return ResourceManager.GetString("VideoPlayer_PotPlayerINI", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to For PotPlayer Integration you must enable the following options (1) Preferences &gt; General &gt; Store Settings to .ini file (2) Preferences &gt; Playback &gt; Play from latest point. See the following screenshot for more details. The location of the PlotPlayer .ini file is usually something like C:\Users\username\AppData\Roaming\PotPlayer64\PotPlayer64.ini.
+        /// </summary>
+        public static string VideoPlayer_PotPlayerNote {
+            get {
+                return ResourceManager.GetString("VideoPlayer_PotPlayerNote", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PotPlayer Options.
+        /// </summary>
+        public static string VideoPlayer_PotPlayerOptions {
+            get {
+                return ResourceManager.GetString("VideoPlayer_PotPlayerOptions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Test PotPlayer File.
+        /// </summary>
+        public static string VideoPlayer_PotPlayerTest {
+            get {
+                return ResourceManager.GetString("VideoPlayer_PotPlayerTest", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to VLC.
+        /// </summary>
+        public static string VideoPlayer_VLC {
+            get {
+                return ResourceManager.GetString("VideoPlayer_VLC", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to VLC INI Folder.
+        /// </summary>
+        public static string VideoPlayer_VLCFolder {
+            get {
+                return ResourceManager.GetString("VideoPlayer_VLCFolder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select VLC INI Folder.
+        /// </summary>
+        public static string VideoPlayer_VLCINI {
+            get {
+                return ResourceManager.GetString("VideoPlayer_VLCINI", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to VLC 2.2+ records recent files and timestamps by default (and disabling is an &apos;Advanced&apos; option). Older versions do not support &apos;Resume from last position&apos; functionality. The location of the VLC .ini file is usually something like C:\Users\username\AppData\Roaming\vlc\vlc-qt-interface.ini.
+        /// </summary>
+        public static string VideoPlayer_VLCNote {
+            get {
+                return ResourceManager.GetString("VideoPlayer_VLCNote", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to VLC Options.
+        /// </summary>
+        public static string VideoPlayer_VLCOptions {
+            get {
+                return ResourceManager.GetString("VideoPlayer_VLCOptions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Test VLC File.
+        /// </summary>
+        public static string VideoPlayer_VLCTest {
+            get {
+                return ResourceManager.GetString("VideoPlayer_VLCTest", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Comment Date.
+        /// </summary>
+        public static string ViewComments_CommentDate {
+            get {
+                return ResourceManager.GetString("ViewComments_CommentDate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Comments.
+        /// </summary>
+        public static string ViewComments_Comments {
+            get {
+                return ResourceManager.GetString("ViewComments_Comments", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to From Trakt.
+        /// </summary>
+        public static string ViewComments_FromTrakt {
+            get {
+                return ResourceManager.GetString("ViewComments_FromTrakt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Username.
+        /// </summary>
+        public static string ViewComments_Username {
+            get {
+                return ResourceManager.GetString("ViewComments_Username", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to View on Website.
+        /// </summary>
+        public static string ViewComments_Website {
+            get {
+                return ResourceManager.GetString("ViewComments_Website", resourceCulture);
             }
         }
         
@@ -5115,6 +9165,15 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Trakt Links.
+        /// </summary>
+        public static string WebCache_TraktLinks {
+            get {
+                return ResourceManager.GetString("WebCache_TraktLinks", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to TvDB Links.
         /// </summary>
         public static string WebCache_TvDBAssociations {
@@ -5129,6 +9188,15 @@ namespace JMMClient.Properties {
         public static string WebCache_UserInfo {
             get {
                 return ResourceManager.GetString("WebCache_UserInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to What Does This Mean?.
+        /// </summary>
+        public static string WhatDoesThisMean {
+            get {
+                return ResourceManager.GetString("WhatDoesThisMean", resourceCulture);
             }
         }
         

--- a/JMMClient/Properties/Resources.de.resx
+++ b/JMMClient/Properties/Resources.de.resx
@@ -126,4 +126,3054 @@
   <data name="ViewLabel" xml:space="preserve">
     <value>Aussicht</value>
   </data>
+  <data name="AirDate" xml:space="preserve">
+    <value>Luftdatum!</value>
+  </data>
+  <data name="AniDBRating" xml:space="preserve">
+    <value>AniDB Bewertung!</value>
+  </data>
+  <data name="AniDBVoteCount" xml:space="preserve">
+    <value>AniDB Stimme!</value>
+  </data>
+  <data name="Episodes" xml:space="preserve">
+    <value>Folgen</value>
+  </data>
+  <data name="EpisodeType" xml:space="preserve">
+    <value>Folge</value>
+  </data>
+  <data name="EpisodeType_Credits" xml:space="preserve">
+    <value>Leistungspunkte</value>
+  </data>
+  <data name="EpisodeType_Normal" xml:space="preserve">
+    <value>Folgen</value>
+  </data>
+  <data name="EpisodeType_Other" xml:space="preserve">
+    <value>Sonstiges</value>
+  </data>
+  <data name="EpisodeType_Parody" xml:space="preserve">
+    <value>Gina Parody</value>
+  </data>
+  <data name="EpisodeType_Specials" xml:space="preserve">
+    <value>Aktionsware:</value>
+  </data>
+  <data name="EpisodeType_Trailer" xml:space="preserve">
+    <value>Anhänger!</value>
+  </data>
+  <data name="Favorite" xml:space="preserve">
+    <value>Favoriten</value>
+  </data>
+  <data name="GroupFilter_All" xml:space="preserve">
+    <value>ALLE</value>
+  </data>
+  <data name="GroupFilter_Favorites" xml:space="preserve">
+    <value>Favoriten</value>
+  </data>
+  <data name="IsWatched" xml:space="preserve">
+    <value>Ist Gesehen!</value>
+  </data>
+  <data name="MyRating" xml:space="preserve">
+    <value>Meine Bewertung!</value>
+  </data>
+  <data name="RunTime" xml:space="preserve">
+    <value>Laufzeit</value>
+  </data>
+  <data name="SortName" xml:space="preserve">
+    <value>Namen sortieren!</value>
+  </data>
+  <data name="Series" xml:space="preserve">
+    <value>Serie</value>
+  </data>
+  <data name="TAB_Config" xml:space="preserve">
+    <value>KONFIGURATION</value>
+  </data>
+  <data name="TAB_Episodes" xml:space="preserve">
+    <value>Folgen</value>
+  </data>
+  <data name="TAB_FileManager" xml:space="preserve">
+    <value>Dateimanager.</value>
+  </data>
+  <data name="TAB_Images" xml:space="preserve">
+    <value>Bilder</value>
+  </data>
+  <data name="TAB_Relations" xml:space="preserve">
+    <value>Verwandte</value>
+  </data>
+  <data name="TAB_SeriesEpisodes" xml:space="preserve">
+    <value>zu vermeiden.</value>
+  </data>
+  <data name="TAB_Server" xml:space="preserve">
+    <value>Server</value>
+  </data>
+  <data name="TAB_TvDB" xml:space="preserve">
+    <value>Tvdb!</value>
+  </data>
+  <data name="Language" xml:space="preserve">
+    <value>﻿Sprache</value>
+  </data>
+  <data name="Delete" xml:space="preserve">
+    <value>Löschen</value>
+  </data>
+  <data name="RunImport" xml:space="preserve">
+    <value>Run Import!</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>SPEICHERN</value>
+  </data>
+  <data name="AnimeTitles" xml:space="preserve">
+    <value>Titel!</value>
+  </data>
+  <data name="AnimeTitlesMain" xml:space="preserve">
+    <value>Titel</value>
+  </data>
+  <data name="AnimeTitlesOfficial" xml:space="preserve">
+    <value>OFFIZIELL</value>
+  </data>
+  <data name="AnimeTitlesShort" xml:space="preserve">
+    <value>Kurz</value>
+  </data>
+  <data name="AnimeTitlesSynonym" xml:space="preserve">
+    <value>Synonym</value>
+  </data>
+  <data name="Categories" xml:space="preserve">
+    <value>Kategorien</value>
+  </data>
+  <data name="Tags" xml:space="preserve">
+    <value>Schlagworte (Mai Spoiler enthalten)!</value>
+  </data>
+  <data name="CategoryWeighting" xml:space="preserve">
+    <value>Gewichtung!</value>
+  </data>
+  <data name="TagApproval" xml:space="preserve">
+    <value>Zulassung!</value>
+  </data>
+  <data name="Episodes_AvAll" xml:space="preserve">
+    <value>Alle Folgen</value>
+  </data>
+  <data name="Episodes_AvMissing" xml:space="preserve">
+    <value>Keine Dateien Aavailable!</value>
+  </data>
+  <data name="Episodes_AvOnly" xml:space="preserve">
+    <value>Dateien Nur!</value>
+  </data>
+  <data name="Episodes_Watched_All" xml:space="preserve">
+    <value>ALLE</value>
+  </data>
+  <data name="Episodes_Watched_Unwatched" xml:space="preserve">
+    <value>Unbeobachtet!</value>
+  </data>
+  <data name="Episodes_Watched_Watched" xml:space="preserve">
+    <value>Gesehen!</value>
+  </data>
+  <data name="Play" xml:space="preserve">
+    <value>Spielen</value>
+  </data>
+  <data name="Tooltip_FileFound" xml:space="preserve">
+    <value>Diese Datei ist nicht möglich!</value>
+  </data>
+  <data name="Tooltip_FileNotFound" xml:space="preserve">
+    <value>Diese Datei existiert nicht!</value>
+  </data>
+  <data name="Tooltip_FutureDated" xml:space="preserve">
+    <value>Diese Episode ist noch nicht gelüftet!</value>
+  </data>
+  <data name="Tooltip_Unwatched" xml:space="preserve">
+    <value>Unbeobachtet - Klicken Sie so beobachtet zu markieren!</value>
+  </data>
+  <data name="Tooltip_Watched" xml:space="preserve">
+    <value>Gesehen - Klicken Sie so unbeobachtet zu markieren!</value>
+  </data>
+  <data name="Tooltip_ZeroFiles" xml:space="preserve">
+    <value>Es gibt keine Dateien zu dieser Episode zur Verfügung!</value>
+  </data>
+  <data name="Unwatched" xml:space="preserve">
+    <value>Unbeobachtet!</value>
+  </data>
+  <data name="Watched" xml:space="preserve">
+    <value>Gesehen!</value>
+  </data>
+  <data name="Rating" xml:space="preserve">
+    <value>Bewertung</value>
+  </data>
+  <data name="Votes" xml:space="preserve">
+    <value>Bewertungen</value>
+  </data>
+  <data name="AnimeType_Movie" xml:space="preserve">
+    <value>Film!</value>
+  </data>
+  <data name="AnimeType_Other" xml:space="preserve">
+    <value>Sonstiges</value>
+  </data>
+  <data name="AnimeType_OVA" xml:space="preserve">
+    <value>EIZELLEN!</value>
+  </data>
+  <data name="AnimeType_TVSeries" xml:space="preserve">
+    <value>Serie</value>
+  </data>
+  <data name="AnimeType_TVSpecial" xml:space="preserve">
+    <value>Spezial</value>
+  </data>
+  <data name="AnimeType_Web" xml:space="preserve">
+    <value>Website</value>
+  </data>
+  <data name="Ongoing" xml:space="preserve">
+    <value>Fortlaufend:</value>
+  </data>
+  <data name="To" xml:space="preserve">
+    <value>An</value>
+  </data>
+  <data name="LastWatched" xml:space="preserve">
+    <value>Zuletzt gesehen!</value>
+  </data>
+  <data name="Today" xml:space="preserve">
+    <value>Heute!</value>
+  </data>
+  <data name="Yesterday" xml:space="preserve">
+    <value>Gestern</value>
+  </data>
+  <data name="GroupsAvailableFrom" xml:space="preserve">
+    <value>parat haben:</value>
+  </data>
+  <data name="Missing" xml:space="preserve">
+    <value>Fehlt</value>
+  </data>
+  <data name="Tooltip_MissingEps" xml:space="preserve">
+    <value>Fehlende Episoden aus allen Freigabegruppen!</value>
+  </data>
+  <data name="Tooltip_MissingEpsGroups" xml:space="preserve">
+    <value>Fehlende Episoden von Release-Gruppen, die ich sammeln werde!</value>
+  </data>
+  <data name="Tooltip_QueueImages" xml:space="preserve">
+    <value>Warteschlange Bilder warten auf Download!</value>
+  </data>
+  <data name="Specials" xml:space="preserve">
+    <value>Aktionsware:</value>
+  </data>
+  <data name="GroupFilter_Missing" xml:space="preserve">
+    <value>Fehlende Episoden!</value>
+  </data>
+  <data name="RemoveMissingFiles" xml:space="preserve">
+    <value>Entfernen von Dateien fehlen!</value>
+  </data>
+  <data name="ServerActions" xml:space="preserve">
+    <value>Server Aktionen!</value>
+  </data>
+  <data name="NewGroup" xml:space="preserve">
+    <value>Gruppe</value>
+  </data>
+  <data name="AllFilters" xml:space="preserve">
+    <value>Filter</value>
+  </data>
+  <data name="Filter" xml:space="preserve">
+    <value>Filter!</value>
+  </data>
+  <data name="Group" xml:space="preserve">
+    <value>Gruppe</value>
+  </data>
+  <data name="AddSubGroup" xml:space="preserve">
+    <value>Neue Untergruppe!</value>
+  </data>
+  <data name="Edit" xml:space="preserve">
+    <value>Bearbeiten</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Abbrechen!</value>
+  </data>
+  <data name="SubGroup" xml:space="preserve">
+    <value>Untergruppe</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Einstellungen</value>
+  </data>
+  <data name="NewSeries" xml:space="preserve">
+    <value>Serie</value>
+  </data>
+  <data name="MoveSeries" xml:space="preserve">
+    <value>Serie</value>
+  </data>
+  <data name="MoveToGroup" xml:space="preserve">
+    <value>Bewegen der ausgewählten Gruppe!</value>
+  </data>
+  <data name="OK" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="QueueGeneral" xml:space="preserve">
+    <value>AniDB Warteschlange!</value>
+  </data>
+  <data name="QueueHasher" xml:space="preserve">
+    <value>Hasher Warteschlange!</value>
+  </data>
+  <data name="Tooltip_QueueGeneral" xml:space="preserve">
+    <value>AniDB Befehle in der Warteschlange!</value>
+  </data>
+  <data name="Tooltip_QueueHasher" xml:space="preserve">
+    <value>Dateien darauf warten, dass Hash!</value>
+  </data>
+  <data name="Pause" xml:space="preserve">
+    <value>Pause</value>
+  </data>
+  <data name="Resume" xml:space="preserve">
+    <value>Fortfahren</value>
+  </data>
+  <data name="Video_Bluray" xml:space="preserve">
+    <value>Blu-Ray!</value>
+  </data>
+  <data name="Video_DVD" xml:space="preserve">
+    <value>DVD</value>
+  </data>
+  <data name="Video_FullHD" xml:space="preserve">
+    <value>Full-HD</value>
+  </data>
+  <data name="Video_HD" xml:space="preserve">
+    <value>HD</value>
+  </data>
+  <data name="NewFolder" xml:space="preserve">
+    <value>Neuer Ordner</value>
+  </data>
+  <data name="DropDestination" xml:space="preserve">
+    <value>Ziel</value>
+  </data>
+  <data name="DropSource" xml:space="preserve">
+    <value>Source</value>
+  </data>
+  <data name="ImportFolderName" xml:space="preserve">
+    <value>Import Ordnername!</value>
+  </data>
+  <data name="ImportFolderPath" xml:space="preserve">
+    <value>Import Ordnerpfad!</value>
+  </data>
+  <data name="LocalMapping" xml:space="preserve">
+    <value>Lokale Mapping!</value>
+  </data>
+  <data name="LocalPath" xml:space="preserve">
+    <value>Regional</value>
+  </data>
+  <data name="ServerDetails" xml:space="preserve">
+    <value>Server Details</value>
+  </data>
+  <data name="MSG_ERR_DropSourceDestCheck" xml:space="preserve">
+    <value>Ein Import-Ordner können nicht gleichzeitig die Fall Quelle und der Tropfen Ziel sein!</value>
+  </data>
+  <data name="MSG_ERR_ImportFolderLocationCheck" xml:space="preserve">
+    <value>Der Import Ordner kann nicht leer sein. Geben Sie einen gültigen Pfad auf OMM Server!</value>
+  </data>
+  <data name="TAB_UnrecognisedFiles" xml:space="preserve">
+    <value>Unerkannt!</value>
+  </data>
+  <data name="Confirm" xml:space="preserve">
+    <value>Bestätigen</value>
+  </data>
+  <data name="NothingSelected" xml:space="preserve">
+    <value>Nichts ausgewählt!</value>
+  </data>
+  <data name="SelectSeriesEp" xml:space="preserve">
+    <value>Wählen Sie eine Serie und Folge!</value>
+  </data>
+  <data name="AssociateFile" xml:space="preserve">
+    <value>Verknüpfen Sie eine Datei mit einer Folge!</value>
+  </data>
+  <data name="Ignore" xml:space="preserve">
+    <value>Ignorieren</value>
+  </data>
+  <data name="OpenFolder" xml:space="preserve">
+    <value>Ordner öffnen!</value>
+  </data>
+  <data name="MSG_ERR_FileNotFound" xml:space="preserve">
+    <value>Die Datei konnte nicht gefunden werden.</value>
+  </data>
+  <data name="FilesSelected" xml:space="preserve">
+    <value>Dateien ausgewählt!</value>
+  </data>
+  <data name="StartingEpisodeNumber" xml:space="preserve">
+    <value>Ab Folge Nummer!</value>
+  </data>
+  <data name="Existing" xml:space="preserve">
+    <value>bestehend</value>
+  </data>
+  <data name="SelectGroup" xml:space="preserve">
+    <value>Wählen Sie eine Gruppe!</value>
+  </data>
+  <data name="SelectAnime" xml:space="preserve">
+    <value>Wählen Anime aus AniDB!</value>
+  </data>
+  <data name="New" xml:space="preserve">
+    <value>Neu!</value>
+  </data>
+  <data name="GroupName" xml:space="preserve">
+    <value>Gruppenname</value>
+  </data>
+  <data name="AniDBID" xml:space="preserve">
+    <value>AniDB ID!</value>
+  </data>
+  <data name="MSG_ERR_AnimeIDRequired" xml:space="preserve">
+    <value>Bitte geben Sie eine gültige AniDB Anime-ID!</value>
+  </data>
+  <data name="MSG_ERR_AnimeSelectionRequired" xml:space="preserve">
+    <value>Bitte wählen Sie eine vorhandene Anime!</value>
+  </data>
+  <data name="MSG_ERR_GroupNameRequired" xml:space="preserve">
+    <value>Bitte geben Sie einen Gruppennamen!</value>
+  </data>
+  <data name="MSG_ERR_GroupSelectionRequired" xml:space="preserve">
+    <value>Bitte wählen Sie eine vorhandene Gruppe!</value>
+  </data>
+  <data name="MSG_ERR_InvalidEpGetAnime" xml:space="preserve">
+    <value>Die Folge Zahlenbereich von Ihnen eingegebenen gilt nicht, tun Sie die Daten aus AniDB auffrischen wollen ?!</value>
+  </data>
+  <data name="MSG_ERR_InvalidEp" xml:space="preserve">
+    <value>Die Folge Bereich Sie eingegeben haben, ist nicht gültig.!</value>
+  </data>
+  <data name="DeleteLink" xml:space="preserve">
+    <value>Link löschen</value>
+  </data>
+  <data name="Tooltip_DeleteLink" xml:space="preserve">
+    <value>Entfernen Verbindung zwischen dieser Datei und die Folge.!</value>
+  </data>
+  <data name="TAB_IgnoredFiles" xml:space="preserve">
+    <value>Ignoriert!</value>
+  </data>
+  <data name="Restore" xml:space="preserve">
+    <value>Wiederherstellen</value>
+  </data>
+  <data name="TAB_ManuallyLinked" xml:space="preserve">
+    <value>Manuelles Linked!</value>
+  </data>
+  <data name="AniDBLogin" xml:space="preserve">
+    <value>AniDB Anmeldung!</value>
+  </data>
+  <data name="Client" xml:space="preserve">
+    <value>Kunde</value>
+  </data>
+  <data name="ImportFolders" xml:space="preserve">
+    <value>Import-Ordner!</value>
+  </data>
+  <data name="JMMServer" xml:space="preserve">
+    <value>Server</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Passwort</value>
+  </data>
+  <data name="Port" xml:space="preserve">
+    <value>Hafen</value>
+  </data>
+  <data name="Server" xml:space="preserve">
+    <value>Server</value>
+  </data>
+  <data name="ServerPath" xml:space="preserve">
+    <value>Pfad am Server</value>
+  </data>
+  <data name="TAB_SettingsAniDB" xml:space="preserve">
+    <value>AniDB!</value>
+  </data>
+  <data name="TAB_SettingsDisplay" xml:space="preserve">
+    <value>Display</value>
+  </data>
+  <data name="TAB_SettingsEssential" xml:space="preserve">
+    <value>ätherische Öle</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB" xml:space="preserve">
+    <value>Community-Seiten!</value>
+  </data>
+  <data name="Test" xml:space="preserve">
+    <value>Test</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Benutzername</value>
+  </data>
+  <data name="TestAndSave" xml:space="preserve">
+    <value>Testen und sparen Sie!</value>
+  </data>
+  <data name="Success" xml:space="preserve">
+    <value>Erfolg</value>
+  </data>
+  <data name="INFO_SettingsEssential" xml:space="preserve">
+    <value>Alle Einstellungen auf dieser Seite sollte aufgefüllt werden. Achten Sie darauf, zu testen und die JMM Server und AniDB Details speichern, bevor Sie fortfahren. Wenn dies Ihr erster Laufzeit der Anwendung geben Sie mindestens eine Import-Ordner und die Presse die Run-Import-Taste.</value>
+  </data>
+  <data name="Search" xml:space="preserve">
+    <value>Suche!</value>
+  </data>
+  <data name="Tooltip_GroupSearch" xml:space="preserve">
+    <value>Suche nach Gruppen nach Name (in jeder Sprache), Kategorie oder Tag!</value>
+  </data>
+  <data name="AniDBDownloadChar" xml:space="preserve">
+    <value>Herunterladen Charaktere / Schöpfer!</value>
+  </data>
+  <data name="AniDBDownloadOptions" xml:space="preserve">
+    <value>AniDB Download Optionen!</value>
+  </data>
+  <data name="AniDBDownloadRelated" xml:space="preserve">
+    <value>Laden Sie Verwandte Anime!</value>
+  </data>
+  <data name="AniDBDownloadReleaseGroups" xml:space="preserve">
+    <value>Download der Mitteilung Gruppen!</value>
+  </data>
+  <data name="AniDBDownloadReviews" xml:space="preserve">
+    <value>Download Bewertungen!</value>
+  </data>
+  <data name="AniDBDownloadSimilar" xml:space="preserve">
+    <value>Downloaden Ähnliche Anime!</value>
+  </data>
+  <data name="AniDBMyListAddFiles" xml:space="preserve">
+    <value>Dateien hinzufügen</value>
+  </data>
+  <data name="AniDBMylistOptions" xml:space="preserve">
+    <value>AniDB MyList Optionen!</value>
+  </data>
+  <data name="AniDBMyListReadUnwatched" xml:space="preserve">
+    <value>Lesen Unbeobachteten!</value>
+  </data>
+  <data name="AniDBMyListReadWatched" xml:space="preserve">
+    <value>Lesen Gesehen!</value>
+  </data>
+  <data name="AniDBMyListSetUnwatched" xml:space="preserve">
+    <value>Stellen Unbeobachteten!</value>
+  </data>
+  <data name="AniDBMyListSetWatched" xml:space="preserve">
+    <value>Stellen Gesehen!</value>
+  </data>
+  <data name="AniDBMyListState" xml:space="preserve">
+    <value>Speicherstatus</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadChar" xml:space="preserve">
+    <value>Informationen zum Download und Bilder über die Charaktere und seiyuu, die im Anime erscheinen!</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadRelated" xml:space="preserve">
+    <value>Wenn Informationen über ein Anime Download Download auch Informationen über alle damit verbundenen Anime. Dies ist notwendig, um richtig Gruppe anime während des Importprozess.!</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadReleaseGroups" xml:space="preserve">
+    <value>Laden Sie detaillierte Informationen über die Freisetzung / Haftgruppen für Ihre Anime!</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadReviews" xml:space="preserve">
+    <value>Heruntergeladene anime Bewertungen AniDB Nutzer!</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadSimilar" xml:space="preserve">
+    <value>Wenn Informationen über ein Anime Herunterladen, auch Informationen zu ähnlichen und empfohlene Titel Download!</value>
+  </data>
+  <data name="Tooltip_AniDBMyListAddFiles" xml:space="preserve">
+    <value>Wenn ausgewählt, wenn Dateien importieren, werden die Dateien auf Ihren AniDB Konto hinzugefügt!</value>
+  </data>
+  <data name="Tooltip_AniDBMyListReadUnwatched" xml:space="preserve">
+    <value>Wenn die Datei als un-angeschaut auf AniDB gesetzt ist, wird es auch als gesetzt werden un gesehene auf Ihrer lokalen Sammlung!</value>
+  </data>
+  <data name="Tooltip_AniDBMyListReadWatched" xml:space="preserve">
+    <value>Wenn die Datei eingestellt ist als auf AniDB schaut, wird es auch als beobachtete auf dem lokalen Sammlung eingestellt werden!</value>
+  </data>
+  <data name="Tooltip_AniDBMyListSetUnwatched" xml:space="preserve">
+    <value>Wenn Sie manuell eine Video angeschaut markieren, wird AniDB ebenfalls aktualisiert werden!</value>
+  </data>
+  <data name="Tooltip_AniDBMyListSetWatched" xml:space="preserve">
+    <value>Wenn Sie ein Video fertig zu beobachten, oder markieren Sie manuell ein Video als beobachtete, wird AniDB ebenfalls aktualisiert werden!</value>
+  </data>
+  <data name="Tooltip_AniDBMyListState" xml:space="preserve">
+    <value>Die Speicherzustand Dateien eingestellt werden, wenn zu Ihrer Liste hinzugefügt!</value>
+  </data>
+  <data name="SyncMyList" xml:space="preserve">
+    <value>Sync AniDB MyList!</value>
+  </data>
+  <data name="Rehash" xml:space="preserve">
+    <value>Aufwärmen!</value>
+  </data>
+  <data name="MSG_INFO_AddedQueueCmds" xml:space="preserve">
+    <value>Befehl (e) wurden in die Warteschlange hinzugefügt!</value>
+  </data>
+  <data name="MultiTypeRange" xml:space="preserve">
+    <value>Folge Strecke!</value>
+  </data>
+  <data name="MultiTypeSingle" xml:space="preserve">
+    <value>Einzelne Episode!</value>
+  </data>
+  <data name="AniDBScheduleCalendar" xml:space="preserve">
+    <value>Automatische Aktualisierung Kalender!</value>
+  </data>
+  <data name="AniDBScheduleHTTP" xml:space="preserve">
+    <value>Automatische Update-Anime und Episoden Information!</value>
+  </data>
+  <data name="AniDBScheduleMyList" xml:space="preserve">
+    <value>Automatische Synchronisierung MyList Informationen!</value>
+  </data>
+  <data name="AniDBScheduleOptions" xml:space="preserve">
+    <value>Geplante Updates!</value>
+  </data>
+  <data name="Tooltip_AniDBScheduleCalendar" xml:space="preserve">
+    <value>Laden Sie Informationen zu den kommenden Anime.!</value>
+  </data>
+  <data name="Tooltip_AniDBScheduleHTTP" xml:space="preserve">
+    <value>Aktualisierung der Informationen über Anime und neue Episode Informationen zu erhalten. Nur Daten, die seit dem letzten geändert wurde aktualisiert werden heruntergeladen.!</value>
+  </data>
+  <data name="Tooltip_AniDBScheduleMyList" xml:space="preserve">
+    <value>Sync Informationen von AniDB nach den Optionen in der MyList Abschnitt angegeben.!</value>
+  </data>
+  <data name="TAB_SettingsWebCache" xml:space="preserve">
+    <value>Cache</value>
+  </data>
+  <data name="DetailedInformationLink" xml:space="preserve">
+    <value>Folgen Sie diesem Link für eine tiefer gehende Erklärung!</value>
+  </data>
+  <data name="Get" xml:space="preserve">
+    <value>Erhalte</value>
+  </data>
+  <data name="INFO_SettingsWebCache" xml:space="preserve">
+    <value>Die Web-Cache ist eine Online-Datenbank von den Entwicklern von JMM und MyAnime erstellt. Sein Zweck ist es, die Lücken zu füllen, die andere Datenbanken sorgen nicht für, und auch der Importvorgang schneller machen, indem Informationen mit anderen Benutzern von JMM teilen.!</value>
+  </data>
+  <data name="Send" xml:space="preserve">
+    <value>Senden!</value>
+  </data>
+  <data name="Tooltip_WebCache_Anonymous" xml:space="preserve">
+    <value>Durch die Auswahl dieser Option Ihre AniDB Benutzername wird nicht auf den Web-Cache gesendet. Allerdings bedeutet dies nicht in den Genuss des Erinnerns Ihre persönliche Auswahl zu bekommen.!</value>
+  </data>
+  <data name="Tooltip_WebCache_FileEpisodes" xml:space="preserve">
+    <value>Wenn Sie Dateien in AniDB kann das Web-Cache haben scheinen keine Informationen über die auf diese Datei beziehen Folge. Dies ist besonders nützlich, wenn Sie Dateien manuell verbinden und wollen nicht, dass die Informationen zu verlieren.!</value>
+  </data>
+  <data name="Tooltip_WebCache_FileHashes" xml:space="preserve">
+    <value>Versuchen Sie, die Datei-Hash aus dem Web-Cache immer vor Ort Hashing. Dies kann eine Menge Zeit sparen, wenn importieren.!</value>
+  </data>
+  <data name="Tooltip_WebCache_TvDBAssociations" xml:space="preserve">
+    <value>Verwenden Sie das Web-Cache zu sehen Verbindungen zwischen AniDB und tvdb. Wenn nicht ausgewählt, müssen Sie manuell für alle tvdb Links zu suchen.!</value>
+  </data>
+  <data name="TvDB_FanartAutoDownload" xml:space="preserve">
+    <value>Auto Download Fanart!</value>
+  </data>
+  <data name="TvDB_FanartCount" xml:space="preserve">
+    <value>Maximale Fanarts!</value>
+  </data>
+  <data name="TvDB_PosterAutoDownload" xml:space="preserve">
+    <value>Auto Download Poster!</value>
+  </data>
+  <data name="TvDB_WideBannerAutoDownload" xml:space="preserve">
+    <value>Auto Download Weit Banner!</value>
+  </data>
+  <data name="WebCache_Anonymous" xml:space="preserve">
+    <value>Bleiben Sie anonym</value>
+  </data>
+  <data name="WebCache_FileEpisodes" xml:space="preserve">
+    <value>Datei zu Folge Verbindungen!</value>
+  </data>
+  <data name="WebCache_FileHashes" xml:space="preserve">
+    <value>Dateihashes!</value>
+  </data>
+  <data name="WebCache_TvDBAssociations" xml:space="preserve">
+    <value>Links</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_MovieDB" xml:space="preserve">
+    <value>Der Film DB!</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_TvDB" xml:space="preserve">
+    <value>Die tvdb!</value>
+  </data>
+  <data name="Tooltip_TvDB_FanartAutoDownload" xml:space="preserve">
+    <value>Automatisch neue Fanart downloaden, wenn ein Import durchgeführt wird.!</value>
+  </data>
+  <data name="Tooltip_TvDB_FanartCount" xml:space="preserve">
+    <value>Die maximale Höhe der Fanart Bilder zum Download!</value>
+  </data>
+  <data name="Tooltip_TvDB_PosterAutoDownload" xml:space="preserve">
+    <value>Automatischer Download von neuen Plakaten, wenn ein Import durchgeführt wird.!</value>
+  </data>
+  <data name="Tooltip_TvDB_WideBannerAutoDownload" xml:space="preserve">
+    <value>Automatischer Download von neuen breiten Banner, wenn ein Import durchgeführt wird.!</value>
+  </data>
+  <data name="ImportSettings_HashCRC32" xml:space="preserve">
+    <value>Berechnen Sie CRC32!</value>
+  </data>
+  <data name="ImportSettings_HashMD5" xml:space="preserve">
+    <value>Berechnen</value>
+  </data>
+  <data name="ImportSettings_ImportOnStart" xml:space="preserve">
+    <value>Import auf Start!</value>
+  </data>
+  <data name="ImportSettings_SHA1" xml:space="preserve">
+    <value>Berechnen</value>
+  </data>
+  <data name="ImportSettings_VideoExtensions" xml:space="preserve">
+    <value>Video-Erweiterungen!</value>
+  </data>
+  <data name="ImportSettings_WatchFiles" xml:space="preserve">
+    <value>Sehen Sie für neue Dateien!</value>
+  </data>
+  <data name="MovieDB_FanartAutoDownload" xml:space="preserve">
+    <value>Auto Download Fanart!</value>
+  </data>
+  <data name="MovieDB_FanartCount" xml:space="preserve">
+    <value>Maximale Fanarts!</value>
+  </data>
+  <data name="MovieDB_PosterAutoDownload" xml:space="preserve">
+    <value>Auto Download Poster!</value>
+  </data>
+  <data name="TAB_Settings_ImportSettings" xml:space="preserve">
+    <value>Importeinstellungen!</value>
+  </data>
+  <data name="Tooltip_MovieDB_FanartAutoDownload" xml:space="preserve">
+    <value>Automatisch neue Fanart downloaden, wenn ein Import durchgeführt wird.!</value>
+  </data>
+  <data name="Tooltip_MovieDB_FanartCount" xml:space="preserve">
+    <value>Die maximale Höhe der Fanart Bilder zum Download!</value>
+  </data>
+  <data name="Tooltip_MovieDB_PosterAutoDownload" xml:space="preserve">
+    <value>Automatischer Download von neuen Plakaten, wenn ein Import durchgeführt wird.!</value>
+  </data>
+  <data name="Down" xml:space="preserve">
+    <value>Herunter</value>
+  </data>
+  <data name="LanguageUseSynonyms" xml:space="preserve">
+    <value>Auch Synonyme verwenden!</value>
+  </data>
+  <data name="TAB_Settings_Language" xml:space="preserve">
+    <value>Spracheinstellungen!</value>
+  </data>
+  <data name="Files" xml:space="preserve">
+    <value>Dateien</value>
+  </data>
+  <data name="ReevaluateDuplicateFiles" xml:space="preserve">
+    <value>Alle Einträge neu zu bewerten</value>
+  </data>
+  <data name="Tooltip_ReevaluateDuplicateFiles" xml:space="preserve">
+    <value>Überprüfen Sie alle doppelten Dateien Einträge um festzustellen, ob die Dateien noch vorhanden sind. Wenn nicht den Datenbankeintrag löschen</value>
+  </data>
+  <data name="TAB_MultipleFiles" xml:space="preserve">
+    <value>Mehrere Dateien</value>
+  </data>
+  <data name="INFO_MultipleFiles" xml:space="preserve">
+    <value>Mehrere Dateien sind, wo Sie zwei oder mehr Dateien für die gleiche Episode haben. Dieses Dienstprogramm können Sie alle diese Vorkommnisse zu prüfen und entscheiden, welche Sie behalten möchten</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Wird geladen...</value>
+  </data>
+  <data name="TotalFileCount" xml:space="preserve">
+    <value>Insgesamt Dateianzahl</value>
+  </data>
+  <data name="ImportSettings_UseEpisodeStatus" xml:space="preserve">
+    <value>Legen Sie als ansah, wenn Folge beobachtet wird</value>
+  </data>
+  <data name="Tooltip_TvDB_Schedule_Updates" xml:space="preserve">
+    <value>Update-Serie und Episode Informationen alle 12 Stunden und auch downloaden, neue Fanart, die Poster und große Banner</value>
+  </data>
+  <data name="TvDB_Schedule_Updates" xml:space="preserve">
+    <value>Update-Info alle 12 Stunden</value>
+  </data>
+  <data name="RescanAll" xml:space="preserve">
+    <value>Alle scan-neu</value>
+  </data>
+  <data name="DeleteAll" xml:space="preserve">
+    <value>Löschen Sie alle</value>
+  </data>
+  <data name="CrossRefSummary" xml:space="preserve">
+    <value>TvDB und andere nicht AniDB-Links</value>
+  </data>
+  <data name="FileSummary" xml:space="preserve">
+    <value>Datei-Zusammenfassung</value>
+  </data>
+  <data name="TheTvDB" xml:space="preserve">
+    <value>Die tvdb!</value>
+  </data>
+  <data name="SeasonNumber" xml:space="preserve">
+    <value>Staffel #</value>
+  </data>
+  <data name="CommunityRecommendation" xml:space="preserve">
+    <value>Gemeinschaftsempfehlung</value>
+  </data>
+  <data name="TvDBSearchPrompt" xml:space="preserve">
+    <value>Suchen Sie auf der TvDB oder geben TvDB Serie ID ein</value>
+  </data>
+  <data name="TvDBShow" xml:space="preserve">
+    <value>Gehen Sie zu TvDB</value>
+  </data>
+  <data name="UseThis" xml:space="preserve">
+    <value>Verwenden Sie diese</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Schließen</value>
+  </data>
+  <data name="SwitchSeason" xml:space="preserve">
+    <value>Switch-Saison</value>
+  </data>
+  <data name="AniDB" xml:space="preserve">
+    <value>AniDB!</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>Update</value>
+  </data>
+  <data name="UpdateAniDBInfo" xml:space="preserve">
+    <value>Update AniDB Info</value>
+  </data>
+  <data name="UpdateInfo" xml:space="preserve">
+    <value>Update-Info</value>
+  </data>
+  <data name="ImageSize_EpisodeImage" xml:space="preserve">
+    <value>Folge-Bild</value>
+  </data>
+  <data name="Tooltip_ImageSize_EpisodeImage" xml:space="preserve">
+    <value>Die Bilder zeigen im Detail Folge</value>
+  </data>
+  <data name="EpisodeDetailStyle" xml:space="preserve">
+    <value>Folge-Detail-Stil</value>
+  </data>
+  <data name="EpisodeDetailStyle_Option1" xml:space="preserve">
+    <value>Bilder/Übersicht Zusammenfassend</value>
+  </data>
+  <data name="EpisodeDetailStyle_Option2" xml:space="preserve">
+    <value>Bilder/Übersicht wenn nur erweitert</value>
+  </data>
+  <data name="EpisodeDetailStyle_Option3" xml:space="preserve">
+    <value>Bilder/Übersicht deaktiviert</value>
+  </data>
+  <data name="HideEpisodeImageWhenUnwatched" xml:space="preserve">
+    <value>Ausblenden Sie Episode-Bild beim Unwatched</value>
+  </data>
+  <data name="HideEpisodeOverviewWhenUnwatched" xml:space="preserve">
+    <value>Ausblenden Sie Episode Übersicht beim Unwatched</value>
+  </data>
+  <data name="Tooltip_HideEpisodeImageWhenUnwatched" xml:space="preserve">
+    <value>Das Folge-Bild wird ausgeblendet werden, bis die Episode beobachtet wird</value>
+  </data>
+  <data name="Tooltip_HideEpisodeOverviewWhenUnwatched" xml:space="preserve">
+    <value>Übersicht über die Folge (Beschreibung) werden versteckt, bis die Episode beobachtet wird</value>
+  </data>
+  <data name="Fanart" xml:space="preserve">
+    <value>Fanart</value>
+  </data>
+  <data name="Images" xml:space="preserve">
+    <value>Bilder</value>
+  </data>
+  <data name="Image_Disabled" xml:space="preserve">
+    <value>Bild ist derzeit deaktiviert.</value>
+  </data>
+  <data name="Image_Dynamic" xml:space="preserve">
+    <value>Legen Sie dieses Bild als das einzige Bild, das angezeigt wird</value>
+  </data>
+  <data name="Image_Enabled" xml:space="preserve">
+    <value>Bild ist derzeit aktiviert.</value>
+  </data>
+  <data name="Image_Static" xml:space="preserve">
+    <value>Dieses Bild ist das einzige Bild, das angezeigt wird</value>
+  </data>
+  <data name="Image_View" xml:space="preserve">
+    <value>Bild anzeigen</value>
+  </data>
+  <data name="Posters" xml:space="preserve">
+    <value>Poster</value>
+  </data>
+  <data name="WideBanners" xml:space="preserve">
+    <value>Große Banner</value>
+  </data>
+  <data name="TheMovieDB" xml:space="preserve">
+    <value>Der Film DB!</value>
+  </data>
+  <data name="MovieDBShow" xml:space="preserve">
+    <value>Gehen Sie zu MovieDB</value>
+  </data>
+  <data name="MovieDBSearchPrompt" xml:space="preserve">
+    <value>Suchen Sie auf der MovieDB oder geben MovieDB-ID ein</value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedTvDBOrMovieDBInfo" xml:space="preserve">
+    <value>Hat TvDB oder MovieDB-Link</value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedMovieDBInfo" xml:space="preserve">
+    <value>Hat MovieDB-Link</value>
+  </data>
+  <data name="Image_Default" xml:space="preserve">
+    <value>Nur dieses Bild wird verwendet</value>
+  </data>
+  <data name="Image_NotDefault" xml:space="preserve">
+    <value>Dieses Bild ist nicht der Standard</value>
+  </data>
+  <data name="PlayNextEpisode" xml:space="preserve">
+    <value>Nächste Episode zu spielen</value>
+  </data>
+  <data name="AllEpisodesWatched" xml:space="preserve">
+    <value>Alle Episoden haben bereits beobachtet worden</value>
+  </data>
+  <data name="FinishEditing" xml:space="preserve">
+    <value>Die Bearbeitung abgeschlossen haben</value>
+  </data>
+  <data name="TAB_Dashboard" xml:space="preserve">
+    <value>Dashboard</value>
+  </data>
+  <data name="Dash_WatchNextEp_Recent" xml:space="preserve">
+    <value>Weiter beobachten... (Kürzlich gesehen)</value>
+  </data>
+  <data name="DeleteSeries" xml:space="preserve">
+    <value>Löschen der Serie</value>
+  </data>
+  <data name="DeleteSeriesConfirm" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie diese Serie/Gruppe löschen möchten?</value>
+  </data>
+  <data name="DeleteSeriesConfirm_Files" xml:space="preserve">
+    <value>Auch löschen die physischen Dateien zu?</value>
+  </data>
+  <data name="Dash_SeriesMissingEps" xml:space="preserve">
+    <value>Fehlende Episoden (von kürzlich gesehen)</value>
+  </data>
+  <data name="LatestEp_Anime" xml:space="preserve">
+    <value>Neueste Episode</value>
+  </data>
+  <data name="LatestEp_Yours" xml:space="preserve">
+    <value>Ihre neueste Episode</value>
+  </data>
+  <data name="MissingEpisodeCount" xml:space="preserve">
+    <value>Fehlende Episoden</value>
+  </data>
+  <data name="Dash_MiniCalendar" xml:space="preserve">
+    <value>Mini-Kalender</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Anmeldung</value>
+  </data>
+  <data name="ImageSize" xml:space="preserve">
+    <value>Bildgröße</value>
+  </data>
+  <data name="INFO_SettingsUserAdmin" xml:space="preserve">
+    <value>Hinzufügen oder Bearbeiten von Benutzern hier. Benutzer sind in der Datenbank gespeichert und für verschiedene Clients freigegeben. Sie muss immer mindestens ein Administratorbenutzer.</value>
+  </data>
+  <data name="TAB_SettingsUsers" xml:space="preserve">
+    <value>Benutzer</value>
+  </data>
+  <data name="User_HideCategories" xml:space="preserve">
+    <value>Kategorien verbergen</value>
+  </data>
+  <data name="User_IsAdmin" xml:space="preserve">
+    <value>Administrator</value>
+  </data>
+  <data name="User_Password" xml:space="preserve">
+    <value>Passwort</value>
+  </data>
+  <data name="User_Username" xml:space="preserve">
+    <value>Benutzername</value>
+  </data>
+  <data name="Items" xml:space="preserve">
+    <value>Elemente</value>
+  </data>
+  <data name="Days" xml:space="preserve">
+    <value>Tagen</value>
+  </data>
+  <data name="DashWatchNextStyle_Detailed" xml:space="preserve">
+    <value>Detaillierte</value>
+  </data>
+  <data name="DashWatchNextStyle_Simple" xml:space="preserve">
+    <value>Einfache</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_Trakt" xml:space="preserve">
+    <value>Trakt TV</value>
+  </data>
+  <data name="Trakt_Password" xml:space="preserve">
+    <value>Passwort</value>
+  </data>
+  <data name="Trakt_Username" xml:space="preserve">
+    <value>Benutzername</value>
+  </data>
+  <data name="UpdateFrequency" xml:space="preserve">
+    <value>Daten automatisch aktualisieren</value>
+  </data>
+  <data name="UpdateFrequency_12Hours" xml:space="preserve">
+    <value>Alle 12 Stunden</value>
+  </data>
+  <data name="UpdateFrequency_6Hours" xml:space="preserve">
+    <value>Alle 6 Stunden</value>
+  </data>
+  <data name="UpdateFrequency_Daily" xml:space="preserve">
+    <value>Alle 24 Stunden</value>
+  </data>
+  <data name="UpdateFrequency_Never" xml:space="preserve">
+    <value>Nie</value>
+  </data>
+  <data name="TraktSyncFrequency" xml:space="preserve">
+    <value>Synchronisieren Sie automatisch Collection</value>
+  </data>
+  <data name="TraktSearchPrompt" xml:space="preserve">
+    <value>Suche auf Trakt oder geben Sie Trakt ID (Slug)</value>
+  </data>
+  <data name="TraktShow" xml:space="preserve">
+    <value>Gehen Sie zum Trakt</value>
+  </data>
+  <data name="TAB_Pinned" xml:space="preserve">
+    <value>Fixiert</value>
+  </data>
+  <data name="Tooltip_ViewSeries" xml:space="preserve">
+    <value>Dieser Anime-Serie in einem neuen Fenster geöffnet</value>
+  </data>
+  <data name="GroupFilterConditionType_UserVotedAny" xml:space="preserve">
+    <value>Benutzer, die abgestimmt (alle)</value>
+  </data>
+  <data name="Tooltip_User_IsAniDB" xml:space="preserve">
+    <value>Jeder Benutzer als Benutzer AniDB gekennzeichnet wird mit anderen Benutzern AniDB synchron gehalten werden. Ist der Benutzer kein AniDB Benutzer aufgepaßt werden Episoden nicht auf der Website AniDB übernommen.</value>
+  </data>
+  <data name="User_IsAniDB" xml:space="preserve">
+    <value>AniDB Benutzer</value>
+  </data>
+  <data name="User_IsTrakt" xml:space="preserve">
+    <value>Trakt Benutzer</value>
+  </data>
+  <data name="ERROR_SeriesExists" xml:space="preserve">
+    <value>Eine Serie für diese Anime ist bereits vorhanden.</value>
+  </data>
+  <data name="Tooltip_CreateSeries" xml:space="preserve">
+    <value>Diese Anime-Serie zu erstellen</value>
+  </data>
+  <data name="SimilarAnime" xml:space="preserve">
+    <value>Ähnliche Anime</value>
+  </data>
+  <data name="RelatedAndSimilar" xml:space="preserve">
+    <value>Verwandte und ähnliche</value>
+  </data>
+  <data name="GetMissingData" xml:space="preserve">
+    <value>Holen Sie sich jetzt Daten fehlen</value>
+  </data>
+  <data name="NoSimilarAnime" xml:space="preserve">
+    <value>Keine ähnlichen Anime konnte gefunden werden.</value>
+  </data>
+  <data name="NoRelatedAnime" xml:space="preserve">
+    <value>Nicht verwandte Anime konnte gefunden werden.</value>
+  </data>
+  <data name="RelatedAnime" xml:space="preserve">
+    <value>Beiträge zu Anime</value>
+  </data>
+  <data name="Dash_RecWatch" xml:space="preserve">
+    <value>Empfehlungen zu beobachten</value>
+  </data>
+  <data name="Dash_RecDownload" xml:space="preserve">
+    <value>Empfehlungen zum Download</value>
+  </data>
+  <data name="ImportSettings_AutoGroupSeries" xml:space="preserve">
+    <value>Setzen Sie automatisch verwandte Serie in der gleichen Gruppe</value>
+  </data>
+  <data name="GroupFilterConditionType_HasWatchedEpisodes" xml:space="preserve">
+    <value>Episoden sah</value>
+  </data>
+  <data name="MyList" xml:space="preserve">
+    <value>MyList</value>
+  </data>
+  <data name="Tooltip_MyList" xml:space="preserve">
+    <value>Fügen Sie diese Datei mit Nachdruck zu Ihrer Liste auf AniDB</value>
+  </data>
+  <data name="TAB_MissingFiles" xml:space="preserve">
+    <value>MyList Dateien fehlen</value>
+  </data>
+  <data name="TAB_Utilities" xml:space="preserve">
+    <value>Dienstprogramme</value>
+  </data>
+  <data name="TAB_SeriesWithoutFiles" xml:space="preserve">
+    <value>Serie ohne Dateien</value>
+  </data>
+  <data name="DeleteSeriesConfirm_Groups" xml:space="preserve">
+    <value>Alle übergeordneten Gruppen zu löschen, wenn sie leer sind</value>
+  </data>
+  <data name="Export" xml:space="preserve">
+    <value>Export</value>
+  </data>
+  <data name="TAB_MissingEpisodes" xml:space="preserve">
+    <value>Fehlende Episoden!</value>
+  </data>
+  <data name="MyGroupsOnly" xml:space="preserve">
+    <value>Freigeben Sie Teilnehmergruppen, die ich gesammelt, bin nur</value>
+  </data>
+  <data name="RegularEpisodesOnly" xml:space="preserve">
+    <value>Reguläre Episoden nur</value>
+  </data>
+  <data name="Dash_TraktFriends" xml:space="preserve">
+    <value>Freunde-Aktivität (Trakt TV)</value>
+  </data>
+  <data name="Tooltip_IgnoreAnimeDownload" xml:space="preserve">
+    <value>Ignorieren Sie diese Anime Empfehlungen herunterladen</value>
+  </data>
+  <data name="Tooltip_IgnoreAnimeWatch" xml:space="preserve">
+    <value>Ignorieren Sie diese Anime Watch Empfehlungen</value>
+  </data>
+  <data name="VisitWebsite" xml:space="preserve">
+    <value>Website besuchen</value>
+  </data>
+  <data name="AniDBSignup" xml:space="preserve">
+    <value>Anmeldung für AniDB jetzt</value>
+  </data>
+  <data name="AvdumpHeader" xml:space="preserve">
+    <value>AVDump2 (Optional)</value>
+  </data>
+  <data name="AvdumpInfoLink" xml:space="preserve">
+    <value>Mehr Infos auf AVDump2</value>
+  </data>
+  <data name="AvdumpKey" xml:space="preserve">
+    <value>API-Schlüssel</value>
+  </data>
+  <data name="AvdumpKeyEditLink" xml:space="preserve">
+    <value>AVDump2 UDP API Key hier bearbeiten</value>
+  </data>
+  <data name="Avdump" xml:space="preserve">
+    <value>Avdump2</value>
+  </data>
+  <data name="AvdumpRequiredFilesLink" xml:space="preserve">
+    <value>Stellen Sie sicher, dass Sie alle erforderlichen Dateien im gleichen Ordner wie JMM Desktop haben</value>
+  </data>
+  <data name="AvdumpSettingsError" xml:space="preserve">
+    <value>Sie nicht Ihren API-Schlüssel und/oder Client-Port angegeben.</value>
+  </data>
+  <data name="AvdumpAddRelease" xml:space="preserve">
+    <value>Neue Version hinzufügen</value>
+  </data>
+  <data name="CopyED2KClipboard" xml:space="preserve">
+    <value>Kopieren von ED2K-Dump</value>
+  </data>
+  <data name="Tooltip_CopyED2KClipboard" xml:space="preserve">
+    <value>Den ED2K-Dump in die Zwischenablage kopieren</value>
+  </data>
+  <data name="TAB_IgnoredAnime" xml:space="preserve">
+    <value>Ignorierte Anime</value>
+  </data>
+  <data name="Anime" xml:space="preserve">
+    <value>Anime</value>
+  </data>
+  <data name="RemoveDefaultSeries" xml:space="preserve">
+    <value>Entfernen Sie die Standard-Serie</value>
+  </data>
+  <data name="SetDefaultSeries" xml:space="preserve">
+    <value>Hinzufügen von Standard-Serie</value>
+  </data>
+  <data name="DefSeries1" xml:space="preserve">
+    <value>Wählen Sie die Standard-Serie für</value>
+  </data>
+  <data name="DefSeries2" xml:space="preserve">
+    <value>Auswählen eines Standard-Serie bedeutet, dass alle Bilder, die für eine Gruppe angezeigt werden, die verwendet wird </value>
+  </data>
+  <data name="DefSeries3" xml:space="preserve">
+    <value>Standard-Serie statt einer zufälligen Reihe innerhalb der Gruppe</value>
+  </data>
+  <data name="ChangeLanguage" xml:space="preserve">
+    <value>Sprache ändern</value>
+  </data>
+  <data name="EpisodeTitleSourceStyle" xml:space="preserve">
+    <value>Folge Titel Quelle</value>
+  </data>
+  <data name="SeriesNameSourceStyle" xml:space="preserve">
+    <value>Serie Namen Quelle</value>
+  </data>
+  <data name="SeriesOverviewSourceStyle" xml:space="preserve">
+    <value>Serie-Übersicht-Quelle</value>
+  </data>
+  <data name="Tooltip_EpisodeTitleSourceStyle" xml:space="preserve">
+    <value>Bevorzugte Informationsquelle bei der Anzeige des Titels einer episode</value>
+  </data>
+  <data name="Tooltip_SeriesNameSourceStyle" xml:space="preserve">
+    <value>Bevorzugte Informationsquelle bei der Anzeige von der Serienname für ein anime</value>
+  </data>
+  <data name="Tooltip_SeriesOverviewSourceStyle" xml:space="preserve">
+    <value>Bevorzugte Informationsquelle bei der Anzeige der Übersicht eine Anime-Serie (Beschreibung)</value>
+  </data>
+  <data name="User_EditSettings" xml:space="preserve">
+    <value>Servereinstellungen bearbeiten</value>
+  </data>
+  <data name="Tooltip_RemoveMissingFiles" xml:space="preserve">
+    <value>Dies entfernt alle Videodateien-Einträge aus der Datenbank, wo die Datei physisch nicht gefunden werden kann. Stellen Sie sicher alle Ihre Netzwerkfreigaben stehen oder USB-Laufwerke angeschlossen, bevor Sie diese ausführen.</value>
+  </data>
+  <data name="Tooltip_UpdateMediaInfo" xml:space="preserve">
+    <value>Die Media-Info ist die Informationen über Ihre Dateien wie Bitrate, Auflösung Codecs etc. die wird gelesen und gespeichert das erste Mal Sie eine Datei importieren</value>
+  </data>
+  <data name="UpdateMediaInfo" xml:space="preserve">
+    <value>Aktualisieren Sie alle Medieninformationen</value>
+  </data>
+  <data name="Video_Hi10P" xml:space="preserve">
+    <value>10-bit</value>
+  </data>
+  <data name="Tooltip_TraktAnimeOnly" xml:space="preserve">
+    <value>Nur Aktivität anzeigen bezieht sich auf Anime (ausschließen ie andere tv-Serie)</value>
+  </data>
+  <data name="TraktAnimeOnly" xml:space="preserve">
+    <value>Nur Anime</value>
+  </data>
+  <data name="ForceRefresh" xml:space="preserve">
+    <value>Kraft-Refresh</value>
+  </data>
+  <data name="TraktFriendNotes" xml:space="preserve">
+    <value>Informationen werden auf Server alle 20 Minuten aktualisiert.</value>
+  </data>
+  <data name="Dash_RecentEpisodes" xml:space="preserve">
+    <value>Vor kurzem beobachtete Episoden</value>
+  </data>
+  <data name="PromptRateSeries" xml:space="preserve">
+    <value>Aufforderung zum Tarif-Serie nach Abschluss</value>
+  </data>
+  <data name="Tooltip_PromptRateSeries" xml:space="preserve">
+    <value>Wenn Sie die letzte Episode in einer Reihe zu sehen, wird eine Aufforderung angezeigt, um Sie um eine Bewertung bitten</value>
+  </data>
+  <data name="MALSearchPrompt" xml:space="preserve">
+    <value>Suche auf MyAnimelist oder MAL ID eingeben</value>
+  </data>
+  <data name="MALShow" xml:space="preserve">
+    <value>Gehen Sie auf MyAnimeList</value>
+  </data>
+  <data name="Tooltip_WebCache_MALAssociations" xml:space="preserve">
+    <value>Verwenden Sie den Webcache Verbindungen zwischen AniDB und MyAnimeList nachschlagen. Wenn nicht aktiviert Sie manuell alle MAL Links suchen müssen.</value>
+  </data>
+  <data name="WebCache_MALAssociations" xml:space="preserve">
+    <value>MyAnimeList Links</value>
+  </data>
+  <data name="Tooltip_MAL_UpdateFrequency" xml:space="preserve">
+    <value>Wie oft Daten werden aktualisiert, und wie oft wird eine automatische Suche nach Anime in Ihrer Sammlung zu suchen, die nicht über einen Link MAL durchgeführt</value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedMALInfo" xml:space="preserve">
+    <value>Hat MAL Link</value>
+  </data>
+  <data name="Tooltip_UseFanartOnSeries" xml:space="preserve">
+    <value>Benutzer-Fanart statt Plakate (soweitbekannt) Serie Display</value>
+  </data>
+  <data name="UseFanartOnSeries" xml:space="preserve">
+    <value>Benutzer-Fanart Serie Display</value>
+  </data>
+  <data name="MAL_NeverDecrease" xml:space="preserve">
+    <value>Nie beobachtete Abnahme zählt</value>
+  </data>
+  <data name="Tooltip_MAL_NeverDecrease" xml:space="preserve">
+    <value>Stellen Sie sicher, dass beobachtete, dass zählt immer gehalten werden. Dies erfordert herunterladen Ihre vollständige Liste jedes Mal, wenn Sie eine Episode zu sehen kann sehr lange dauern</value>
+  </data>
+  <data name="GroupFilterConditionType_EpisodeCount" xml:space="preserve">
+    <value>Folge Graf</value>
+  </data>
+  <data name="SyncMalDown" xml:space="preserve">
+    <value>Laden Sie überwachte Staaten von MAL</value>
+  </data>
+  <data name="SyncMalUp" xml:space="preserve">
+    <value>Überwachte Staaten auf MAL hochladen</value>
+  </data>
+  <data name="Tooltip_SyncMalDown" xml:space="preserve">
+    <value>Herunterladen Sie überwachte Staaten von MAL und aktualisieren Sie Ihre lokalen Sammlung und AniDB.</value>
+  </data>
+  <data name="Tooltip_SyncMalUp" xml:space="preserve">
+    <value>Update MAL mit der beobachteten Statistik aus Ihrer lokalen Sammlung</value>
+  </data>
+  <data name="Tooltip_WebCache_AniDB_File" xml:space="preserve">
+    <value>Dies ist jede einzelne Datei zugeordneten Daten. Empfohlen für große Sammlungen</value>
+  </data>
+  <data name="WebCache_AniDB_File" xml:space="preserve">
+    <value>AniDB Dateidaten</value>
+  </data>
+  <data name="PlaylistPlayOrderRandom" xml:space="preserve">
+    <value>Zufällige</value>
+  </data>
+  <data name="PlaylistPlayOrderSeq" xml:space="preserve">
+    <value>Sequenzielle</value>
+  </data>
+  <data name="AniDBScheduleMyListStats" xml:space="preserve">
+    <value>Erhalten Sie automatisch MyList Stats von AniDB</value>
+  </data>
+  <data name="GroupFilter_Predefined" xml:space="preserve">
+    <value>Vordefinierte Filter</value>
+  </data>
+  <data name="BakaBTResetBody" xml:space="preserve">
+    <value>Zurücksetzen Sie das Cookie, wenn Sie nicht immer alle Ergebnisse aus BakaBT Wenn Sie sein sollte. Dadurch wird eine Anmeldung wieder zu BakaBT gezwungen.</value>
+  </data>
+  <data name="BakaBTResetTitle" xml:space="preserve">
+    <value>Cookie zurücksetzen</value>
+  </data>
+  <data name="BakaBTSeriesBody" xml:space="preserve">
+    <value>Bei der Suche nach einer Reihe werden BakaBT (AnimeBytes) die einzige Schwall-Quelle in der ersten Suche verwendet und</value>
+  </data>
+  <data name="BakaBTSeriesTitle" xml:space="preserve">
+    <value>BakaBT (und AnimeBytes) nur</value>
+  </data>
+  <data name="AnimeBytesResetBody" xml:space="preserve">
+    <value>Zurücksetzen Sie das Cookie, wenn Sie nicht immer alle Ergebnisse aus AnimeBytes Wenn Sie sein sollte. Dadurch wird eine Anmeldung wieder zu AnimeBytes gezwungen.</value>
+  </data>
+  <data name="AnimeBytesResetTitle" xml:space="preserve">
+    <value>Cookie zurücksetzen</value>
+  </data>
+  <data name="AnimeBytesSeriesBody" xml:space="preserve">
+    <value>Bei der Suche nach einer Reihe werden AnimeBytes (BakaBT) die einzige Schwall-Quelle in der ersten Suche verwendet und</value>
+  </data>
+  <data name="AnimeBytesSeriesTitle" xml:space="preserve">
+    <value>AnimeBytes (und BakaBT) nur</value>
+  </data>
+  <data name="IsVariation" xml:space="preserve">
+    <value>Ist Variation</value>
+  </data>
+  <data name="Tooltip_IsVariation" xml:space="preserve">
+    <value>Verwenden Sie diese Option, wenn Sie nicht, dass eine Datei in mehrere Dateien-Steuerelement angezeigt wird möchten. Dies ist möglicherweise der Fall, wo Sie mehrere Versionen einer OP/ED für sauber reinigen/Nein haben, Cut des Direktors und andere Typen von Variationen</value>
+  </data>
+  <data name="AniDBDownloadCharacters" xml:space="preserve">
+    <value>Zeichen Bilder herunterladen</value>
+  </data>
+  <data name="AniDBDownloadCreators" xml:space="preserve">
+    <value>Creator-Images herunterladen</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadCharacters" xml:space="preserve">
+    <value>Diese Bilder sind in 3 MyAnime und Anime Buddy dargestellt.</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadCreators" xml:space="preserve">
+    <value>Diese Bilder sind in 3 MyAnime und Anime Buddy (Synchronsprecher) dargestellt.</value>
+  </data>
+  <data name="AniDBMyListDeleteAction" xml:space="preserve">
+    <value>Löschvorgang</value>
+  </data>
+  <data name="Tooltip_AniDBMyListDeleteAction" xml:space="preserve">
+    <value>Welche Aktion für eine Datei auszuführen, wenn Sie es aus Sie lokale Sammlung löschen.
+Löschen Sie die Datei (AniDB) - entfernt die Datei aus Ihrem AniDB MyList.
+Löschen Sie die Datei (lokale DB) - entfernen-Datei von Ihrem lokalen DB nur.
+Mark-Deleted - bleibt die Datei auf Ihrer Liste, aber ändert den Zustand gelöscht.
+Mark-extern (CD/DVD) - bleibt die Datei auf Ihrer Liste, aber ändert den Zustand zu externem Speicher.
+Mark-Unknown - bleibt die Datei auf Ihrer Liste, aber ändert den Zustand unbekannt.</value>
+  </data>
+  <data name="GroupFilterConditionType_CustomTag" xml:space="preserve">
+    <value>Benutzerdefiniertes Tag</value>
+  </data>
+  <data name="Tooltip_WebCache_UserInfo" xml:space="preserve">
+    <value>Sendet anonyme Nutzung Info an den Webcache wie Datenbanktyp, Windowsversion Etc. Finden Sie in der Hilfe-Link für alle Daten, die gesendet wird</value>
+  </data>
+  <data name="WebCache_UserInfo" xml:space="preserve">
+    <value>Anonyme Nutzung Infos senden</value>
+  </data>
+  <data name="NewSeries_Search" xml:space="preserve">
+    <value>Suche nach Titel oder ID</value>
+  </data>
+  <data name="Tooltip_NewSeries_Search" xml:space="preserve">
+    <value>Der Name der Anime oder wenn Sie die ID AniDB wissen geben Sie ein, die direkt</value>
+  </data>
+  <data name="Link_CommunityRecommendation" xml:space="preserve">
+    <value>http://jmediamanager.org/FAQ/#What-are-Community-Recommendations</value>
+  </data>
+  <data name="WhatsThis" xml:space="preserve">
+    <value>Direkthilfe?</value>
+  </data>
+  <data name="Override" xml:space="preserve">
+    <value>Außer Kraft setzen</value>
+  </data>
+  <data name="Tooltip_NameOverride" xml:space="preserve">
+    <value>Sie können manuell eingeben den bevorzugten Name oder die grünen Pfeile auf der rechten Seite verwenden, um einen Namen aus AniDB auswählen.</value>
+  </data>
+  <data name="Tooltip_NameOverride2" xml:space="preserve">
+    <value>Wählen Sie einen Namen aus einer Liste von Namen AniDB.</value>
+  </data>
+  <data name="AdminMessageTitle" xml:space="preserve">
+    <value>Admin-Meldung</value>
+  </data>
+  <data name="CheckForUpdate" xml:space="preserve">
+    <value>Nach Updates suchen</value>
+  </data>
+  <data name="Link_Blog" xml:space="preserve">
+    <value>http://jmediamanager.org/Blog</value>
+  </data>
+  <data name="Link_AniDBBanned" xml:space="preserve">
+    <value>http://jmediamanager.org/FAQ/#Banned-from-anidb</value>
+  </data>
+  <data name="Link_AniDBSettings" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#anidb</value>
+  </data>
+  <data name="Link_FileRenaming" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Utilities/File-Renaming/</value>
+  </data>
+  <data name="Link_GroupFilters" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Collection/#What-are-Filters</value>
+  </data>
+  <data name="Link_ImportFolders" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Server/Configuring-JMM-Server/#Import-Folders</value>
+  </data>
+  <data name="Link_MAL" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#Community-Sites</value>
+  </data>
+  <data name="Link_MPC" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#MPC</value>
+  </data>
+  <data name="Link_PotPlayer" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#Pot-Player</value>
+  </data>
+  <data name="Link_TMDb" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#Community-Sites</value>
+  </data>
+  <data name="Link_Trakt" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#Community-Sites</value>
+  </data>
+  <data name="Link_TvDB" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#Community-Sites</value>
+  </data>
+  <data name="Link_uTorrent" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Downloads/#uTorrent</value>
+  </data>
+  <data name="Link_VLC" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#vlc</value>
+  </data>
+  <data name="Link_WebCache" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#Web-Cache</value>
+  </data>
+  <data name="UpdateFrequency_OneMonth" xml:space="preserve">
+    <value>Einmal im Monat</value>
+  </data>
+  <data name="UpdateFrequency_OneWeek" xml:space="preserve">
+    <value>Einmal pro Woche</value>
+  </data>
+  <data name="SettingAlwaysAniDBPoster" xml:space="preserve">
+    <value>Verwenden Sie immer das AniDB-Plakat</value>
+  </data>
+  <data name="Tooltip_SettingAlwaysAniDBPoster" xml:space="preserve">
+    <value>Diese Einstellung wird andere Poster Einstellungen übergehen, so dass nur die AniDB Plakat verwendet wird. Dies ist im Allgemeinen schneller als die Verwendung von zufälliger posters</value>
+  </data>
+  <data name="MoreInfo" xml:space="preserve">
+    <value>Mehr Info</value>
+  </data>
+  <data name="Link_Changelog" xml:space="preserve">
+    <value>http://jmediamanager.org/Changelog/</value>
+  </data>
+  <data name="Link_Download" xml:space="preserve">
+    <value>http://jmediamanager.org/Downloads/</value>
+  </data>
+  <data name="Link_Site" xml:space="preserve">
+    <value>http://jmediamanager.org/</value>
+  </data>
+  <data name="ReenterPassword" xml:space="preserve">
+    <value>Kennwort erneut eingeben</value>
+  </data>
+  <data name="ChangePassword" xml:space="preserve">
+    <value>Passwort ändern</value>
+  </data>
+  <data name="ChangingPassword" xml:space="preserve">
+    <value>Ändern des Kennworts für: </value>
+  </data>
+  <data name="WhatDoesThisMean" xml:space="preserve">
+    <value>Was bedeutet das?</value>
+  </data>
+  <data name="DetailedExplanation" xml:space="preserve">
+    <value>Ausführliche Erläuterung der Optionen klicken</value>
+  </data>
+  <data name="CustomTag_Name" xml:space="preserve">
+    <value>Tag-Namen</value>
+  </data>
+  <data name="CustomTag_Description" xml:space="preserve">
+    <value>Tag-Beschreibung</value>
+  </data>
+  <data name="Add" xml:space="preserve">
+    <value>Hinzufügen</value>
+  </data>
+  <data name="MissingEpisodes_AnimeName" xml:space="preserve">
+    <value>Anime-Name</value>
+  </data>
+  <data name="MissingEpisodes_AnimeID" xml:space="preserve">
+    <value>Anime-ID</value>
+  </data>
+  <data name="MissingEpisodes_EpisodeNumber" xml:space="preserve">
+    <value>Folge Nummer</value>
+  </data>
+  <data name="MissingEpisodes_EpisodeID" xml:space="preserve">
+    <value>Folge-ID</value>
+  </data>
+  <data name="MissingEpisodes_GroupSummary" xml:space="preserve">
+    <value>Gruppenübersicht</value>
+  </data>
+  <data name="MissingEpisodes_AnimeLink" xml:space="preserve">
+    <value>Link zum Anime</value>
+  </data>
+  <data name="MissingEpisodes_EpisodeLink" xml:space="preserve">
+    <value>Link zur Episode</value>
+  </data>
+  <data name="MissingEpisodes_FileSummary" xml:space="preserve">
+    <value>Datei-Zusammenfassung</value>
+  </data>
+  <data name="NewSeries_AlreadyAttached" xml:space="preserve">
+    <value>Eine Serie ist bereits an dieser Anime angefügt.</value>
+  </data>
+  <data name="NewSeries_Step1" xml:space="preserve">
+    <value>Schritt 1 - Wählen Sie ein Anime</value>
+  </data>
+  <data name="NewSeries_SearchBy" xml:space="preserve">
+    <value>Suche nach Titel oder ID</value>
+  </data>
+  <data name="NewSeries_Step2" xml:space="preserve">
+    <value>Wählen Sie eine lokale Gruppe</value>
+  </data>
+  <data name="NewSeries_BackToStep1" xml:space="preserve">
+    <value>Zurück zu Schritt 1</value>
+  </data>
+  <data name="TryAgain" xml:space="preserve">
+    <value>Wiederholen!</value>
+  </data>
+  <data name="Random_Tags" xml:space="preserve">
+    <value>Markierungen</value>
+  </data>
+  <data name="Finish" xml:space="preserve">
+    <value>Fertig stellen</value>
+  </data>
+  <data name="Clear" xml:space="preserve">
+    <value>Klar</value>
+  </data>
+  <data name="Matches" xml:space="preserve">
+    <value>Treffern</value>
+  </data>
+  <data name="Random_Watched" xml:space="preserve">
+    <value>Gesehen!</value>
+  </data>
+  <data name="Random_Unwatched" xml:space="preserve">
+    <value>Unbeobachtet!</value>
+  </data>
+  <data name="Random_PartiallyWatched" xml:space="preserve">
+    <value>Teilweise sah</value>
+  </data>
+  <data name="Random_CompleteOnly" xml:space="preserve">
+    <value>Füllen Sie nur</value>
+  </data>
+  <data name="Random_View" xml:space="preserve">
+    <value>Dieser Serie anzeigen</value>
+  </data>
+  <data name="RateSeries_Rate" xml:space="preserve">
+    <value>Tarif-Serie:</value>
+  </data>
+  <data name="RateSeries_TraktShout" xml:space="preserve">
+    <value>Sagen Sie Ihre Meinung auf Trakt</value>
+  </data>
+  <data name="Search_Episodes" xml:space="preserve">
+    <value>Episoden:</value>
+  </data>
+  <data name="Search_StartingAt" xml:space="preserve">
+    <value>Beginnend am</value>
+  </data>
+  <data name="Search_ID" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="Search_Title" xml:space="preserve">
+    <value>Titel</value>
+  </data>
+  <data name="Search_AniDBStart" xml:space="preserve">
+    <value>AniDB Start:</value>
+  </data>
+  <data name="Search_Trakt" xml:space="preserve">
+    <value>Trakt: </value>
+  </data>
+  <data name="Search_Approved" xml:space="preserve">
+    <value>Admin genehmigt</value>
+  </data>
+  <data name="Search_TvDB" xml:space="preserve">
+    <value>TvDB: </value>
+  </data>
+  <data name="Search_MAL" xml:space="preserve">
+    <value>MAL: </value>
+  </data>
+  <data name="SelectAniDBTitle_SelectName" xml:space="preserve">
+    <value>Wählen Sie einen Namen überschreiben</value>
+  </data>
+  <data name="SelectGroupSeries_Select" xml:space="preserve">
+    <value>Wählen Sie eine </value>
+  </data>
+  <data name="Select_MyAnimeList" xml:space="preserve">
+    <value>MyAnimeList</value>
+  </data>
+  <data name="Select_StartingEpisode" xml:space="preserve">
+    <value>Ab Episode #</value>
+  </data>
+  <data name="Select_EpisodeType" xml:space="preserve">
+    <value>Folge-Typ:</value>
+  </data>
+  <data name="Select_TraktTV" xml:space="preserve">
+    <value>Trakt TV</value>
+  </data>
+  <data name="Select_TvDBDetails" xml:space="preserve">
+    <value>Wählen Sie TvDB Details</value>
+  </data>
+  <data name="Select_Season" xml:space="preserve">
+    <value>Saison</value>
+  </data>
+  <data name="Select_DefaultLanguage" xml:space="preserve">
+    <value>Wählen Sie die Standardsprache</value>
+  </data>
+  <data name="Update_Update" xml:space="preserve">
+    <value>JMM Desktop Update verfügbar!</value>
+  </data>
+  <data name="Update_UpdatePage" xml:space="preserve">
+    <value>Update-Seite</value>
+  </data>
+  <data name="Update_Changelog" xml:space="preserve">
+    <value>Changelog</value>
+  </data>
+  <data name="Update_AvailableVersion" xml:space="preserve">
+    <value>Verfügbare Version</value>
+  </data>
+  <data name="Update_YourVersion" xml:space="preserve">
+    <value>Ihre Version</value>
+  </data>
+  <data name="ViewComments_FromTrakt" xml:space="preserve">
+    <value>Von Trakt</value>
+  </data>
+  <data name="ViewComments_Username" xml:space="preserve">
+    <value>Benutzername</value>
+  </data>
+  <data name="ViewComments_CommentDate" xml:space="preserve">
+    <value>Kommentar-Datum</value>
+  </data>
+  <data name="ViewComments_Comments" xml:space="preserve">
+    <value>Kommentare</value>
+  </data>
+  <data name="ViewComments_Website" xml:space="preserve">
+    <value>Blick auf Website</value>
+  </data>
+  <data name="JMMDesktop" xml:space="preserve">
+    <value>JMM-Desktop</value>
+  </data>
+  <data name="MoreInformation" xml:space="preserve">
+    <value>Weitere Informationen</value>
+  </data>
+  <data name="Metro_Continue" xml:space="preserve">
+    <value>Weiter beobachten</value>
+  </data>
+  <data name="Metro_New" xml:space="preserve">
+    <value>Neue Episoden</value>
+  </data>
+  <data name="Metro_Random" xml:space="preserve">
+    <value>Zufällige Serie</value>
+  </data>
+  <data name="Metro_Trakt" xml:space="preserve">
+    <value>Trakt Aktivität</value>
+  </data>
+  <data name="MarkedFavorite" xml:space="preserve">
+    <value>Diese Gruppe wird als Favorit gekennzeichnet.</value>
+  </data>
+  <data name="Community_TraktValid" xml:space="preserve">
+    <value>Überprüfen Sie meine Links auf Trakt noch gültig sind</value>
+  </data>
+  <data name="Community_TraktRemoveBad" xml:space="preserve">
+    <value>Entfernen Sie schlechte Informationen automatisch aus der Datenbank (sehr empfehlenswert)</value>
+  </data>
+  <data name="Community_CommunityCheck" xml:space="preserve">
+    <value>Überprüfen Sie, ob meine Links von der Gemeinschaft-Empfehlungen abweichen</value>
+  </data>
+  <data name="Community_ProblemStop" xml:space="preserve">
+    <value>Beenden Sie nach der Suche nach diesem viele Probleme</value>
+  </data>
+  <data name="Trakt" xml:space="preserve">
+    <value>Trakt</value>
+  </data>
+  <data name="Start" xml:space="preserve">
+    <value>Start</value>
+  </data>
+  <data name="Stop" xml:space="preserve">
+    <value>Stop</value>
+  </data>
+  <data name="Community_Filter" xml:space="preserve">
+    <value>Filter:</value>
+  </data>
+  <data name="Community_Refresh" xml:space="preserve">
+    <value>Aktualisieren Sie die Daten für diese Serie</value>
+  </data>
+  <data name="Community_SeriesName" xml:space="preserve">
+    <value>Name der Reihe</value>
+  </data>
+  <data name="Community_Status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="Community_ValidTraktLink" xml:space="preserve">
+    <value>Gültige Verknüpfung der Trakt</value>
+  </data>
+  <data name="Community_HasTraktLink" xml:space="preserve">
+    <value>Hat Trakt Link</value>
+  </data>
+  <data name="Community_CommunityLink" xml:space="preserve">
+    <value>Gemeinschaft-Link</value>
+  </data>
+  <data name="Community_Match" xml:space="preserve">
+    <value>Links-Match?</value>
+  </data>
+  <data name="Download_Bookmark" xml:space="preserve">
+    <value>Bookmarken Sie diese Anime später herunterladen</value>
+  </data>
+  <data name="Download_SeriesSearch" xml:space="preserve">
+    <value>Downloads für diese Serie suchen</value>
+  </data>
+  <data name="Download_Approval" xml:space="preserve">
+    <value>Zulassung!</value>
+  </data>
+  <data name="Download_YourVote" xml:space="preserve">
+    <value>Ihre Stimme</value>
+  </data>
+  <data name="Download_RecommendPrompt" xml:space="preserve">
+    <value>Dieses Dienstprogramm zeigt Ihnen eine Liste der empfohlenen Anime, die nicht in Ihrer Sammlung, die auf der Grundlage von Ihre eigenen Bewertungen und Feedback von Benutzern AniDB sind</value>
+  </data>
+  <data name="Torrent" xml:space="preserve">
+    <value>Schwall</value>
+  </data>
+  <data name="Torrents" xml:space="preserve">
+    <value>Schwalle</value>
+  </data>
+  <data name="Download_Name" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="Download_Size" xml:space="preserve">
+    <value>Größe</value>
+  </data>
+  <data name="Download_Seeders" xml:space="preserve">
+    <value>Sämaschinen</value>
+  </data>
+  <data name="Download_Leechers" xml:space="preserve">
+    <value>Blutegel</value>
+  </data>
+  <data name="Download_ExtraInfo" xml:space="preserve">
+    <value>Info-Markt</value>
+  </data>
+  <data name="Download_WrongSeries" xml:space="preserve">
+    <value>Falsch-Serie?</value>
+  </data>
+  <data name="Tooltip_WrongSeries" xml:space="preserve">
+    <value>Dies ist JMMs Versuch zu erraten, welche Serie Sie betrachten sind, so können Sie zu Ihrer lokalen Sammlung vergleichen. Wenn Sie nicht die Serie in Ihrer Sammlung haben, wird es falsch sein.</value>
+  </data>
+  <data name="Download_ResetCookie" xml:space="preserve">
+    <value>Cookie zurücksetzen</value>
+  </data>
+  <data name="Download_AnimeBytesOnly" xml:space="preserve">
+    <value>AnimeBytes nur für die Serie</value>
+  </data>
+  <data name="Download_BakaBTOnly" xml:space="preserve">
+    <value>BakaBT nur für die Serie</value>
+  </data>
+  <data name="Available" xml:space="preserve">
+    <value>Verfügbar</value>
+  </data>
+  <data name="Selected" xml:space="preserve">
+    <value>Ausgewählt</value>
+  </data>
+  <data name="Download_Source" xml:space="preserve">
+    <value>Quelle</value>
+  </data>
+  <data name="Download_Server" xml:space="preserve">
+    <value>Server</value>
+  </data>
+  <data name="Download_RefreshInterval" xml:space="preserve">
+    <value>Aktualisierungsintervall (Sekunden)</value>
+  </data>
+  <data name="Download_AutoRefresh" xml:space="preserve">
+    <value>Auto-Refresh</value>
+  </data>
+  <data name="Download_UseBlackHole" xml:space="preserve">
+    <value>Verwenden Sie Torrent Schwarzes Loch</value>
+  </data>
+  <data name="Download_FolderLocation" xml:space="preserve">
+    <value>Speicherort des Ordners</value>
+  </data>
+  <data name="Download_Hash" xml:space="preserve">
+    <value>Hash</value>
+  </data>
+  <data name="Download_Queue" xml:space="preserve">
+    <value>#</value>
+  </data>
+  <data name="Download_Done" xml:space="preserve">
+    <value>Fertig</value>
+  </data>
+  <data name="Download_Peers" xml:space="preserve">
+    <value>Gleichaltrigen</value>
+  </data>
+  <data name="Download_DownSpeed" xml:space="preserve">
+    <value>Geschwindigkeit</value>
+  </data>
+  <data name="Download_UpSpeed" xml:space="preserve">
+    <value>Upload-Geschwindigkeit</value>
+  </data>
+  <data name="Download_Ratio" xml:space="preserve">
+    <value>Verhältnis</value>
+  </data>
+  <data name="Download_InvalidCred" xml:space="preserve">
+    <value>Sie nicht uTorrent gültige Anmeldeinformationen angegeben.</value>
+  </data>
+  <data name="Download_EnterCred" xml:space="preserve">
+    <value>Bitte geben Sie Ihre Anmeldeinformationen auf der Registerkarte Einstellung und dann zurückkehren</value>
+  </data>
+  <data name="Download_Priority" xml:space="preserve">
+    <value>Priorität</value>
+  </data>
+  <data name="Download_Downloaded" xml:space="preserve">
+    <value>Heruntergeladen</value>
+  </data>
+  <data name="Settings_DeleteAction" xml:space="preserve">
+    <value>Löschvorgang</value>
+  </data>
+  <data name="Settings_AutoUpdateInfo" xml:space="preserve">
+    <value>Dateien mit fehlenden Informationen automatisch aktualisieren</value>
+  </data>
+  <data name="Settings_HideDownloadButton" xml:space="preserve">
+    <value>Ausblenden Sie Episode-Download-Button, wenn Sie Dateien bereits</value>
+  </data>
+  <data name="Settings_RecreateGroups" xml:space="preserve">
+    <value>Alle Gruppen neu zu erstellen</value>
+  </data>
+  <data name="Settings_ScanOnStart" xml:space="preserve">
+    <value>Drop-Ordner auf Start Scan</value>
+  </data>
+  <data name="Settings_ImagePath" xml:space="preserve">
+    <value>Image-Pfad</value>
+  </data>
+  <data name="Settings_SelectFolder" xml:space="preserve">
+    <value>Wählen Sie Ordner</value>
+  </data>
+  <data name="Settings_FilePort" xml:space="preserve">
+    <value>File-Port</value>
+  </data>
+  <data name="WebCache_TraktLinks" xml:space="preserve">
+    <value>Trakt Links</value>
+  </data>
+  <data name="VideoPlayer_MPC" xml:space="preserve">
+    <value>Media Player Classic</value>
+  </data>
+  <data name="VideoPlayer_MPCNote" xml:space="preserve">
+    <value>MPC-Integration, die Sie, zwei Optionen (1) Shop-Einstellungen ini-Datei und (2) halten Sie Geschichte der kürzlich aktivieren müssen beobachtete Dateien. Siehe folgenden Screenshot für weitere Details. Die Lage des MPC ist in der Regel so etwas wie C:\Program Files (X 86) \Combined Community Codec Pack\MPC</value>
+  </data>
+  <data name="VideoPlayer_MPCOptions" xml:space="preserve">
+    <value>MPC-Optionen</value>
+  </data>
+  <data name="VideoPlayer_VLC" xml:space="preserve">
+    <value>VLC</value>
+  </data>
+  <data name="VideoPlayer_VLCNote" xml:space="preserve">
+    <value>VLC 2.2 + zeichnet zuletzt geöffnete Dateien und Zeitstempeln standardmäßig (und deaktivieren ist eine Option "Erweitert"). Ältere Versionen unterstützen keine 'Resume aus der letzten Position'-Funktionalität. Die Lage des VLC-ini-Datei ist in der Regel so etwas wie C:\Users\username\AppData\Roaming\vlc\vlc-qt-interface.ini</value>
+  </data>
+  <data name="VideoPlayer_VLCOptions" xml:space="preserve">
+    <value>VLC-Optionen</value>
+  </data>
+  <data name="VideoPlayer_PotPlayer" xml:space="preserve">
+    <value>PotPlayer</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerNote" xml:space="preserve">
+    <value>PotPlayer Integration müssen Sie aktivieren folgende Optionen (1) Präferenzen &gt; allgemeine &gt; Shop-Einstellungen in der INI-Datei (2) Einstellungen &gt; Wiedergabe &gt; aus der späteste Zeitpunkt spielen. Siehe folgenden Screenshot für weitere Details. Die Lage der PlotPlayer ini-Datei ist in der Regel so etwas wie C:\Users\username\AppData\Roaming\PotPlayer64\PotPlayer64.ini</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerOptions" xml:space="preserve">
+    <value>PotPlayer Optionen</value>
+  </data>
+  <data name="VideoPlayer_MPCINI" xml:space="preserve">
+    <value>MPC-INI-Ordner auswählen</value>
+  </data>
+  <data name="VideoPlayer_VLCINI" xml:space="preserve">
+    <value>VLC-INI-Ordner auswählen</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerINI" xml:space="preserve">
+    <value>PotPlayer INI-Ordner auswählen</value>
+  </data>
+  <data name="VideoPlayer_MPCTest" xml:space="preserve">
+    <value>MPC-Testdatei</value>
+  </data>
+  <data name="VideoPlayer_VLCTest" xml:space="preserve">
+    <value>VLC-Testdatei</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerTest" xml:space="preserve">
+    <value>PotPlayer Testdatei</value>
+  </data>
+  <data name="VideoPlayer_AutoMark" xml:space="preserve">
+    <value>Automatisches Markieren von Dateien wie sah beim folgende Prozentsatz beobachtet wird</value>
+  </data>
+  <data name="VideoPlayer_MPCFolder" xml:space="preserve">
+    <value>MPC-INI-Ordner</value>
+  </data>
+  <data name="VideoPlayer_VLCFolder" xml:space="preserve">
+    <value>VLC-INI-Ordner</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerFolder" xml:space="preserve">
+    <value>PotPlayer INI-Ordner</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote1" xml:space="preserve">
+    <value>Automatische Datei-Auswahl "Einstellungen" - Dies bezieht sich auf Wenn Sie mehr als Datei für eine Episode haben</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote2" xml:space="preserve">
+    <value>Für eine Wiedergabeliste muss nur eine Datei zu wählen, die auf Sie "Einstellungen" unten basieren soll.</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote3" xml:space="preserve">
+    <value>Für eine einzelne Episode können automatische Datei-Auswahl aktivieren oder JMM fordert Sie eine Datei auswählen, wenn Sie mehr als eine haben</value>
+  </data>
+  <data name="VideoPlayer_AutoFileFirstEpisode" xml:space="preserve">
+    <value>Automatische Dateiauswahl - erste Episode in Serie</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNextEpisode" xml:space="preserve">
+    <value>Automatische Dateiauswahl - nachfolgende Episoden in Serie</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote4" xml:space="preserve">
+    <value>Bei Auswahl von "Release Group aus zuvor spielte Episode" in der oben genannten Einstellung müssen Sie auch Folgendes</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote5" xml:space="preserve">
+    <value>Deaktivieren Sie unter Einstellungen - Essential --Importeinstellungen "Set Datei wie sah wenn Folge beobachtet wird"</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote6" xml:space="preserve">
+    <value>Immer eine Datei wie sah Mark und keine episode</value>
+  </data>
+  <data name="VideoPlayer_AutoFileEnable" xml:space="preserve">
+    <value>Automatische Datei-Auswahl auf einzelne Episoden aktivieren</value>
+  </data>
+  <data name="TvDB_WideBannerMax" xml:space="preserve">
+    <value>Maximale Breite Banner</value>
+  </data>
+  <data name="TvDB_PostersMax" xml:space="preserve">
+    <value>Maximale Poster</value>
+  </data>
+  <data name="Trakt_Enable" xml:space="preserve">
+    <value>Trakt aktivieren</value>
+  </data>
+  <data name="Trakt_PIN" xml:space="preserve">
+    <value>Trakt PIN</value>
+  </data>
+  <data name="Trakt_GetPIN" xml:space="preserve">
+    <value>Pin erhalten</value>
+  </data>
+  <data name="Trakt_Authorize" xml:space="preserve">
+    <value>Autorisieren von JMM</value>
+  </data>
+  <data name="Trakt_CurrentToken" xml:space="preserve">
+    <value>Aktuellen Token ist gültig bis:</value>
+  </data>
+  <data name="Trakt_AutoFanart" xml:space="preserve">
+    <value>Auto Download Fanart!</value>
+  </data>
+  <data name="Trakt_AutoPosters" xml:space="preserve">
+    <value>Auto Download Poster!</value>
+  </data>
+  <data name="Trakt_AutoEpisodeImages" xml:space="preserve">
+    <value>Auto Download Episode Bilder</value>
+  </data>
+  <data name="MovieDB_MaxPosters" xml:space="preserve">
+    <value>Maximale Poster</value>
+  </data>
+  <data name="AnimeGroup_Random" xml:space="preserve">
+    <value>Zufällige Episode</value>
+  </data>
+  <data name="AnimeGroup_AllSeries" xml:space="preserve">
+    <value>Alle Serien</value>
+  </data>
+  <data name="AnimeGroup_DoubleClick" xml:space="preserve">
+    <value>Klicken Sie doppelt auf eine Reihe direkt anzeigen</value>
+  </data>
+  <data name="PinnedSeries_Simple" xml:space="preserve">
+    <value>Vereinfachte Ansicht anzeigen</value>
+  </data>
+  <data name="Playlist_Add" xml:space="preserve">
+    <value>Zur Playlist hinzufügen</value>
+  </data>
+  <data name="Series_Overview" xml:space="preserve">
+    <value>Übersicht</value>
+  </data>
+  <data name="Series_MoreInfo" xml:space="preserve">
+    <value>Weitere Informationen</value>
+  </data>
+  <data name="Series_CustomTags" xml:space="preserve">
+    <value>Benutzerdefinierte Tags</value>
+  </data>
+  <data name="Series_ManageCustom" xml:space="preserve">
+    <value>Verwalten von benutzerdefinierten Tags</value>
+  </data>
+  <data name="Series_Tag" xml:space="preserve">
+    <value>Tag</value>
+  </data>
+  <data name="Series_Add" xml:space="preserve">
+    <value>Hinzufügen</value>
+  </data>
+  <data name="Series_Files" xml:space="preserve">
+    <value>Dateien</value>
+  </data>
+  <data name="Series_Folder" xml:space="preserve">
+    <value>Ordner</value>
+  </data>
+  <data name="SeriesSimple_TraktLink" xml:space="preserve">
+    <value>Diese Episode auf Trakt.TV gehen</value>
+  </data>
+  <data name="SeriesSimple_Comments" xml:space="preserve">
+    <value>Kommentare</value>
+  </data>
+  <data name="SeriesSimple_Play" xml:space="preserve">
+    <value>Spielen</value>
+  </data>
+  <data name="SeriesSimple_Watched" xml:space="preserve">
+    <value>Beobachtete:</value>
+  </data>
+  <data name="SeriesSimple_From" xml:space="preserve">
+    <value>Von:</value>
+  </data>
+  <data name="SeriesSimple_AlreadyHave" xml:space="preserve">
+    <value>Sie haben bereits diese Anime in Ihrer Sammlung</value>
+  </data>
+  <data name="SeriesSimple_Details" xml:space="preserve">
+    <value>Informationen:</value>
+  </data>
+  <data name="SeriesSimple_Voteup" xml:space="preserve">
+    <value>Abstimmung bis</value>
+  </data>
+  <data name="SeriesSimple_VoteDown" xml:space="preserve">
+    <value>Stimmen nach unten</value>
+  </data>
+  <data name="SeriesSimple_FromTrakt" xml:space="preserve">
+    <value>Von Trakt</value>
+  </data>
+  <data name="SeriesSimple_View" xml:space="preserve">
+    <value>Anzeigen</value>
+  </data>
+  <data name="SeriesSimple_FromAniDB" xml:space="preserve">
+    <value>Von AniDB</value>
+  </data>
+  <data name="SeriesSimple_Aired" xml:space="preserve">
+    <value>Ausgestrahlt wurde</value>
+  </data>
+  <data name="SeriesSimple_Episodes" xml:space="preserve">
+    <value>Folgen</value>
+  </data>
+  <data name="SeriesSimple_MyVote" xml:space="preserve">
+    <value>Meine Stimme</value>
+  </data>
+  <data name="SeriesSimple_PlayNext" xml:space="preserve">
+    <value>Nächste Episode zu spielen</value>
+  </data>
+  <data name="SeriesSimple_PlayUnWatched" xml:space="preserve">
+    <value>Spielen Sie alle unbewacht)</value>
+  </data>
+  <data name="SeriesSimple_YourSay" xml:space="preserve">
+    <value>Haben Sie Ihr sagen...</value>
+  </data>
+  <data name="SeriesSimple_Spoiler" xml:space="preserve">
+    <value>Verkleidungsscheibe</value>
+  </data>
+  <data name="SeriesSimple_CommentTrakt" xml:space="preserve">
+    <value>Kommentar am Trakt</value>
+  </data>
+  <data name="SeriesSimple_Characters" xml:space="preserve">
+    <value>Zeichen</value>
+  </data>
+  <data name="SeriesSimple_AlsoLike" xml:space="preserve">
+    <value>Sie können auch gerne</value>
+  </data>
+  <data name="SeriesSimple_PeopleSaying" xml:space="preserve">
+    <value>Was die Leute sagen</value>
+  </data>
+  <data name="SeriesSimple_Loading" xml:space="preserve">
+    <value>Wird geladen...</value>
+  </data>
+  <data name="AvDump_Remove" xml:space="preserve">
+    <value>Aus Liste entfernen</value>
+  </data>
+  <data name="AvDump_Clear" xml:space="preserve">
+    <value>Liste leeren</value>
+  </data>
+  <data name="AvDump_Dump" xml:space="preserve">
+    <value>Dump-Dateien</value>
+  </data>
+  <data name="Bookmarks_Downloading" xml:space="preserve">
+    <value>Download</value>
+  </data>
+  <data name="Bookmarks_NotDownloading" xml:space="preserve">
+    <value>Nicht herunterladen</value>
+  </data>
+  <data name="Dashboard_YourVote" xml:space="preserve">
+    <value>Ihre Stimme</value>
+  </data>
+  <data name="Dashboard_Bookmark" xml:space="preserve">
+    <value>Bookmarken Sie diese Anime später herunterladen</value>
+  </data>
+  <data name="Dashboard_Download" xml:space="preserve">
+    <value>Downloads für diese Serie suchen</value>
+  </data>
+  <data name="Dashboard_NoRecommend" xml:space="preserve">
+    <value>Keine Empfehlungen gefunden.</value>
+  </data>
+  <data name="Dashboard_DownloadVotes" xml:space="preserve">
+    <value>Laden Sie jetzt Ihre Stimme, oder Abstimmung über ein Anime Empfehlungen anfangen.</value>
+  </data>
+  <data name="Dashboard_SyncVotes" xml:space="preserve">
+    <value>Sync-Stimmen</value>
+  </data>
+  <data name="Dashboard_Added" xml:space="preserve">
+    <value>Hinzugefügt</value>
+  </data>
+  <data name="Dashboard_Metro" xml:space="preserve">
+    <value>Metro-Dashboard</value>
+  </data>
+  <data name="Dashboard_UpdateCalendar" xml:space="preserve">
+    <value>Kalenderdaten aktualisieren</value>
+  </data>
+  <data name="Dashboard_Recent" xml:space="preserve">
+    <value>Jüngsten Ergänzungen</value>
+  </data>
+  <data name="Metro_Options" xml:space="preserve">
+    <value>Optionen</value>
+  </data>
+  <data name="Metro_General" xml:space="preserve">
+    <value>Allgemeine</value>
+  </data>
+  <data name="Metro_ImageType" xml:space="preserve">
+    <value>Image-Typ</value>
+  </data>
+  <data name="Metro_Sections" xml:space="preserve">
+    <value>Abschnitte</value>
+  </data>
+  <data name="Metro_Items" xml:space="preserve">
+    <value>Elemente</value>
+  </data>
+  <data name="Metro_Refresh" xml:space="preserve">
+    <value>Erfrischen</value>
+  </data>
+  <data name="PlayVideo" xml:space="preserve">
+    <value>Video abspielen</value>
+  </data>
+  <data name="Episode_MoreInfo" xml:space="preserve">
+    <value>Mehr Info...</value>
+  </data>
+  <data name="Episode_LessInfo" xml:space="preserve">
+    <value>Weniger Info...</value>
+  </data>
+  <data name="Episode_Manual" xml:space="preserve">
+    <value>Manuelle Verknüpfung</value>
+  </data>
+  <data name="Episode_ForceAniDBUpdate" xml:space="preserve">
+    <value>Kraft-Update-Informationen von AniDB</value>
+  </data>
+  <data name="Episode_RecalculateHash" xml:space="preserve">
+    <value>Hash neu berechnen</value>
+  </data>
+  <data name="Episode_Hash" xml:space="preserve">
+    <value>Hash</value>
+  </data>
+  <data name="Episode_CRC32" xml:space="preserve">
+    <value>CRC32</value>
+  </data>
+  <data name="Episode_SHA1" xml:space="preserve">
+    <value>SHA1</value>
+  </data>
+  <data name="Episode_MD5" xml:space="preserve">
+    <value>MD5</value>
+  </data>
+  <data name="Episode_DownloadSearch" xml:space="preserve">
+    <value>Suche downloads für diese episode</value>
+  </data>
+  <data name="Episode_PlaylistAdd" xml:space="preserve">
+    <value>Zur Playlist hinzufügen</value>
+  </data>
+  <data name="Episode_TvDBOverride" xml:space="preserve">
+    <value>Überschreiben Sie, die TvDB für diese episode</value>
+  </data>
+  <data name="Episode_TvDBRemove" xml:space="preserve">
+    <value>Entfernen Sie die Verknüpfung TvDB für diese episode</value>
+  </data>
+  <data name="Episode_AniDBForceUpdate" xml:space="preserve">
+    <value>Kraft-Update-Informationen von AniDB</value>
+  </data>
+  <data name="Episode_Type" xml:space="preserve">
+    <value>Typ</value>
+  </data>
+  <data name="Episode_Availability" xml:space="preserve">
+    <value>Verfügbarkeit</value>
+  </data>
+  <data name="Episode_WatchedState" xml:space="preserve">
+    <value>Überwachten Zustand</value>
+  </data>
+  <data name="Rename_Script" xml:space="preserve">
+    <value>Skript</value>
+  </data>
+  <data name="Rename_New" xml:space="preserve">
+    <value>Neu!</value>
+  </data>
+  <data name="Rename_Save" xml:space="preserve">
+    <value>SPEICHERN</value>
+  </data>
+  <data name="Rename_Delete" xml:space="preserve">
+    <value>Löschen</value>
+  </data>
+  <data name="Rename_Tag" xml:space="preserve">
+    <value>Tag</value>
+  </data>
+  <data name="Rename_Add" xml:space="preserve">
+    <value>Hinzufügen</value>
+  </data>
+  <data name="Rename_Test" xml:space="preserve">
+    <value>Test</value>
+  </data>
+  <data name="Rename_ScriptingHelp" xml:space="preserve">
+    <value>Helfen mit scripting</value>
+  </data>
+  <data name="Rename_ImportRun" xml:space="preserve">
+    <value>Führen Sie dieses Skript beim Importieren von Dateien in Sammlung</value>
+  </data>
+  <data name="Rename_Filter" xml:space="preserve">
+    <value>Filter:</value>
+  </data>
+  <data name="Rename_Clear" xml:space="preserve">
+    <value>Klar</value>
+  </data>
+  <data name="Rename_AddFiles" xml:space="preserve">
+    <value>Dateien hinzufügen</value>
+  </data>
+  <data name="Rename_Rename" xml:space="preserve">
+    <value>Jetzt umbenennen</value>
+  </data>
+  <data name="Rename_Preview" xml:space="preserve">
+    <value>Vorschau</value>
+  </data>
+  <data name="FileSearch_Rescan" xml:space="preserve">
+    <value>Neu einlesen</value>
+  </data>
+  <data name="FileSearch_AniDBForceUpdate" xml:space="preserve">
+    <value>Kraft-Update-Informationen von AniDB</value>
+  </data>
+  <data name="GroupFilter_RandomSeries" xml:space="preserve">
+    <value>Zufällige Serie</value>
+  </data>
+  <data name="GroupFilter_RandomEpisode" xml:space="preserve">
+    <value>Zufällige Episode</value>
+  </data>
+  <data name="IgnoredAnime_Delete" xml:space="preserve">
+    <value>Diesen Eintrag löschen</value>
+  </data>
+  <data name="IgnoredAnime_Note" xml:space="preserve">
+    <value>Dieses Dienstprogramm zeigt Ihnen den Anime, die, den Sie, um von den Empfehlungen gewählt haben zu ignorieren. Diese Einträge löschen bedeutet, dass sie wieder in Empfehlungen zeigen können.</value>
+  </data>
+  <data name="ImportFolder_Watched" xml:space="preserve">
+    <value>Dieser Ordner ist für neue Dateien beobachtet</value>
+  </data>
+  <data name="MissingEpisodes_SelectColumns" xml:space="preserve">
+    <value>Wählen Sie die Spalten in den Import verwendet werden</value>
+  </data>
+  <data name="MissingEpisodes_AiringState" xml:space="preserve">
+    <value>Lüften-Status:</value>
+  </data>
+  <data name="RefreshWait" xml:space="preserve">
+    <value>Durch Drücken der Schaltfläche "Aktualisieren" kann mehrere Minuten dauern, also bitte etwas Geduld</value>
+  </data>
+  <data name="MissingEpisodes_Note" xml:space="preserve">
+    <value>Dieses Dienstprogramm wird Ihnen eine Zusammenfassung aller Ihrer fehlenden Episoden zeigen.</value>
+  </data>
+  <data name="MissingMyList_Missing" xml:space="preserve">
+    <value>Fehlende Datei anzeigen</value>
+  </data>
+  <data name="MissingMyList_RemoveAll" xml:space="preserve">
+    <value>Entfernen Sie alle Einträge aus AniDB</value>
+  </data>
+  <data name="MissingMyList_Note" xml:space="preserve">
+    <value>Dieses Dienstprogramm wird Ihre Liste von Dateien von AniDB herunterladen und vergleichen Sie sie mit den Dateien lokal. Sie haben dann die Möglichkeit, diese Dateien aus AniDB zu entfernen, wenn diese nicht vorhanden sind.</value>
+  </data>
+  <data name="Episode" xml:space="preserve">
+    <value>Folge</value>
+  </data>
+  <data name="Playlist_Random" xml:space="preserve">
+    <value>Zufällige Episode</value>
+  </data>
+  <data name="Playlist_Default" xml:space="preserve">
+    <value>Standard-Abspielreihenfolge</value>
+  </data>
+  <data name="Playlist_Items" xml:space="preserve">
+    <value>Elemente der Wiedergabeliste</value>
+  </data>
+  <data name="PlayNext_Hidden" xml:space="preserve">
+    <value>Verborgen um Spoiler zu vermeiden</value>
+  </data>
+  <data name="Rankings_Overall" xml:space="preserve">
+    <value>Von insgesamt Benutzerbewertung</value>
+  </data>
+  <data name="Rankings_GroupedByYear" xml:space="preserve">
+    <value>Gruppiert nach Jahr</value>
+  </data>
+  <data name="Rankings_CollectionState" xml:space="preserve">
+    <value>Collection-Zustand</value>
+  </data>
+  <data name="Rankings_Voted" xml:space="preserve">
+    <value>Stimmten</value>
+  </data>
+  <data name="Rankings_Completed" xml:space="preserve">
+    <value>Abgeschlossen</value>
+  </data>
+  <data name="Rankings_Anime" xml:space="preserve">
+    <value> Anime</value>
+  </data>
+  <data name="Rankings_AniDB" xml:space="preserve">
+    <value>AniDB Bewertung!</value>
+  </data>
+  <data name="Rankings_User" xml:space="preserve">
+    <value>Deine Bewertung</value>
+  </data>
+  <data name="Rankings_Year" xml:space="preserve">
+    <value>Jahr</value>
+  </data>
+  <data name="Rankings_View" xml:space="preserve">
+    <value>Blick-Serie</value>
+  </data>
+  <data name="Rankings_MyVote" xml:space="preserve">
+    <value>Meine Stimme</value>
+  </data>
+  <data name="Related_Bookmark" xml:space="preserve">
+    <value>Bookmarken Sie diese Anime später herunterladen</value>
+  </data>
+  <data name="Related_Search" xml:space="preserve">
+    <value>Downloads für diese Serie suchen</value>
+  </data>
+  <data name="SeriesWithoutFiles_Delete" xml:space="preserve">
+    <value>Diese Serie aus der Datenbank löschen</value>
+  </data>
+  <data name="SeriesWithoutFiles_Note" xml:space="preserve">
+    <value>Dieses Dienstprogramm zeigen Ihnen alle Serien die keine Dateien verfügen. Löschen der Serie wird die Gruppe auch löschen, wenn keine andere Serie in dieser Gruppe Dateien haben.</value>
+  </data>
+  <data name="TraktShouts_View" xml:space="preserve">
+    <value>Anzeigen</value>
+  </data>
+  <data name="TraktShouts_FromAniDB" xml:space="preserve">
+    <value>Von AniDB</value>
+  </data>
+  <data name="TraktShouts_Spoiler" xml:space="preserve">
+    <value>Verkleidungsscheibe</value>
+  </data>
+  <data name="TraktShouts_Loading" xml:space="preserve">
+    <value>Wird geladen...</value>
+  </data>
+  <data name="TraktShouts_Comments" xml:space="preserve">
+    <value>Kommentare</value>
+  </data>
+  <data name="CommunityLinks_Start" xml:space="preserve">
+    <value>Start:</value>
+  </data>
+  <data name="CommunityLinks_Edit" xml:space="preserve">
+    <value>Details bearbeiten</value>
+  </data>
+  <data name="CommunityLinks_AniDBStart" xml:space="preserve">
+    <value>AniDB Start:</value>
+  </data>
+  <data name="CommunityLinks_TvDB" xml:space="preserve">
+    <value>TvDB: </value>
+  </data>
+  <data name="CommunityLinks_Trakt" xml:space="preserve">
+    <value>Trakt: </value>
+  </data>
+  <data name="CommunityLinks_TMDb" xml:space="preserve">
+    <value>Der Film DB!</value>
+  </data>
+  <data name="CommunityLinks_MAL" xml:space="preserve">
+    <value>MyAnimeList</value>
+  </data>
+  <data name="CommunityLinks_AutoLink" xml:space="preserve">
+    <value>Automatische Verknüpfung</value>
+  </data>
+  <data name="Tooltip_DeleteTitle" xml:space="preserve">
+    <value>Löschen</value>
+  </data>
+  <data name="Tooltip_DeleteInfo" xml:space="preserve">
+    <value>Diese Verknüpfung löschen</value>
+  </data>
+  <data name="Tooltip_EditTitle" xml:space="preserve">
+    <value>Bearbeiten</value>
+  </data>
+  <data name="Tooltip_EditInfo" xml:space="preserve">
+    <value>Bearbeiten Sie die Informationen über diesen Link</value>
+  </data>
+  <data name="Tooltip_UpdateTitle" xml:space="preserve">
+    <value>Update</value>
+  </data>
+  <data name="Tooltip_UpdateTvDB" xml:space="preserve">
+    <value>Frische Daten von The TvDB herunterladen und Aktualisieren der lokalen Datenbank</value>
+  </data>
+  <data name="Tooltip_ReportLinkTitle" xml:space="preserve">
+    <value>Link-Fehler melden</value>
+  </data>
+  <data name="Tooltip_ReportLinkInfo" xml:space="preserve">
+    <value>Wenn dies der falsche Serie verbunden ist klicken Sie hier, um die Entwickler wissen lassen</value>
+  </data>
+  <data name="Tooltip_UpdateTrakt" xml:space="preserve">
+    <value>Frische Daten von Trakt herunterladen und Aktualisieren der lokalen Datenbank</value>
+  </data>
+  <data name="Tooltip_Sync" xml:space="preserve">
+    <value>Sync</value>
+  </data>
+  <data name="Tooltip_SyncTrakt" xml:space="preserve">
+    <value>Synchronisieren Sie Ihre Sammlung und Geschichte Daten mit Trakt</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTitle" xml:space="preserve">
+    <value>Automatische Verknüpfung deaktiviert</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTvDB" xml:space="preserve">
+    <value>Automatische Verlinkung von dieser Anime zu einer Reihe TvDB ist derzeit deaktiviert.</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTitle" xml:space="preserve">
+    <value>Automatische Verknüpfung aktiviert</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTvDB" xml:space="preserve">
+    <value>Automatische Verlinkung von dieser Anime zu einer Reihe TvDB ist zurzeit aktiviert. JMM-Server findet eine enge Übereinstimmung oder Gemeinschaft-Empfehlung wird es automatisch eine Verknüpfung erstellen.</value>
+  </data>
+  <data name="CommunityLinks_TraktTV" xml:space="preserve">
+    <value>Trakt TV</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTrakt" xml:space="preserve">
+    <value>Automatische Verknüpfung von dieser Anime ein Trakt-Serie ist derzeit deaktiviert.</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTrakt" xml:space="preserve">
+    <value>Automatische Verknüpfung von dieser Anime zu einer Reihe Trakt ist zurzeit aktiviert. JMM-Server findet eine enge Übereinstimmung oder Gemeinschaft-Empfehlung wird es automatisch eine Verknüpfung erstellen.</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledMAL" xml:space="preserve">
+    <value>Automatische Verknüpfung von dieser Anime MAL-Serie ist derzeit deaktiviert.</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledMAL" xml:space="preserve">
+    <value>Automatische Verlinkung von dieser Anime zu einer Reihe MAL ist zurzeit aktiviert. JMM-Server findet eine enge Übereinstimmung oder Gemeinschaft-Empfehlung wird es automatisch eine Verknüpfung erstellen.</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTMDb" xml:space="preserve">
+    <value>Automatische Verknüpfung von dieser Anime eine MovieDB-Reihe ist derzeit deaktiviert.</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTMDb" xml:space="preserve">
+    <value>Automatische Verknüpfung von dieser Anime eine MovieDB-Reihe ist derzeit aktiviert. JMM-Server findet eine enge Übereinstimmung oder Gemeinschaft-Empfehlung wird es automatisch eine Verknüpfung erstellen.</value>
+  </data>
+  <data name="Tooltip_CommunityAdminTitle" xml:space="preserve">
+    <value>Gemeinschaft-Admin</value>
+  </data>
+  <data name="Tooltip_CommunityAdminInfo" xml:space="preserve">
+    <value>Gehen Sie zur Registerkarte Admin Gemeinschaft und bearbeiten Sie die empfohlene Links für diese anime</value>
+  </data>
+  <data name="Unrecognized_Rescan" xml:space="preserve">
+    <value>Neu einlesen</value>
+  </data>
+  <data name="Unrecognized_ForceAniDB" xml:space="preserve">
+    <value>Kraft-Update-Informationen von AniDB</value>
+  </data>
+  <data name="Unrecognized_Hash" xml:space="preserve">
+    <value>Hash</value>
+  </data>
+  <data name="Unrecognized_CRC32" xml:space="preserve">
+    <value>CRC32</value>
+  </data>
+  <data name="Unrecognized_Rehash" xml:space="preserve">
+    <value>Alle Re-hash</value>
+  </data>
+  <data name="Unrecognized_Logs" xml:space="preserve">
+    <value>Protokolle</value>
+  </data>
+  <data name="Unrecognized_NA" xml:space="preserve">
+    <value>NA</value>
+  </data>
+  <data name="Unrecognized_RefreshSeries" xml:space="preserve">
+    <value>Serie-Liste aktualisieren</value>
+  </data>
+  <data name="Unrecognized_To" xml:space="preserve">
+    <value>An</value>
+  </data>
+  <data name="UpdateAniDB_UpdateLocal" xml:space="preserve">
+    <value>Lokale AniDB Datei Daten aktualisieren</value>
+  </data>
+  <data name="UpdateAniDB_Info1" xml:space="preserve">
+    <value>Angaben zu den Dateien ist von AniDB heruntergeladen und dann in Ihrer lokalen Datenbank gespeichert, wenn Sie zuerst eine Datei importieren. In einigen Fällen können diese Daten nicht abgeschlossen, wenn Sie es zunächst herunterladen. Oder zusätzliche Daten heruntergeladen, aber neuere Versionen von JMM. Dieses Dienstprogramm können Sie eine neue Kopie dieser Informationen von AniDB erhalten</value>
+  </data>
+  <data name="UpdateAniDB_MissingInfo" xml:space="preserve">
+    <value>Aktualisieren von Dateien mit fehlenden Informationen</value>
+  </data>
+  <data name="UpdateAniDB_Info2" xml:space="preserve">
+    <value>Fehlende Daten bezieht sich meist auf fehlende Informationen zu Codec und Lösungen. Sie können sehen, Auflösung: 0 x 0 neben diese Dateien</value>
+  </data>
+  <data name="UpdateAniDB_Version" xml:space="preserve">
+    <value>Update-Dateien für interne Version 2</value>
+  </data>
+  <data name="UpdateAniDB_Info3" xml:space="preserve">
+    <value>Interne Version 2 hinzugefügt die folgende Informationen - File-Version (v2, v3 usw.), wird zensiert, ist veraltet</value>
+  </data>
+  <data name="UpdateAniDB_Info4" xml:space="preserve">
+    <value>Zu viele Befehle an AniDB zu senden, kann zu ein zeitweiligen Verbot führen. Verwenden Sie auf eigene Gefahr</value>
+  </data>
+  <data name="UpdateAniDB_HowManyQueued" xml:space="preserve">
+    <value>Wie viele Befehle in eine Warteschlange gestellt werden?</value>
+  </data>
+  <data name="UpdateAniDB_Queued" xml:space="preserve">
+    <value>Queue-Befehle</value>
+  </data>
+  <data name="User_HideTags" xml:space="preserve">
+    <value>Tags ausblenden</value>
+  </data>
+  <data name="User_ChangePassword" xml:space="preserve">
+    <value>Passwort ändern</value>
+  </data>
+  <data name="Sort_Error" xml:space="preserve">
+    <value>Fehler beim Sortieren </value>
+  </data>
+  <data name="Sort_Using" xml:space="preserve">
+    <value> Verwendung </value>
+  </data>
+  <data name="Sort_Property" xml:space="preserve">
+    <value>Eigenschaft </value>
+  </data>
+  <data name="Sort_Field" xml:space="preserve">
+    <value>Feld </value>
+  </data>
+  <data name="Sort_Exception" xml:space="preserve">
+    <value>Ausnahme in MultiSort beim Sortieren einer Liste von </value>
+  </data>
+  <data name="Sort_PassedEmpty" xml:space="preserve">
+    <value>MultiSort Parameter RgSortBy wurde ein leeres Feldname im RgSortBy [verabschiedet</value>
+  </data>
+  <data name="Selected_DoesNotExist" xml:space="preserve">
+    <value>Die angegebene Datei oder den Ordner existiert nicht: </value>
+  </data>
+  <data name="ValueCompare_PropertyName" xml:space="preserve">
+    <value>Eigenschaftennamen </value>
+  </data>
+  <data name="ValueCompare_NotFound" xml:space="preserve">
+    <value> nicht gefunden Sie beim Versuch, Objekte vom Typ vergleichen </value>
+  </data>
+  <data name="ValueCompare_FieldName" xml:space="preserve">
+    <value>Feldname </value>
+  </data>
+  <data name="Video_VLCError1" xml:space="preserve">
+    <value>Nicht URI in VLC-Ini-Datei analysieren</value>
+  </data>
+  <data name="Video_VLCError2" xml:space="preserve">
+    <value>Unterscheiden sich die Anzahl der zuletzt verwendeten Dateien und Zeitstempel in der Ini-Datei mit VLC</value>
+  </data>
+  <data name="Video_Complete" xml:space="preserve">
+    <value>Komplette</value>
+  </data>
+  <data name="Video_Position" xml:space="preserve">
+    <value>Video Position für</value>
+  </data>
+  <data name="Video_HasChanged" xml:space="preserve">
+    <value>wurde zu geändert</value>
+  </data>
+  <data name="Video_Updating" xml:space="preserve">
+    <value>Fortschreibung von MediaPlayer beobachtet: </value>
+  </data>
+  <data name="AniDB_DataMissing" xml:space="preserve">
+    <value>Daten fehlen</value>
+  </data>
+  <data name="AniDB_Votes" xml:space="preserve">
+    <value>Bewertungen</value>
+  </data>
+  <data name="AniDB_GotVids" xml:space="preserve">
+    <value>Bekam Vids für Anime vom Dienst:</value>
+  </data>
+  <data name="AniDB_In" xml:space="preserve">
+    <value>in</value>
+  </data>
+  <data name="AniDB_ForFans" xml:space="preserve">
+    <value>Für Fans</value>
+  </data>
+  <data name="AniDB_Recommended" xml:space="preserve">
+    <value>Empfohlen</value>
+  </data>
+  <data name="AniDB_MustSee" xml:space="preserve">
+    <value>Müssen Sie unbedingt sehen</value>
+  </data>
+  <data name="AniDB_Collecting" xml:space="preserve">
+    <value>Sammeln:</value>
+  </data>
+  <data name="AniDB_Files" xml:space="preserve">
+    <value>Dateien:</value>
+  </data>
+  <data name="AnimeEpisode_Previous" xml:space="preserve">
+    <value>Vorherige Folge</value>
+  </data>
+  <data name="AnimeEpisode_Next" xml:space="preserve">
+    <value>Nächste Episode</value>
+  </data>
+  <data name="AnimeEpisode_NoOverview" xml:space="preserve">
+    <value>Folge-Übersicht nicht verfügbar</value>
+  </data>
+  <data name="Anime_Groups" xml:space="preserve">
+    <value>Gruppen</value>
+  </data>
+  <data name="Anime_Series" xml:space="preserve">
+    <value>Serie</value>
+  </data>
+  <data name="Anime_GroupName" xml:space="preserve">
+    <value>Gruppenname muss gefüllt werden</value>
+  </data>
+  <data name="Anime_SortName" xml:space="preserve">
+    <value>Name sortieren muss gefüllt werden</value>
+  </data>
+  <data name="Anime_GotVids" xml:space="preserve">
+    <value>Bekam Vids für Anime vom Dienst:</value>
+  </data>
+  <data name="Anime_GotEpisodes" xml:space="preserve">
+    <value>Habe Episodendaten vom Dienst:</value>
+  </data>
+  <data name="Anime_In" xml:space="preserve">
+    <value>in</value>
+  </data>
+  <data name="Anime_Contracts" xml:space="preserve">
+    <value>Folge-Aufträge bekam:</value>
+  </data>
+  <data name="Anime_Sorted" xml:space="preserve">
+    <value>Folge-Aufträge sortiert:</value>
+  </data>
+  <data name="AVDump_ToBe" xml:space="preserve">
+    <value>Verarbeitet werden</value>
+  </data>
+  <data name="Group_Groups" xml:space="preserve">
+    <value>Gruppen</value>
+  </data>
+  <data name="Group_FilterName" xml:space="preserve">
+    <value>Filtername aufgefüllt werden muss</value>
+  </data>
+  <data name="Ignore_RecDown" xml:space="preserve">
+    <value>Empfehlungen - Download</value>
+  </data>
+  <data name="Ignore_RecWatch" xml:space="preserve">
+    <value>Empfehlungen - Watch</value>
+  </data>
+  <data name="Ignore_AnimeID" xml:space="preserve">
+    <value>Anime-ID:</value>
+  </data>
+  <data name="JMMServer_TraktAuth" xml:space="preserve">
+    <value>Trakt Auth</value>
+  </data>
+  <data name="JMMServer_Success" xml:space="preserve">
+    <value>Erfolg</value>
+  </data>
+  <data name="JMMServer_Error" xml:space="preserve">
+    <value>Fehler</value>
+  </data>
+  <data name="Missing_Episode" xml:space="preserve">
+    <value>Folge</value>
+  </data>
+  <data name="Missing_File" xml:space="preserve">
+    <value>Datei</value>
+  </data>
+  <data name="Playlist_Name" xml:space="preserve">
+    <value>Playlist-Namen eingeben: </value>
+  </data>
+  <data name="Playlist_NameBlank" xml:space="preserve">
+    <value>Bitte geben Sie einen Namen der Wiedergabeliste</value>
+  </data>
+  <data name="Recommendation_Missing" xml:space="preserve">
+    <value>Daten fehlen</value>
+  </data>
+  <data name="Recommendation_NoOverview" xml:space="preserve">
+    <value>Übersicht nicht verfügbar</value>
+  </data>
+  <data name="uTorrent_NotConnected" xml:space="preserve">
+    <value>Nicht verbunden</value>
+  </data>
+  <data name="uTorrent_Connecting" xml:space="preserve">
+    <value>Verbindung wird hergestellt...</value>
+  </data>
+  <data name="Constants_Continue" xml:space="preserve">
+    <value>Weiter beobachten (SYSTEM)</value>
+  </data>
+  <data name="Constants_MainCharacter" xml:space="preserve">
+    <value>Hauptfigur in</value>
+  </data>
+  <data name="Group_GroupCount" xml:space="preserve">
+    <value> Gruppen</value>
+  </data>
+  <data name="Tab_Playlists" xml:space="preserve">
+    <value>Playlisten</value>
+  </data>
+  <data name="Playlist_NewPlaylist" xml:space="preserve">
+    <value>Neue Playlist</value>
+  </data>
+  <data name="Tab_Bookmarks" xml:space="preserve">
+    <value>Lesezeichen</value>
+  </data>
+  <data name="JMMServer_ImportFolders" xml:space="preserve">
+    <value>Import-Ordner!</value>
+  </data>
+  <data name="JMMServer_ServerStatus" xml:space="preserve">
+    <value>Server-Status</value>
+  </data>
+  <data name="Tooltip_ClearHash" xml:space="preserve">
+    <value>Deaktivieren Sie alle in der Warteschlange Hash-Befehle</value>
+  </data>
+  <data name="JMMServer_Running" xml:space="preserve">
+    <value>Ausführen</value>
+  </data>
+  <data name="JMMServer_Paused" xml:space="preserve">
+    <value>Angehalten</value>
+  </data>
+  <data name="Tooltip_ClearGeneral" xml:space="preserve">
+    <value>Deaktivieren Sie alle in der Warteschlange allgemeine Befehle</value>
+  </data>
+  <data name="Tooltip_ClearImages" xml:space="preserve">
+    <value>Deaktivieren Sie alle in der Warteschlange Bild herunterladen Serverbefehle</value>
+  </data>
+  <data name="JMMServer_ServerImage" xml:space="preserve">
+    <value>Server-Images-Warteschlange</value>
+  </data>
+  <data name="Tab_AniDBAVDump" xml:space="preserve">
+    <value>AniDB AV Dump</value>
+  </data>
+  <data name="Tab_FileSearch" xml:space="preserve">
+    <value>Dateisuche</value>
+  </data>
+  <data name="Tab_FileRename" xml:space="preserve">
+    <value>Umbenennen von Dateien</value>
+  </data>
+  <data name="Tab_UpdateAniDB" xml:space="preserve">
+    <value>AniDB Daten aktualisieren</value>
+  </data>
+  <data name="Tab_CommunityData" xml:space="preserve">
+    <value>Gemeinschaft-Daten</value>
+  </data>
+  <data name="Tab_MyVotes" xml:space="preserve">
+    <value>Meine Stimmen</value>
+  </data>
+  <data name="VideoPlayer_MPCI" xml:space="preserve">
+    <value>Media Player Classic Integration</value>
+  </data>
+  <data name="VideoPlayer_AutoFile" xml:space="preserve">
+    <value>Automatische Datei-Auswahl</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_MAL" xml:space="preserve">
+    <value>Meine Anime-Liste</value>
+  </data>
+  <data name="Tab_Downloads" xml:space="preserve">
+    <value>Downloads</value>
+  </data>
+  <data name="Downloads_uTorrentInfo" xml:space="preserve">
+    <value>Dies verwendet die uTorrent WebUI-API, die müssen Sie zuerst in Ihrem uTorrent-Client aktivieren</value>
+  </data>
+  <data name="Downloads_uTorrentWebUI" xml:space="preserve">
+    <value>uTorrent WebUI Informationen</value>
+  </data>
+  <data name="Downloads_TorrentBlackHole" xml:space="preserve">
+    <value>Schwall-Black-Hole-Einstellungen</value>
+  </data>
+  <data name="Downloads_TorrentDefault" xml:space="preserve">
+    <value>Standard-Torrent-Quellen für die Suche</value>
+  </data>
+  <data name="Downloads_BakaBT" xml:space="preserve">
+    <value>BakaBT Einstellungen</value>
+  </data>
+  <data name="Downloads_AnimeBytes" xml:space="preserve">
+    <value>AnimeBytes Einstellungen</value>
+  </data>
+  <data name="Downloads_BakaBTInfo" xml:space="preserve">
+    <value>BakaBT ist ein Anime-Torrent-Site, die vollständige Reihe Downloads, spezialisiert, aber es zunächst ein Konto erfordert</value>
+  </data>
+  <data name="Downloads_AnimeBytesInfo" xml:space="preserve">
+    <value>AnimeBytes ist ein Anime-Torrent-Site, die vollständige Reihe Downloads, spezialisiert, aber es zunächst ein Konto erfordert</value>
+  </data>
+  <data name="Downloads_GoTo" xml:space="preserve">
+    <value>Zur Website</value>
+  </data>
+  <data name="Tab_Search" xml:space="preserve">
+    <value>Suche!</value>
+  </data>
+  <data name="Tab_Community" xml:space="preserve">
+    <value>Gemeinschaft</value>
+  </data>
+  <data name="Main_Messages" xml:space="preserve">
+    <value>Nachrichten</value>
+  </data>
+  <data name="Main_Paused" xml:space="preserve">
+    <value>Angehalten wegen Verbot von AniDB)</value>
+  </data>
+  <data name="Main_User" xml:space="preserve">
+    <value>Benutzer</value>
+  </data>
+  <data name="Main_Feed" xml:space="preserve">
+    <value>Füttern</value>
+  </data>
+  <data name="Main_About" xml:space="preserve">
+    <value>Über</value>
+  </data>
+  <data name="Tooltip_LanguageUseSynonyms" xml:space="preserve">
+    <value>Auch Synonyme aus ausgewählten bevorzugte Sprache für die Anzeige der Serie und Gruppen. Englisch und Romaji Synonyme werden nicht verwendet</value>
+  </data>
+  <data name="Up" xml:space="preserve">
+    <value>Bis</value>
+  </data>
+  <data name="GroupFilterConditions" xml:space="preserve">
+    <value>Filterbedingungen</value>
+  </data>
+  <data name="GroupFilterConditionType" xml:space="preserve">
+    <value>Konditionsart</value>
+  </data>
+  <data name="GroupFilterConditionType_AirDate" xml:space="preserve">
+    <value>Erstausstrahlung</value>
+  </data>
+  <data name="GroupFilterConditionType_AllEpisodesWatched" xml:space="preserve">
+    <value>Alle Episoden beobachtet</value>
+  </data>
+  <data name="GroupFilterConditionType_AnimeGroup" xml:space="preserve">
+    <value>Gruppe</value>
+  </data>
+  <data name="GroupFilterConditionType_AnimeType" xml:space="preserve">
+    <value>Anime-Typ</value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedTvDBInfo" xml:space="preserve">
+    <value>Hat TvDB Link</value>
+  </data>
+  <data name="GroupFilterConditionType_Category" xml:space="preserve">
+    <value>Kategorie</value>
+  </data>
+  <data name="GroupFilterConditionType_CompletedSeries" xml:space="preserve">
+    <value>Abgeschlossene Serie</value>
+  </data>
+  <data name="GroupFilterConditionType_Favourite" xml:space="preserve">
+    <value>Favorit</value>
+  </data>
+  <data name="GroupFilterConditionType_HasUnwatchedEpisodes" xml:space="preserve">
+    <value>Hat Episoden Unwatched</value>
+  </data>
+  <data name="GroupFilterConditionType_MissingEpisodes" xml:space="preserve">
+    <value>Fehlende Episoden!</value>
+  </data>
+  <data name="GroupFilterConditionType_ReleaseGroup" xml:space="preserve">
+    <value>Freigabegruppe</value>
+  </data>
+  <data name="GroupFilterConditionType_Studio" xml:space="preserve">
+    <value>Studio</value>
+  </data>
+  <data name="GroupFilterConditionType_Tag" xml:space="preserve">
+    <value>Tag</value>
+  </data>
+  <data name="GroupFilterConditionType_UserVoted" xml:space="preserve">
+    <value>Benutzer, die abgestimmt (Perm)</value>
+  </data>
+  <data name="GroupFilterConditionType_VideoQuality" xml:space="preserve">
+    <value>Video-Qualität</value>
+  </data>
+  <data name="GroupFilterOperator" xml:space="preserve">
+    <value>Operator</value>
+  </data>
+  <data name="GroupFilterOperator_Equals" xml:space="preserve">
+    <value>Gleich ist</value>
+  </data>
+  <data name="GroupFilterOperator_Exclude" xml:space="preserve">
+    <value>Ausschließen</value>
+  </data>
+  <data name="GroupFilterOperator_GreaterThan" xml:space="preserve">
+    <value>Größer als oder gleich</value>
+  </data>
+  <data name="GroupFilterOperator_Include" xml:space="preserve">
+    <value>Enthalten</value>
+  </data>
+  <data name="GroupFilterOperator_LessThan" xml:space="preserve">
+    <value>Kleiner oder gleich</value>
+  </data>
+  <data name="GroupFilterOperator_NotEquals" xml:space="preserve">
+    <value>Ungleich</value>
+  </data>
+  <data name="GroupFilterSorting" xml:space="preserve">
+    <value>Sortieren</value>
+  </data>
+  <data name="ImageSize_GroupList" xml:space="preserve">
+    <value>Gruppen und Serien Liste</value>
+  </data>
+  <data name="ImageSize_SeriesPoster" xml:space="preserve">
+    <value>Serie Poster</value>
+  </data>
+  <data name="ImageSize_SubGroupList" xml:space="preserve">
+    <value>Sub-Gruppen Liste und Reihe</value>
+  </data>
+  <data name="INFO_SettingsDisplayStyle" xml:space="preserve">
+    <value>Sie müssen Ihre Gruppenliste um zu sehen, die Auswirkungen der Änderungen zu aktualisieren.</value>
+  </data>
+  <data name="MSG_ERR_SelectDate" xml:space="preserve">
+    <value>Wählen Sie zuerst ein Datum</value>
+  </data>
+  <data name="NewGroupFilter" xml:space="preserve">
+    <value>Neue Gruppenfilter</value>
+  </data>
+  <data name="RenameGroups" xml:space="preserve">
+    <value>Alle Gruppen umbenennen</value>
+  </data>
+  <data name="Style_GroupList" xml:space="preserve">
+    <value>Gruppenliste</value>
+  </data>
+  <data name="Style_GroupList_MediumDetail" xml:space="preserve">
+    <value>Mittlere Details</value>
+  </data>
+  <data name="Style_GroupList_Simple" xml:space="preserve">
+    <value>Einfache</value>
+  </data>
+  <data name="TAB_SettingsImageSizes" xml:space="preserve">
+    <value>Bildgrößen</value>
+  </data>
+  <data name="TAB_SettingsStyle" xml:space="preserve">
+    <value>Stile</value>
+  </data>
+  <data name="Tooltip_ImageSize_GroupList" xml:space="preserve">
+    <value>Die Bilder in der Hauptliste angezeigt wird, wenn die Gruppen und Serien anzeigen</value>
+  </data>
+  <data name="Tooltip_ImageSize_SeriesPoster" xml:space="preserve">
+    <value>Die Abbildungen auf der rechten für die Serie, die Zugehörigkeit zu einer Gruppe</value>
+  </data>
+  <data name="Tooltip_ImageSize_SubGroupList" xml:space="preserve">
+    <value>Die Bilder in der Hauptliste angezeigt, wenn Sie Untergruppen oder Serie anzeigen</value>
+  </data>
+  <data name="Tooltip_Style_GroupList" xml:space="preserve">
+    <value>Der Stil der Gruppen bei der Anzeige in der Hauptliste (auch Untergruppen)</value>
+  </data>
+  <data name="FilterValue" xml:space="preserve">
+    <value>Filterwert</value>
+  </data>
+  <data name="MSG_ERR_EnterValue" xml:space="preserve">
+    <value>Bitte geben Sie einen Wert</value>
+  </data>
+  <data name="PreviewFilter" xml:space="preserve">
+    <value>Vorschau der Filterergebnisse</value>
+  </data>
+  <data name="GroupFilter_ApplyToSeries" xml:space="preserve">
+    <value>Wenden Sie Filter auf Ebene der Serie statt Gruppenebene</value>
+  </data>
+  <data name="GroupFilter_BaseCondition" xml:space="preserve">
+    <value>Basis-Bedingung</value>
+  </data>
+  <data name="GroupFilter_BaseCondition_ExcludeAll" xml:space="preserve">
+    <value>Alle ausgeschlossen werden sollen</value>
+  </data>
+  <data name="GroupFilter_BaseCondition_IncludeAll" xml:space="preserve">
+    <value>Umfassen Sie alle</value>
+  </data>
+  <data name="Tooltip_GroupFilter_BaseCondition" xml:space="preserve">
+    <value>Schließen Sie alle, so dass alle Gruppen standardmäßig enthalten sind. Alle ausgeschlossen werden sollen, so dass keine Gruppen enthalten sind, dies soll verwendet werden, wenn Sie manuell die Gruppen auf Basis Indvidual angeben möchten.</value>
+  </data>
+  <data name="GroupFilterOperator_In" xml:space="preserve">
+    <value>In</value>
+  </data>
+  <data name="GroupFilterOperator_NotIn" xml:space="preserve">
+    <value>Nicht In</value>
+  </data>
+  <data name="GroupFilter_Category_Help" xml:space="preserve">
+    <value>Klicken Sie doppelt auf Catgeories sie die ausgewählte Liste hinzu</value>
+  </data>
+  <data name="GroupFilterConditionType_AniDBRating" xml:space="preserve">
+    <value>Rating von-AniDB</value>
+  </data>
+  <data name="GroupFilterConditionType_UserRating" xml:space="preserve">
+    <value>Bewertung - Benutzer</value>
+  </data>
+  <data name="MSG_ERR_RatingValue" xml:space="preserve">
+    <value>Bewertung muss ein Wert zwischen 0 und 10 sein. Dezimalkommas dürfen.</value>
+  </data>
+  <data name="ScanFolder" xml:space="preserve">
+    <value>Diesen Ordner jetzt Scannen</value>
+  </data>
+  <data name="GroupFilterConditionType_EpisodeAddedDate" xml:space="preserve">
+    <value>Folge hinzugefügt Datum</value>
+  </data>
+  <data name="GroupFilterConditionType_EpisodeWatchedDate" xml:space="preserve">
+    <value>Folge sah Datum</value>
+  </data>
+  <data name="GroupFilterConditionType_SeriesDate" xml:space="preserve">
+    <value>Serie hinzugefügt Datum</value>
+  </data>
+  <data name="GroupFilterOperator_LastXDays" xml:space="preserve">
+    <value>'X' Tage letzten</value>
+  </data>
+  <data name="SelectDate" xml:space="preserve">
+    <value>Wählen Sie Datum</value>
+  </data>
+  <data name="MSG_ERR_DaysValue" xml:space="preserve">
+    <value>Bitte geben Sie die Anzahl der Tage, als Ganzzahl (Minimum ist 1)</value>
+  </data>
+  <data name="SyncVotes" xml:space="preserve">
+    <value>Sync AniDB Stimmen</value>
+  </data>
+  <data name="UserVote" xml:space="preserve">
+    <value>Meine Stimme</value>
+  </data>
+  <data name="VoteNow" xml:space="preserve">
+    <value>Jetzt abstimmen</value>
+  </data>
+  <data name="VoteRevoke" xml:space="preserve">
+    <value>Widerrufen</value>
+  </data>
+  <data name="GroupFilterConditionType_FinishedAiring" xml:space="preserve">
+    <value>Fertige lüften</value>
+  </data>
+  <data name="VoteTypeAnimePermanent" xml:space="preserve">
+    <value>Permanente</value>
+  </data>
+  <data name="VoteTypeAnimeTemporary" xml:space="preserve">
+    <value>Temporäre</value>
+  </data>
+  <data name="AniDBMyListLocalActions" xml:space="preserve">
+    <value>Aktionen vor Ort</value>
+  </data>
+  <data name="AniDBMyListSyncAndImport" xml:space="preserve">
+    <value>MyList Sync und Importoptionen</value>
+  </data>
+  <data name="EpisodeMarkAllUnwatched" xml:space="preserve">
+    <value>Mark allen unbewacht</value>
+  </data>
+  <data name="EpisodeMarkAllWatched" xml:space="preserve">
+    <value>Mark allen überwachten</value>
+  </data>
+  <data name="EpisodeMarkAllWatchedPrevious" xml:space="preserve">
+    <value>Alle vorherigen markieren beobachtete einschließlich EP #</value>
+  </data>
+  <data name="GroupFilter_VideoQuality_Help" xml:space="preserve">
+    <value>Klicken Sie doppelt auf die Einträge der Liste hinzufügen</value>
+  </data>
+  <data name="GroupFilterConditionType_MissingEpisodesCollecting" xml:space="preserve">
+    <value>Fehlende Episoden (sammeln)</value>
+  </data>
+  <data name="GroupFilterOperator_InAllEpisodes" xml:space="preserve">
+    <value>(Alle Episoden)</value>
+  </data>
+  <data name="GroupFilterOperator_NotInAllEpisodes" xml:space="preserve">
+    <value>Nicht In (alle Episoden)</value>
+  </data>
+  <data name="GroupFilterConditionType_AudioLanguage" xml:space="preserve">
+    <value>Audio-Sprache</value>
+  </data>
+  <data name="GroupFilterConditionType_SubtitleLanguage" xml:space="preserve">
+    <value>Untertitelsprache</value>
+  </data>
+  <data name="GroupFilterSortDirection_Asc" xml:space="preserve">
+    <value>ASC</value>
+  </data>
+  <data name="GroupFilterSortDirection_Desc" xml:space="preserve">
+    <value>DESC</value>
+  </data>
+  <data name="GroupFilterSorting_AniDBRating" xml:space="preserve">
+    <value>AniDB Bewertung!</value>
+  </data>
+  <data name="GroupFilterSorting_EpisodeAddedDate" xml:space="preserve">
+    <value>Folge hinzugefügt Datum</value>
+  </data>
+  <data name="GroupFilterSorting_EpisodeAirDate" xml:space="preserve">
+    <value>Folge-Luft-Datum</value>
+  </data>
+  <data name="GroupFilterSorting_EpisodeWatchedDate" xml:space="preserve">
+    <value>Folge sah Datum</value>
+  </data>
+  <data name="GroupFilterSorting_GroupName" xml:space="preserve">
+    <value>Gruppenname</value>
+  </data>
+  <data name="GroupFilterSorting_MissingEpisodeCount" xml:space="preserve">
+    <value>Fehlende Episode Count</value>
+  </data>
+  <data name="GroupFilterSorting_SeriesAddedDate" xml:space="preserve">
+    <value>Serie hinzugefügt Datum</value>
+  </data>
+  <data name="GroupFilterSorting_SeriesCount" xml:space="preserve">
+    <value>Serie Count</value>
+  </data>
+  <data name="GroupFilterSorting_UnwatchedEpisodeCount" xml:space="preserve">
+    <value>Ungesehene Episode Count</value>
+  </data>
+  <data name="GroupFilterSorting_UserRating" xml:space="preserve">
+    <value>User-Rating</value>
+  </data>
+  <data name="GroupFilterSorting_Year" xml:space="preserve">
+    <value>Jahr</value>
+  </data>
+  <data name="GroupFilterSorting_SortName" xml:space="preserve">
+    <value>Namen sortieren!</value>
+  </data>
+  <data name="GroupFilterDirection" xml:space="preserve">
+    <value>Richtung</value>
+  </data>
+  <data name="GroupFilterSortType" xml:space="preserve">
+    <value>Sortierungsart</value>
+  </data>
+  <data name="QuickSort" xml:space="preserve">
+    <value>Schnellsortierung</value>
+  </data>
+  <data name="TAB_DuplicateFiles" xml:space="preserve">
+    <value>Doppelte Dateien</value>
+  </data>
+  <data name="INFO_DuplicateFiles" xml:space="preserve">
+    <value>Doppelte Dateien sind, wo Sie zwei oder mehr Dateien haben, die genau gleich sind, außer sie in verschiedenen Ordnern sind oder sind anders benannt. JMM erlaubt nur eine Datei mit dem gleichen Hash in der Auflistung.</value>
+  </data>
+  <data name="Tooltip_DeleteDuplicateFileAll" xml:space="preserve">
+    <value>Löschen Sie der Datenbankeintrag und die ausgewählte Datei auf dem Datenträger.</value>
+  </data>
+  <data name="Tooltip_DeleteDuplicateFileEntry" xml:space="preserve">
+    <value>Löschen Sie den Datenbankeintrag nur. Dateien auf der Festplatte bleiben unberührt.</value>
+  </data>
+  <data name="Tab_uTorrent" xml:space="preserve">
+    <value>uTorrent</value>
+  </data>
+  <data name="Tab_BrowseTorrents" xml:space="preserve">
+    <value>Durchsuchen Torrents</value>
+  </data>
+  <data name="Tab_SearchTorrents" xml:space="preserve">
+    <value>Suche Torrents</value>
+  </data>
+  <data name="Tab_Recommendations" xml:space="preserve">
+    <value>Empfehlungen</value>
+  </data>
+  <data name="Tab_Settings" xml:space="preserve">
+    <value>Einstellungen</value>
+  </data>
+  <data name="Tab_SeriesInfo" xml:space="preserve">
+    <value>Serien-Info</value>
+  </data>
+  <data name="Tab_Comments" xml:space="preserve">
+    <value>Kommentare von Anwendern</value>
+  </data>
+  <data name="Tab_Files" xml:space="preserve">
+    <value>Dateien</value>
+  </data>
+  <data name="Download_TorrentFolder" xml:space="preserve">
+    <value>Torrent Mappe Ort</value>
+  </data>
+  <data name="Search_TitleOnly" xml:space="preserve">
+    <value>TEST TEST TEST</value>
+  </data>
 </root>

--- a/JMMClient/Properties/Resources.en-gb.resx
+++ b/JMMClient/Properties/Resources.en-gb.resx
@@ -123,10 +123,2143 @@
   <data name="GroupFilter_Favorites" xml:space="preserve">
     <value>Favourites</value>
   </data>
-  <data name="SortName" xml:space="preserve">
-    <value>Sorted By</value>
-  </data>
   <data name="TAB_UnrecognisedFiles" xml:space="preserve">
     <value>Unrecognised Files</value>
+  </data>
+  <data name="AniDBRating" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDBVoteCount" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episodes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="EpisodeType" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="EpisodeType_Credits" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="EpisodeType_Normal" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="EpisodeType_Other" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="EpisodeType_Parody" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="EpisodeType_Specials" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="EpisodeType_Trailer" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilter_All" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="IsWatched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MyRating" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Refresh" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="RunTime" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Series" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_Config" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_Episodes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_FileManager" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_Images" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_Relations" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_SeriesEpisodes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_Server" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_TvDB" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ViewLabel" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Back" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Language" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Delete" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="RunImport" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AnimeTitles" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AnimeTitlesMain" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AnimeTitlesOfficial" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AnimeTitlesShort" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AnimeTitlesSynonym" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Categories" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tags" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="CategoryWeighting" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TagApproval" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episodes_AvAll" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episodes_AvMissing" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episodes_AvOnly" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episodes_Watched_All" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episodes_Watched_Unwatched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episodes_Watched_Watched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Play" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_FileFound" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_FileNotFound" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_FutureDated" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_Unwatched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_Watched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_ZeroFiles" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Unwatched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Watched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rating" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Votes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AnimeType_Movie" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AnimeType_Other" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AnimeType_OVA" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AnimeType_TVSeries" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AnimeType_TVSpecial" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AnimeType_Web" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Ongoing" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="To" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="LastWatched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Today" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Yesterday" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupsAvailableFrom" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Missing" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_MissingEps" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_MissingEpsGroups" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_QueueImages" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Specials" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilter_Missing" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="RemoveMissingFiles" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ServerActions" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="NewGroup" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AllFilters" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Filter" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Group" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AddSubGroup" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Edit" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SubGroup" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="NewSeries" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MoveSeries" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MoveToGroup" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="OK" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="QueueGeneral" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="QueueHasher" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_QueueGeneral" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_QueueHasher" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Pause" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Resume" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Video_Bluray" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Video_DVD" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Video_FullHD" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Video_HD" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="NewFolder" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="DropDestination" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="DropSource" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ImportFolderName" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ImportFolderPath" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="LocalMapping" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="LocalPath" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ServerDetails" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MSG_ERR_DropSourceDestCheck" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MSG_ERR_ImportFolderLocationCheck" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Confirm" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="NothingSelected" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SelectSeriesEp" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AssociateFile" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Ignore" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="OpenFolder" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MSG_ERR_FileNotFound" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="FilesSelected" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="StartingEpisodeNumber" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Existing" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SelectGroup" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SelectAnime" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="New" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupName" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDBID" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MSG_ERR_AnimeIDRequired" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MSG_ERR_AnimeSelectionRequired" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MSG_ERR_GroupNameRequired" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MSG_ERR_GroupSelectionRequired" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MSG_ERR_InvalidEpGetAnime" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MSG_ERR_InvalidEp" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="DeleteLink" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_DeleteLink" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_IgnoredFiles" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Restore" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_ManuallyLinked" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDBLogin" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Client" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ImportFolders" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="JMMServer" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Port" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Server" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ServerPath" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_SettingsAniDB" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_SettingsDisplay" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_SettingsEssential" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_SettingsOnlineDB" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Test" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TestAndSave" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Success" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="INFO_SettingsEssential" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Search" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_GroupSearch" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDBDownloadChar" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDBDownloadOptions" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDBDownloadRelated" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDBDownloadReleaseGroups" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDBDownloadReviews" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDBDownloadSimilar" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDBMyListAddFiles" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDBMylistOptions" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDBMyListReadUnwatched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDBMyListReadWatched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDBMyListSetUnwatched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDBMyListSetWatched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDBMyListState" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_AniDBDownloadChar" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_AniDBDownloadRelated" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_AniDBDownloadReleaseGroups" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_AniDBDownloadReviews" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_AniDBDownloadSimilar" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_AniDBMyListAddFiles" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_AniDBMyListReadUnwatched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_AniDBMyListReadWatched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_AniDBMyListSetUnwatched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_AniDBMyListSetWatched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_AniDBMyListState" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SyncMyList" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rehash" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MSG_INFO_AddedQueueCmds" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MultiTypeRange" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MultiTypeSingle" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDBScheduleCalendar" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDBScheduleHTTP" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDBScheduleMyList" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDBScheduleOptions" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_AniDBScheduleCalendar" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_AniDBScheduleHTTP" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_AniDBScheduleMyList" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_SettingsWebCache" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="DetailedInformationLink" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Get" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="INFO_SettingsWebCache" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Send" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_WebCache_Anonymous" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_WebCache_FileEpisodes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_WebCache_FileHashes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_WebCache_TvDBAssociations" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TvDB_FanartAutoDownload" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TvDB_FanartCount" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TvDB_PosterAutoDownload" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TvDB_WideBannerAutoDownload" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="WebCache_Anonymous" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="WebCache_FileEpisodes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="WebCache_FileHashes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="WebCache_TvDBAssociations" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_MovieDB" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_TvDB" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_TvDB_FanartAutoDownload" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_TvDB_FanartCount" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_TvDB_PosterAutoDownload" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_TvDB_WideBannerAutoDownload" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ImportSettings_HashCRC32" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ImportSettings_HashMD5" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ImportSettings_ImportOnStart" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ImportSettings_SHA1" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ImportSettings_VideoExtensions" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ImportSettings_WatchFiles" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MovieDB_FanartAutoDownload" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MovieDB_FanartCount" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MovieDB_PosterAutoDownload" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_Settings_ImportSettings" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_MovieDB_FanartAutoDownload" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_MovieDB_FanartCount" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_MovieDB_PosterAutoDownload" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Down" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="LanguageUseSynonyms" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_Settings_Language" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_LanguageUseSynonyms" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Up" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditions" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_AirDate" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_AllEpisodesWatched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_AnimeGroup" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_AnimeType" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedTvDBInfo" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_Category" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_CompletedSeries" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_Favourite" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_HasUnwatchedEpisodes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_MissingEpisodes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_ReleaseGroup" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_Studio" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_Tag" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_UserVoted" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_VideoQuality" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterOperator" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterOperator_Equals" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterOperator_Exclude" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterOperator_GreaterThan" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterOperator_Include" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterOperator_LessThan" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterOperator_NotEquals" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterSorting" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ImageSize_GroupList" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ImageSize_SeriesPoster" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ImageSize_SubGroupList" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="INFO_SettingsDisplayStyle" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MSG_ERR_SelectDate" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="NewGroupFilter" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="RenameGroups" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Style_GroupList" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Style_GroupList_MediumDetail" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Style_GroupList_Simple" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_SettingsImageSizes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_SettingsStyle" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_ImageSize_GroupList" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_ImageSize_SeriesPoster" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_ImageSize_SubGroupList" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_Style_GroupList" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="FilterValue" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MSG_ERR_EnterValue" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="PreviewFilter" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilter_ApplyToSeries" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilter_BaseCondition" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilter_BaseCondition_ExcludeAll" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilter_BaseCondition_IncludeAll" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_GroupFilter_BaseCondition" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterOperator_In" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterOperator_NotIn" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilter_Category_Help" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_AniDBRating" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_UserRating" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MSG_ERR_RatingValue" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ScanFolder" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_EpisodeAddedDate" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_EpisodeWatchedDate" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_SeriesDate" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterOperator_LastXDays" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SelectDate" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MSG_ERR_DaysValue" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SyncVotes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="UserVote" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="VoteNow" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="VoteRevoke" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_FinishedAiring" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="VoteTypeAnimePermanent" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="VoteTypeAnimeTemporary" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDBMyListLocalActions" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDBMyListSyncAndImport" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="EpisodeMarkAllUnwatched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="EpisodeMarkAllWatched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="EpisodeMarkAllWatchedPrevious" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilter_VideoQuality_Help" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_MissingEpisodesCollecting" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterOperator_InAllEpisodes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterOperator_NotInAllEpisodes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_AudioLanguage" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_SubtitleLanguage" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterSortDirection_Asc" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterSortDirection_Desc" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterSorting_AniDBRating" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterSorting_EpisodeAddedDate" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterSorting_EpisodeAirDate" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterSorting_EpisodeWatchedDate" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterSorting_GroupName" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterSorting_MissingEpisodeCount" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterSorting_SeriesAddedDate" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterSorting_SeriesCount" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterSorting_UnwatchedEpisodeCount" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterSorting_UserRating" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterSorting_Year" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterDirection" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterSortType" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="QuickSort" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_DuplicateFiles" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="INFO_DuplicateFiles" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_DeleteDuplicateFileAll" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_DeleteDuplicateFileEntry" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Files" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ReevaluateDuplicateFiles" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_ReevaluateDuplicateFiles" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_MultipleFiles" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="INFO_MultipleFiles" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TotalFileCount" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ImportSettings_UseEpisodeStatus" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_TvDB_Schedule_Updates" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TvDB_Schedule_Updates" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="RescanAll" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="DeleteAll" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="CrossRefSummary" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="FileSummary" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TheTvDB" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SeasonNumber" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="CommunityRecommendation" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TvDBSearchPrompt" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TvDBShow" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="UseThis" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SwitchSeason" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDB" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="UpdateAniDBInfo" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="UpdateInfo" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ImageSize_EpisodeImage" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_ImageSize_EpisodeImage" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="EpisodeDetailStyle" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="EpisodeDetailStyle_Option1" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="EpisodeDetailStyle_Option2" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="EpisodeDetailStyle_Option3" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="HideEpisodeImageWhenUnwatched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="HideEpisodeOverviewWhenUnwatched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_HideEpisodeImageWhenUnwatched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_HideEpisodeOverviewWhenUnwatched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Fanart" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Images" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Image_Disabled" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Image_Dynamic" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Image_Enabled" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Image_Static" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Image_View" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Posters" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="WideBanners" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TheMovieDB" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MovieDBShow" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MovieDBSearchPrompt" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedTvDBOrMovieDBInfo" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedMovieDBInfo" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Image_Default" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Image_NotDefault" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="PlayNextEpisode" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AllEpisodesWatched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="FinishEditing" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_Dashboard" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Dash_WatchNextEp_Recent" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="DeleteSeries" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="DeleteSeriesConfirm" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="DeleteSeriesConfirm_Files" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Dash_SeriesMissingEps" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="LatestEp_Anime" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="LatestEp_Yours" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MissingEpisodeCount" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Dash_MiniCalendar" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ImageSize" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="INFO_SettingsUserAdmin" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_SettingsUsers" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="User_HideCategories" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="User_IsAdmin" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="User_Password" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="User_Username" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Items" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Days" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="DashWatchNextStyle_Detailed" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="DashWatchNextStyle_Simple" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_Trakt" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Trakt_Password" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Trakt_Username" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="UpdateFrequency" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="UpdateFrequency_12Hours" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="UpdateFrequency_6Hours" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="UpdateFrequency_Daily" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="UpdateFrequency_Never" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TraktSyncFrequency" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TraktSearchPrompt" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TraktShow" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_Pinned" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_ViewSeries" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_UserVotedAny" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_User_IsAniDB" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="User_IsAniDB" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="User_IsTrakt" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ERROR_SeriesExists" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_CreateSeries" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SimilarAnime" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="RelatedAndSimilar" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GetMissingData" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="NoSimilarAnime" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="NoRelatedAnime" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="RelatedAnime" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Dash_RecWatch" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Dash_RecDownload" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ImportSettings_AutoGroupSeries" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_HasWatchedEpisodes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MyList" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_MyList" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_MissingFiles" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_Utilities" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_SeriesWithoutFiles" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="DeleteSeriesConfirm_Groups" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Export" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_MissingEpisodes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MyGroupsOnly" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="RegularEpisodesOnly" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Dash_TraktFriends" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_IgnoreAnimeDownload" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_IgnoreAnimeWatch" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="VisitWebsite" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AniDBSignup" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AvdumpHeader" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AvdumpInfoLink" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AvdumpKey" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AvdumpKeyEditLink" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Avdump" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AvdumpRequiredFilesLink" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AvdumpSettingsError" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AvdumpAddRelease" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="CopyED2KClipboard" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_CopyED2KClipboard" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_IgnoredAnime" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Anime" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="RemoveDefaultSeries" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SetDefaultSeries" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="DefSeries1" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="DefSeries2" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="DefSeries3" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ChangeLanguage" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="EpisodeTitleSourceStyle" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SeriesNameSourceStyle" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SeriesOverviewSourceStyle" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_EpisodeTitleSourceStyle" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_SeriesNameSourceStyle" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_SeriesOverviewSourceStyle" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="User_EditSettings" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_RemoveMissingFiles" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_UpdateMediaInfo" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="UpdateMediaInfo" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Video_Hi10P" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_TraktAnimeOnly" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TraktAnimeOnly" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ForceRefresh" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TraktFriendNotes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Dash_RecentEpisodes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="PromptRateSeries" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_PromptRateSeries" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MALSearchPrompt" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MALShow" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_WebCache_MALAssociations" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="WebCache_MALAssociations" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_MAL_UpdateFrequency" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedMALInfo" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_UseFanartOnSeries" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="UseFanartOnSeries" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MAL_NeverDecrease" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_MAL_NeverDecrease" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilterConditionType_EpisodeCount" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SyncMalDown" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SeriesSimple_Episodes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SeriesSimple_MyVote" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SeriesSimple_PlayNext" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SeriesSimple_PlayUnWatched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SeriesSimple_YourSay" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SeriesSimple_Spoiler" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SeriesSimple_CommentTrakt" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SeriesSimple_Characters" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SeriesSimple_AlsoLike" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SeriesSimple_PeopleSaying" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SeriesSimple_Loading" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AvDump_Remove" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AvDump_Clear" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AvDump_Dump" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Bookmarks_Downloading" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Bookmarks_NotDownloading" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Dashboard_YourVote" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Dashboard_Bookmark" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Dashboard_Download" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Dashboard_NoRecommend" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Dashboard_DownloadVotes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Dashboard_SyncVotes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Dashboard_Added" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Dashboard_Metro" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Dashboard_UpdateCalendar" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Dashboard_Recent" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Metro_Options" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Metro_General" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Metro_ImageType" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Metro_Sections" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Metro_Items" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Metro_Refresh" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="PlayVideo" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episode_MoreInfo" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episode_LessInfo" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episode_Manual" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episode_ForceAniDBUpdate" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episode_RecalculateHash" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episode_Hash" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episode_CRC32" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episode_SHA1" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episode_MD5" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episode_DownloadSearch" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episode_PlaylistAdd" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episode_TvDBOverride" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episode_TvDBRemove" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episode_AniDBForceUpdate" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episode_Type" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episode_Availability" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episode_WatchedState" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rename_Script" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rename_New" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rename_Save" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rename_Delete" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rename_Tag" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rename_Add" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rename_Test" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rename_ScriptingHelp" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rename_ImportRun" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rename_Filter" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rename_Clear" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rename_AddFiles" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rename_Rename" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rename_Preview" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="FileSearch_Rescan" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="FileSearch_AniDBForceUpdate" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilter_RandomSeries" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="GroupFilter_RandomEpisode" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="IgnoredAnime_Delete" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="IgnoredAnime_Note" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="ImportFolder_Watched" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MissingEpisodes_SelectColumns" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MissingEpisodes_AiringState" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="RefreshWait" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MissingEpisodes_Note" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MissingMyList_Missing" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MissingMyList_RemoveAll" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="MissingMyList_Note" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Episode" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Playlist_Random" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Playlist_Default" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Playlist_Items" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="PlayNext_Hidden" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rankings_Overall" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rankings_GroupedByYear" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rankings_CollectionState" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rankings_Voted" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rankings_Completed" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rankings_Anime" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rankings_AniDB" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rankings_User" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rankings_Year" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rankings_View" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Rankings_MyVote" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Related_Bookmark" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Related_Search" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SeriesWithoutFiles_Delete" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SeriesWithoutFiles_Note" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TraktShouts_View" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TraktShouts_FromAniDB" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TraktShouts_Spoiler" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TraktShouts_Loading" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TraktShouts_Comments" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="CommunityLinks_Start" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="CommunityLinks_Edit" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="CommunityLinks_AniDBStart" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="CommunityLinks_TvDB" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="CommunityLinks_Trakt" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="CommunityLinks_TMDb" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="CommunityLinks_MAL" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="CommunityLinks_AutoLink" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_DeleteTitle" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_DeleteInfo" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_EditTitle" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_EditInfo" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_UpdateTitle" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_UpdateTvDB" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_ReportLinkTitle" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_ReportLinkInfo" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_UpdateTrakt" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_Sync" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_SyncTrakt" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTitle" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTvDB" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTitle" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTvDB" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTMDb" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_CommunityAdminTitle" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_CommunityAdminInfo" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Unrecognized_Rescan" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Unrecognized_ForceAniDB" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Unrecognized_Hash" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Unrecognized_CRC32" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Unrecognized_Rehash" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Unrecognized_Logs" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Unrecognized_NA" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Unrecognized_RefreshSeries" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Unrecognized_To" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="UpdateAniDB_UpdateLocal" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="UpdateAniDB_Info1" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="UpdateAniDB_MissingInfo" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="UpdateAniDB_Info2" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="UpdateAniDB_Version" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="UpdateAniDB_Info3" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="UpdateAniDB_Info4" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="UpdateAniDB_HowManyQueued" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="UpdateAniDB_Queued" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="User_ChangePassword" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Anime_GroupName" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Anime_SortName" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Anime_GotVids" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Anime_GotEpisodes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Anime_In" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Anime_Contracts" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Anime_Sorted" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="AVDump_ToBe" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Group_Groups" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Group_FilterName" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Ignore_RecDown" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Ignore_RecWatch" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Ignore_AnimeID" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="JMMServer_TraktAuth" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="JMMServer_Success" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="JMMServer_Error" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Missing_Episode" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Missing_File" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Playlist_Name" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Playlist_NameBlank" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Recommendation_Missing" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Recommendation_NoOverview" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="uTorrent_NotConnected" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="uTorrent_Connecting" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Constants_Continue" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Constants_MainCharacter" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Group_GroupCount" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tab_Playlists" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Playlist_NewPlaylist" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tab_Bookmarks" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="JMMServer_ImportFolders" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="JMMServer_ServerStatus" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_ClearHash" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="JMMServer_Running" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="JMMServer_Paused" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_ClearGeneral" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tooltip_ClearImages" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="JMMServer_ServerImage" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tab_AniDBAVDump" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tab_FileSearch" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tab_FileRename" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tab_UpdateAniDB" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tab_CommunityData" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tab_MyVotes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="VideoPlayer_MPCI" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="VideoPlayer_AutoFile" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_MAL" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tab_Downloads" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Downloads_uTorrentInfo" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Downloads_uTorrentWebUI" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Downloads_TorrentBlackHole" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Downloads_TorrentDefault" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Downloads_BakaBT" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Downloads_AnimeBytes" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Downloads_BakaBTInfo" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Downloads_AnimeBytesInfo" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Downloads_GoTo" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tab_Search" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Tab_Community" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Main_Messages" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Main_Paused" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Main_User" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Main_Feed" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="Main_About" xml:space="preserve">
+    <value></value>
   </data>
 </root>

--- a/JMMClient/Properties/Resources.es.resx
+++ b/JMMClient/Properties/Resources.es.resx
@@ -1,0 +1,3179 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AirDate" xml:space="preserve">
+    <value>Fecha de aire</value>
+  </data>
+  <data name="AniDBRating" xml:space="preserve">
+    <value>AniDB calificación</value>
+  </data>
+  <data name="AniDBVoteCount" xml:space="preserve">
+    <value>Recuento de votos de AniDB</value>
+  </data>
+  <data name="Episodes" xml:space="preserve">
+    <value>Episodios</value>
+  </data>
+  <data name="EpisodeType" xml:space="preserve">
+    <value>Tipo de episodio</value>
+  </data>
+  <data name="EpisodeType_Credits" xml:space="preserve">
+    <value>Créditos</value>
+  </data>
+  <data name="EpisodeType_Normal" xml:space="preserve">
+    <value>Episodios</value>
+  </data>
+  <data name="EpisodeType_Other" xml:space="preserve">
+    <value>Otros</value>
+  </data>
+  <data name="EpisodeType_Parody" xml:space="preserve">
+    <value>Parodia</value>
+  </data>
+  <data name="EpisodeType_Specials" xml:space="preserve">
+    <value>Ofertas especiales</value>
+  </data>
+  <data name="EpisodeType_Trailer" xml:space="preserve">
+    <value>Remolques</value>
+  </data>
+  <data name="Favorite" xml:space="preserve">
+    <value>Favoritos</value>
+  </data>
+  <data name="GroupFilter_All" xml:space="preserve">
+    <value>Todos</value>
+  </data>
+  <data name="GroupFilter_Favorites" xml:space="preserve">
+    <value>Le gusta:</value>
+  </data>
+  <data name="IsWatched" xml:space="preserve">
+    <value>Es visto</value>
+  </data>
+  <data name="MyRating" xml:space="preserve">
+    <value>MyRating</value>
+  </data>
+  <data name="Refresh" xml:space="preserve">
+    <value>Actualización</value>
+  </data>
+  <data name="RunTime" xml:space="preserve">
+    <value>Tiempo de ejecución</value>
+  </data>
+  <data name="SortName" xml:space="preserve">
+    <value>Nombre de la especie</value>
+  </data>
+  <data name="Series" xml:space="preserve">
+    <value>Serie</value>
+  </data>
+  <data name="TAB_Config" xml:space="preserve">
+    <value>Config</value>
+  </data>
+  <data name="TAB_Episodes" xml:space="preserve">
+    <value>Episodios</value>
+  </data>
+  <data name="TAB_FileManager" xml:space="preserve">
+    <value>Administrador de archivos</value>
+  </data>
+  <data name="TAB_Images" xml:space="preserve">
+    <value>Imágenes</value>
+  </data>
+  <data name="TAB_Relations" xml:space="preserve">
+    <value>Relaciones</value>
+  </data>
+  <data name="TAB_SeriesEpisodes" xml:space="preserve">
+    <value>Colección</value>
+  </data>
+  <data name="TAB_Server" xml:space="preserve">
+    <value>Servidor</value>
+  </data>
+  <data name="TAB_TvDB" xml:space="preserve">
+    <value>TvDB</value>
+  </data>
+  <data name="ViewLabel" xml:space="preserve">
+    <value>Vista: </value>
+  </data>
+  <data name="Back" xml:space="preserve">
+    <value>Atrás</value>
+  </data>
+  <data name="Language" xml:space="preserve">
+    <value>Idioma</value>
+  </data>
+  <data name="Delete" xml:space="preserve">
+    <value>Eliminar</value>
+  </data>
+  <data name="RunImport" xml:space="preserve">
+    <value>Ejecutar importación</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Guardar</value>
+  </data>
+  <data name="AnimeTitles" xml:space="preserve">
+    <value>Títulos</value>
+  </data>
+  <data name="AnimeTitlesMain" xml:space="preserve">
+    <value>Título principal</value>
+  </data>
+  <data name="AnimeTitlesOfficial" xml:space="preserve">
+    <value>Oficial</value>
+  </data>
+  <data name="AnimeTitlesShort" xml:space="preserve">
+    <value>Corta</value>
+  </data>
+  <data name="AnimeTitlesSynonym" xml:space="preserve">
+    <value>Sinónimos</value>
+  </data>
+  <data name="Categories" xml:space="preserve">
+    <value>Categorías</value>
+  </data>
+  <data name="Tags" xml:space="preserve">
+    <value>Etiquetas (puede contener Spoilers)</value>
+  </data>
+  <data name="CategoryWeighting" xml:space="preserve">
+    <value>De ponderación</value>
+  </data>
+  <data name="TagApproval" xml:space="preserve">
+    <value>Aprobación</value>
+  </data>
+  <data name="Episodes_AvAll" xml:space="preserve">
+    <value>Todos los episodios</value>
+  </data>
+  <data name="Episodes_AvMissing" xml:space="preserve">
+    <value>No hay archivos Aavailable</value>
+  </data>
+  <data name="Episodes_AvOnly" xml:space="preserve">
+    <value>Sólo los archivos disponibles</value>
+  </data>
+  <data name="Episodes_Watched_All" xml:space="preserve">
+    <value>Todos</value>
+  </data>
+  <data name="Episodes_Watched_Unwatched" xml:space="preserve">
+    <value>No</value>
+  </data>
+  <data name="Episodes_Watched_Watched" xml:space="preserve">
+    <value>Visto</value>
+  </data>
+  <data name="Play" xml:space="preserve">
+    <value>Juego</value>
+  </data>
+  <data name="Tooltip_FileFound" xml:space="preserve">
+    <value>Este archivo está disponible</value>
+  </data>
+  <data name="Tooltip_FileNotFound" xml:space="preserve">
+    <value>Este archivo no existe</value>
+  </data>
+  <data name="Tooltip_FutureDated" xml:space="preserve">
+    <value>Este episodio no ha emitido aún</value>
+  </data>
+  <data name="Tooltip_Unwatched" xml:space="preserve">
+    <value>- Haga clic en marcar como vistos</value>
+  </data>
+  <data name="Tooltip_Watched" xml:space="preserve">
+    <value>Visto - haga clic en marcar como</value>
+  </data>
+  <data name="Tooltip_ZeroFiles" xml:space="preserve">
+    <value>Hay no hay archivos disponibles para este episodio</value>
+  </data>
+  <data name="Unwatched" xml:space="preserve">
+    <value>No</value>
+  </data>
+  <data name="Watched" xml:space="preserve">
+    <value>Visto</value>
+  </data>
+  <data name="Rating" xml:space="preserve">
+    <value>Valorar</value>
+  </data>
+  <data name="Votes" xml:space="preserve">
+    <value>Votos</value>
+  </data>
+  <data name="AnimeType_Movie" xml:space="preserve">
+    <value>Película</value>
+  </data>
+  <data name="AnimeType_Other" xml:space="preserve">
+    <value>Otros</value>
+  </data>
+  <data name="AnimeType_OVA" xml:space="preserve">
+    <value>OVA</value>
+  </data>
+  <data name="AnimeType_TVSeries" xml:space="preserve">
+    <value>Serie de TV</value>
+  </data>
+  <data name="AnimeType_TVSpecial" xml:space="preserve">
+    <value>Especial de TV</value>
+  </data>
+  <data name="AnimeType_Web" xml:space="preserve">
+    <value>Web</value>
+  </data>
+  <data name="Ongoing" xml:space="preserve">
+    <value>Curso</value>
+  </data>
+  <data name="To" xml:space="preserve">
+    <value>Para</value>
+  </data>
+  <data name="LastWatched" xml:space="preserve">
+    <value>Último visto</value>
+  </data>
+  <data name="Today" xml:space="preserve">
+    <value>Hoy</value>
+  </data>
+  <data name="Yesterday" xml:space="preserve">
+    <value>Ayer</value>
+  </data>
+  <data name="GroupsAvailableFrom" xml:space="preserve">
+    <value>Disponible en:</value>
+  </data>
+  <data name="Missing" xml:space="preserve">
+    <value>Falta</value>
+  </data>
+  <data name="Tooltip_MissingEps" xml:space="preserve">
+    <value>Episodios perdidos de todos los grupos de liberación</value>
+  </data>
+  <data name="Tooltip_MissingEpsGroups" xml:space="preserve">
+    <value>Episodios perdidos de los grupos de liberación que estoy recogiendo</value>
+  </data>
+  <data name="Tooltip_QueueImages" xml:space="preserve">
+    <value>Imágenes cola esperando descargar</value>
+  </data>
+  <data name="Specials" xml:space="preserve">
+    <value>Ofertas especiales</value>
+  </data>
+  <data name="GroupFilter_Missing" xml:space="preserve">
+    <value>Episodios que falta</value>
+  </data>
+  <data name="RemoveMissingFiles" xml:space="preserve">
+    <value>Eliminar archivos que faltan</value>
+  </data>
+  <data name="ServerActions" xml:space="preserve">
+    <value>Acciones del servidor</value>
+  </data>
+  <data name="NewGroup" xml:space="preserve">
+    <value>Nuevo grupo de</value>
+  </data>
+  <data name="AllFilters" xml:space="preserve">
+    <value>Todos los filtros</value>
+  </data>
+  <data name="Filter" xml:space="preserve">
+    <value>Filtro</value>
+  </data>
+  <data name="Group" xml:space="preserve">
+    <value>Grupo</value>
+  </data>
+  <data name="AddSubGroup" xml:space="preserve">
+    <value>Nuevo Sub grupo</value>
+  </data>
+  <data name="Edit" xml:space="preserve">
+    <value>Editar</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
+  <data name="SubGroup" xml:space="preserve">
+    <value>Sub grupo</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Configuración</value>
+  </data>
+  <data name="NewSeries" xml:space="preserve">
+    <value>Nueva serie</value>
+  </data>
+  <data name="MoveSeries" xml:space="preserve">
+    <value>Serie de movimiento</value>
+  </data>
+  <data name="MoveToGroup" xml:space="preserve">
+    <value>Mover al grupo seleccionado</value>
+  </data>
+  <data name="OK" xml:space="preserve">
+    <value>Vale</value>
+  </data>
+  <data name="QueueGeneral" xml:space="preserve">
+    <value>Cola de AniDB</value>
+  </data>
+  <data name="QueueHasher" xml:space="preserve">
+    <value>Cola de Hasher</value>
+  </data>
+  <data name="Tooltip_QueueGeneral" xml:space="preserve">
+    <value>AniDB comandos en cola</value>
+  </data>
+  <data name="Tooltip_QueueHasher" xml:space="preserve">
+    <value>Archivos esperando a ser molida</value>
+  </data>
+  <data name="Pause" xml:space="preserve">
+    <value>Pausa</value>
+  </data>
+  <data name="Resume" xml:space="preserve">
+    <value>Curriculum Vitae</value>
+  </data>
+  <data name="Video_Bluray" xml:space="preserve">
+    <value>BluRay</value>
+  </data>
+  <data name="Video_DVD" xml:space="preserve">
+    <value>DVD</value>
+  </data>
+  <data name="Video_FullHD" xml:space="preserve">
+    <value>Full HD</value>
+  </data>
+  <data name="Video_HD" xml:space="preserve">
+    <value>HD</value>
+  </data>
+  <data name="NewFolder" xml:space="preserve">
+    <value>Nueva carpeta</value>
+  </data>
+  <data name="DropDestination" xml:space="preserve">
+    <value>Destino de la gota</value>
+  </data>
+  <data name="DropSource" xml:space="preserve">
+    <value>Fuente de la gota</value>
+  </data>
+  <data name="ImportFolderName" xml:space="preserve">
+    <value>Nombre de la carpeta de importación</value>
+  </data>
+  <data name="ImportFolderPath" xml:space="preserve">
+    <value>Ruta de la carpeta de importación</value>
+  </data>
+  <data name="LocalMapping" xml:space="preserve">
+    <value>Asignación local</value>
+  </data>
+  <data name="LocalPath" xml:space="preserve">
+    <value>Ruta de acceso local</value>
+  </data>
+  <data name="ServerDetails" xml:space="preserve">
+    <value>Detalles servidor</value>
+  </data>
+  <data name="MSG_ERR_DropSourceDestCheck" xml:space="preserve">
+    <value>Una carpeta de importación no puede ser la fuente de la gota y el destino de la gota</value>
+  </data>
+  <data name="MSG_ERR_ImportFolderLocationCheck" xml:space="preserve">
+    <value>La ubicación de carpeta de importación no puede ser en blanco. Introduzca una ruta válida en el servidor de la OMM</value>
+  </data>
+  <data name="TAB_UnrecognisedFiles" xml:space="preserve">
+    <value>No se reconoce</value>
+  </data>
+  <data name="Confirm" xml:space="preserve">
+    <value>Confirmar</value>
+  </data>
+  <data name="NothingSelected" xml:space="preserve">
+    <value>Nada seleccionado</value>
+  </data>
+  <data name="SelectSeriesEp" xml:space="preserve">
+    <value>Seleccione una serie y episodio</value>
+  </data>
+  <data name="AssociateFile" xml:space="preserve">
+    <value>Vincular un archivo con un episodio</value>
+  </data>
+  <data name="Ignore" xml:space="preserve">
+    <value>Ignorar</value>
+  </data>
+  <data name="OpenFolder" xml:space="preserve">
+    <value>Abra la carpeta</value>
+  </data>
+  <data name="MSG_ERR_FileNotFound" xml:space="preserve">
+    <value>No se pudo encontrar el archivo</value>
+  </data>
+  <data name="FilesSelected" xml:space="preserve">
+    <value>Archivos seleccionados</value>
+  </data>
+  <data name="StartingEpisodeNumber" xml:space="preserve">
+    <value>Número de episodio inicial</value>
+  </data>
+  <data name="Existing" xml:space="preserve">
+    <value>Existentes</value>
+  </data>
+  <data name="SelectGroup" xml:space="preserve">
+    <value>Seleccione un grupo</value>
+  </data>
+  <data name="SelectAnime" xml:space="preserve">
+    <value>Seleccione Anime en AniDB</value>
+  </data>
+  <data name="New" xml:space="preserve">
+    <value>Nuevo</value>
+  </data>
+  <data name="GroupName" xml:space="preserve">
+    <value>Nombre del grupo</value>
+  </data>
+  <data name="AniDBID" xml:space="preserve">
+    <value>AniDB ID</value>
+  </data>
+  <data name="MSG_ERR_AnimeIDRequired" xml:space="preserve">
+    <value>Por favor introduzca un ID válido de AniDB Anime</value>
+  </data>
+  <data name="MSG_ERR_AnimeSelectionRequired" xml:space="preserve">
+    <value>Por favor seleccione un anime existente</value>
+  </data>
+  <data name="MSG_ERR_GroupNameRequired" xml:space="preserve">
+    <value>Introduzca un nombre de grupo</value>
+  </data>
+  <data name="MSG_ERR_GroupSelectionRequired" xml:space="preserve">
+    <value>Por favor, seleccione un grupo existente</value>
+  </data>
+  <data name="MSG_ERR_InvalidEpGetAnime" xml:space="preserve">
+    <value>La gama de episodio número ingresado no es válida, ¿desea actualizar los datos de AniDB?</value>
+  </data>
+  <data name="MSG_ERR_InvalidEp" xml:space="preserve">
+    <value>La gama de episodio que ha introducido no es válida.</value>
+  </data>
+  <data name="DeleteLink" xml:space="preserve">
+    <value>Eliminar enlace</value>
+  </data>
+  <data name="Tooltip_DeleteLink" xml:space="preserve">
+    <value>Quitar el vínculo entre este archivo y el episodio.</value>
+  </data>
+  <data name="TAB_IgnoredFiles" xml:space="preserve">
+    <value>No hizo caso</value>
+  </data>
+  <data name="Restore" xml:space="preserve">
+    <value>Restaurar</value>
+  </data>
+  <data name="TAB_ManuallyLinked" xml:space="preserve">
+    <value>Vinculado manualmente</value>
+  </data>
+  <data name="AniDBLogin" xml:space="preserve">
+    <value>AniDB Login</value>
+  </data>
+  <data name="Client" xml:space="preserve">
+    <value>Cliente</value>
+  </data>
+  <data name="ImportFolders" xml:space="preserve">
+    <value>Carpetas de importación</value>
+  </data>
+  <data name="JMMServer" xml:space="preserve">
+    <value>Servidor JMM</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Contraseña</value>
+  </data>
+  <data name="Port" xml:space="preserve">
+    <value>Puerto</value>
+  </data>
+  <data name="Server" xml:space="preserve">
+    <value>Servidor</value>
+  </data>
+  <data name="ServerPath" xml:space="preserve">
+    <value>Ruta del servidor</value>
+  </data>
+  <data name="TAB_SettingsAniDB" xml:space="preserve">
+    <value>AniDB</value>
+  </data>
+  <data name="TAB_SettingsDisplay" xml:space="preserve">
+    <value>Pantalla</value>
+  </data>
+  <data name="TAB_SettingsEssential" xml:space="preserve">
+    <value>Esencial</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB" xml:space="preserve">
+    <value>Sitios de la comunidad</value>
+  </data>
+  <data name="Test" xml:space="preserve">
+    <value>Prueba</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Nombre de usuario</value>
+  </data>
+  <data name="TestAndSave" xml:space="preserve">
+    <value>Prueba y guardar</value>
+  </data>
+  <data name="Success" xml:space="preserve">
+    <value>¡ Un éxito!</value>
+  </data>
+  <data name="INFO_SettingsEssential" xml:space="preserve">
+    <value>Deben rellenarse todos los ajustes en esta página. Asegúrese de probar y guardar el servidor JMM y AniDB detalles antes de proceder. Si esta es la primera vez que ejecuta la aplicación entrar importación al menos una carpeta y el Presione el botón de ejecutar la importación.</value>
+  </data>
+  <data name="Search" xml:space="preserve">
+    <value>Búsqueda de</value>
+  </data>
+  <data name="Tooltip_GroupSearch" xml:space="preserve">
+    <value>Grupos de búsqueda por nombre (en cualquier idioma), categoría o etiqueta</value>
+  </data>
+  <data name="AniDBDownloadChar" xml:space="preserve">
+    <value>Descargar personajes y creadores</value>
+  </data>
+  <data name="AniDBDownloadOptions" xml:space="preserve">
+    <value>Opciones de descarga AniDB</value>
+  </data>
+  <data name="AniDBDownloadRelated" xml:space="preserve">
+    <value>Descargar Anime relacionado</value>
+  </data>
+  <data name="AniDBDownloadReleaseGroups" xml:space="preserve">
+    <value>Descargar grupos de liberación</value>
+  </data>
+  <data name="AniDBDownloadReviews" xml:space="preserve">
+    <value>Descargar comentarios</value>
+  </data>
+  <data name="AniDBDownloadSimilar" xml:space="preserve">
+    <value>Descargar Anime Similar</value>
+  </data>
+  <data name="AniDBMyListAddFiles" xml:space="preserve">
+    <value>Agregar archivos</value>
+  </data>
+  <data name="AniDBMylistOptions" xml:space="preserve">
+    <value>Opciones de AniDB MyList</value>
+  </data>
+  <data name="AniDBMyListReadUnwatched" xml:space="preserve">
+    <value>Leer</value>
+  </data>
+  <data name="AniDBMyListReadWatched" xml:space="preserve">
+    <value>Visto leer</value>
+  </data>
+  <data name="AniDBMyListSetUnwatched" xml:space="preserve">
+    <value>Conjunto</value>
+  </data>
+  <data name="AniDBMyListSetWatched" xml:space="preserve">
+    <value>Conjunto observado</value>
+  </data>
+  <data name="AniDBMyListState" xml:space="preserve">
+    <value>Estado de almacenamiento de información</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadChar" xml:space="preserve">
+    <value>Descargar información e imágenes sobre los personajes y seiyuu que aparecen en el anime</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadRelated" xml:space="preserve">
+    <value>Descarga información sobre anime, descargar información sobre todos los relacionados con anime. Esto es necesario para agrupar correctamente relacionados con anime durante el proceso de importación.</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadReleaseGroups" xml:space="preserve">
+    <value>Descargar información detallada acerca de la liberación/sustituía los grupos para el anime</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadReviews" xml:space="preserve">
+    <value>Comentarios sobre el anime descargado por los usuarios de AniDB</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadSimilar" xml:space="preserve">
+    <value>Descarga información sobre anime, descargar información sobre títulos similares y recomendadas</value>
+  </data>
+  <data name="Tooltip_AniDBMyListAddFiles" xml:space="preserve">
+    <value>Si al importar archivos, los archivos se agregarán a tu cuenta de AniDB</value>
+  </data>
+  <data name="Tooltip_AniDBMyListReadUnwatched" xml:space="preserve">
+    <value>Si el archivo se establece como no-controladas en AniDB, también va a ser como no-controladas en su colección local</value>
+  </data>
+  <data name="Tooltip_AniDBMyListReadWatched" xml:space="preserve">
+    <value>Si el archivo se definirá como visto en AniDB, también se establecerá mientras miraba en su colección local</value>
+  </data>
+  <data name="Tooltip_AniDBMyListSetUnwatched" xml:space="preserve">
+    <value>Cuando se marca manualmente un video ya visto, también se actualizarán AniDB</value>
+  </data>
+  <data name="Tooltip_AniDBMyListSetWatched" xml:space="preserve">
+    <value>Al terminar viendo un vídeo o marcar manualmente un video ya visto, también se actualizarán AniDB</value>
+  </data>
+  <data name="Tooltip_AniDBMyListState" xml:space="preserve">
+    <value>Los archivos de estado de almacenamiento se establecerá cuando se añade a su lista de</value>
+  </data>
+  <data name="SyncMyList" xml:space="preserve">
+    <value>Sync AniDB MyList</value>
+  </data>
+  <data name="Rehash" xml:space="preserve">
+    <value>Rehash</value>
+  </data>
+  <data name="MSG_INFO_AddedQueueCmds" xml:space="preserve">
+    <value>Comandos se han añadido a la cola</value>
+  </data>
+  <data name="MultiTypeRange" xml:space="preserve">
+    <value>Gama del episodio</value>
+  </data>
+  <data name="MultiTypeSingle" xml:space="preserve">
+    <value>Solo episodio</value>
+  </data>
+  <data name="AniDBScheduleCalendar" xml:space="preserve">
+    <value>Calendario de actualización automáticamente</value>
+  </data>
+  <data name="AniDBScheduleHTTP" xml:space="preserve">
+    <value>Actualizar automáticamente la información del episodio y Anime</value>
+  </data>
+  <data name="AniDBScheduleMyList" xml:space="preserve">
+    <value>Automáticamente información de sincronización MyList</value>
+  </data>
+  <data name="AniDBScheduleOptions" xml:space="preserve">
+    <value>Actualizaciones programadas</value>
+  </data>
+  <data name="Tooltip_AniDBScheduleCalendar" xml:space="preserve">
+    <value>Descargar información sobre próximo anime.</value>
+  </data>
+  <data name="Tooltip_AniDBScheduleHTTP" xml:space="preserve">
+    <value>Actualizar la información sobre anime y obtener nueva información del episodio. Se descargarán sólo los datos que ha cambiado desde la última actualización.</value>
+  </data>
+  <data name="Tooltip_AniDBScheduleMyList" xml:space="preserve">
+    <value>Sincronizar información desde AniDB según las opciones especificadas en la sección de MyList.</value>
+  </data>
+  <data name="TAB_SettingsWebCache" xml:space="preserve">
+    <value>Caché Web</value>
+  </data>
+  <data name="DetailedInformationLink" xml:space="preserve">
+    <value>Siga este enlace para una profundidad de explicación</value>
+  </data>
+  <data name="Get" xml:space="preserve">
+    <value>Obtener</value>
+  </data>
+  <data name="INFO_SettingsWebCache" xml:space="preserve">
+    <value>La caché de web es una base de datos creada por los desarrolladores de JMM y MyAnime. Su propósito es llenar los vacíos que otras bases de datos no atender y también hacer más rápido el proceso de importación mediante el intercambio de información con otros usuarios de JMM.</value>
+  </data>
+  <data name="Send" xml:space="preserve">
+    <value>Enviar</value>
+  </data>
+  <data name="Tooltip_WebCache_Anonymous" xml:space="preserve">
+    <value>Seleccionando esta opción el usuario AniDB no se enviará a la caché de web. Sin embargo ello que no obtendrá el beneficio de su propia selección personal de recordar.</value>
+  </data>
+  <data name="Tooltip_WebCache_FileEpisodes" xml:space="preserve">
+    <value>Cuando los archivos no aparecen en AniDB, la caché web que tenga información sobre el episodio referente a ese archivo. Esto es especialmente útil cuando vincular los archivos manualmente y no quiere perder esa información.</value>
+  </data>
+  <data name="Tooltip_WebCache_FileHashes" xml:space="preserve">
+    <value>Trate de conseguir el archivo hash de la caché de web antes de hashing localmente. Esto puede ahorrar mucho tiempo al importar.</value>
+  </data>
+  <data name="Tooltip_WebCache_TvDBAssociations" xml:space="preserve">
+    <value>Para ver enlaces entre AniDB y TvDB, usar la caché web. Si no ha seleccionado tendrá que buscar manualmente todos los enlaces TvDB.</value>
+  </data>
+  <data name="TvDB_FanartAutoDownload" xml:space="preserve">
+    <value>Auto descargar Fanart</value>
+  </data>
+  <data name="TvDB_FanartCount" xml:space="preserve">
+    <value>Fanarts máxima</value>
+  </data>
+  <data name="TvDB_PosterAutoDownload" xml:space="preserve">
+    <value>Auto descargar carteles</value>
+  </data>
+  <data name="TvDB_WideBannerAutoDownload" xml:space="preserve">
+    <value>Auto descarga Banners amplia</value>
+  </data>
+  <data name="WebCache_Anonymous" xml:space="preserve">
+    <value>Mantenerse anónimo</value>
+  </data>
+  <data name="WebCache_FileEpisodes" xml:space="preserve">
+    <value>Archivo a los enlaces del episodio</value>
+  </data>
+  <data name="WebCache_FileHashes" xml:space="preserve">
+    <value>Hash de archivo</value>
+  </data>
+  <data name="WebCache_TvDBAssociations" xml:space="preserve">
+    <value>Enlaces de TvDB</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_MovieDB" xml:space="preserve">
+    <value>La película de DB</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_TvDB" xml:space="preserve">
+    <value>El TvDB</value>
+  </data>
+  <data name="Tooltip_TvDB_FanartAutoDownload" xml:space="preserve">
+    <value>Descarga automáticamente nuevos fanart cuando se realiza una importación.</value>
+  </data>
+  <data name="Tooltip_TvDB_FanartCount" xml:space="preserve">
+    <value>La máxima cantidad de fanart imágenes para descargar</value>
+  </data>
+  <data name="Tooltip_TvDB_PosterAutoDownload" xml:space="preserve">
+    <value>Descarga automáticamente nuevos posters cuando se realiza una importación.</value>
+  </data>
+  <data name="Tooltip_TvDB_WideBannerAutoDownload" xml:space="preserve">
+    <value>Descarga automáticamente nuevos banners amplia cuando se realiza una importación.</value>
+  </data>
+  <data name="ImportSettings_HashCRC32" xml:space="preserve">
+    <value>Calcular CRC32</value>
+  </data>
+  <data name="ImportSettings_HashMD5" xml:space="preserve">
+    <value>Calcular MD5</value>
+  </data>
+  <data name="ImportSettings_ImportOnStart" xml:space="preserve">
+    <value>Importar en Inicio</value>
+  </data>
+  <data name="ImportSettings_SHA1" xml:space="preserve">
+    <value>Calcular el SHA1</value>
+  </data>
+  <data name="ImportSettings_VideoExtensions" xml:space="preserve">
+    <value>Extensiones de video</value>
+  </data>
+  <data name="ImportSettings_WatchFiles" xml:space="preserve">
+    <value>Reloj para los nuevos archivos</value>
+  </data>
+  <data name="MovieDB_FanartAutoDownload" xml:space="preserve">
+    <value>Auto descargar Fanart</value>
+  </data>
+  <data name="MovieDB_FanartCount" xml:space="preserve">
+    <value>Fanarts máxima</value>
+  </data>
+  <data name="MovieDB_PosterAutoDownload" xml:space="preserve">
+    <value>Auto descargar carteles</value>
+  </data>
+  <data name="TAB_Settings_ImportSettings" xml:space="preserve">
+    <value>Configuración de importación</value>
+  </data>
+  <data name="Tooltip_MovieDB_FanartAutoDownload" xml:space="preserve">
+    <value>Descarga automáticamente nuevos fanart cuando se realiza una importación.</value>
+  </data>
+  <data name="Tooltip_MovieDB_FanartCount" xml:space="preserve">
+    <value>La máxima cantidad de fanart imágenes para descargar</value>
+  </data>
+  <data name="Tooltip_MovieDB_PosterAutoDownload" xml:space="preserve">
+    <value>Descarga automáticamente nuevos posters cuando se realiza una importación.</value>
+  </data>
+  <data name="Down" xml:space="preserve">
+    <value>Abajo</value>
+  </data>
+  <data name="LanguageUseSynonyms" xml:space="preserve">
+    <value>También utilizar sinónimos</value>
+  </data>
+  <data name="TAB_Settings_Language" xml:space="preserve">
+    <value>Preferencias de idioma</value>
+  </data>
+  <data name="Tooltip_LanguageUseSynonyms" xml:space="preserve">
+    <value>También utilizar sinónimos de idioma seleccionado para la visualización de series y grupos. Inglés y sinónimos de Romaji no se utilizará</value>
+  </data>
+  <data name="Up" xml:space="preserve">
+    <value>Hasta</value>
+  </data>
+  <data name="GroupFilterConditions" xml:space="preserve">
+    <value>Condiciones de filtrado</value>
+  </data>
+  <data name="GroupFilterConditionType" xml:space="preserve">
+    <value>Tipo de condición</value>
+  </data>
+  <data name="GroupFilterConditionType_AirDate" xml:space="preserve">
+    <value>AirDate</value>
+  </data>
+  <data name="GroupFilterConditionType_AllEpisodesWatched" xml:space="preserve">
+    <value>Visto todos los episodios</value>
+  </data>
+  <data name="GroupFilterConditionType_AnimeGroup" xml:space="preserve">
+    <value>Grupo</value>
+  </data>
+  <data name="GroupFilterConditionType_AnimeType" xml:space="preserve">
+    <value>Tipo de anime</value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedTvDBInfo" xml:space="preserve">
+    <value>Tiene enlace TvDB</value>
+  </data>
+  <data name="GroupFilterConditionType_Category" xml:space="preserve">
+    <value>Categoría</value>
+  </data>
+  <data name="GroupFilterConditionType_CompletedSeries" xml:space="preserve">
+    <value>Serie completa</value>
+  </data>
+  <data name="GroupFilterConditionType_Favourite" xml:space="preserve">
+    <value>Favorito</value>
+  </data>
+  <data name="GroupFilterConditionType_HasUnwatchedEpisodes" xml:space="preserve">
+    <value>Ha episodios</value>
+  </data>
+  <data name="GroupFilterConditionType_MissingEpisodes" xml:space="preserve">
+    <value>Episodios que falta</value>
+  </data>
+  <data name="GroupFilterConditionType_ReleaseGroup" xml:space="preserve">
+    <value>Grupo de liberación</value>
+  </data>
+  <data name="GroupFilterConditionType_Studio" xml:space="preserve">
+    <value>Estudio</value>
+  </data>
+  <data name="GroupFilterConditionType_Tag" xml:space="preserve">
+    <value>Etiqueta</value>
+  </data>
+  <data name="GroupFilterConditionType_UserVoted" xml:space="preserve">
+    <value>Usuario ha votado (Perm)</value>
+  </data>
+  <data name="GroupFilterConditionType_VideoQuality" xml:space="preserve">
+    <value>Calidad de video</value>
+  </data>
+  <data name="GroupFilterOperator" xml:space="preserve">
+    <value>Operador</value>
+  </data>
+  <data name="GroupFilterOperator_Equals" xml:space="preserve">
+    <value>Es igual a</value>
+  </data>
+  <data name="GroupFilterOperator_Exclude" xml:space="preserve">
+    <value>Excluir</value>
+  </data>
+  <data name="GroupFilterOperator_GreaterThan" xml:space="preserve">
+    <value>Mayor o igual a</value>
+  </data>
+  <data name="GroupFilterOperator_Include" xml:space="preserve">
+    <value>Incluyen</value>
+  </data>
+  <data name="GroupFilterOperator_LessThan" xml:space="preserve">
+    <value>Menor o igual a</value>
+  </data>
+  <data name="GroupFilterOperator_NotEquals" xml:space="preserve">
+    <value>No es igual a</value>
+  </data>
+  <data name="GroupFilterSorting" xml:space="preserve">
+    <value>Clasificación</value>
+  </data>
+  <data name="ImageSize_GroupList" xml:space="preserve">
+    <value>Grupo y lista de la serie</value>
+  </data>
+  <data name="ImageSize_SeriesPoster" xml:space="preserve">
+    <value>Poster de la serie</value>
+  </data>
+  <data name="ImageSize_SubGroupList" xml:space="preserve">
+    <value>Sub grupos lista y serie</value>
+  </data>
+  <data name="INFO_SettingsDisplayStyle" xml:space="preserve">
+    <value>Usted tendrá que actualizar su lista de grupo para ver los efectos de los cambios</value>
+  </data>
+  <data name="MSG_ERR_SelectDate" xml:space="preserve">
+    <value>Elige un primero</value>
+  </data>
+  <data name="NewGroupFilter" xml:space="preserve">
+    <value>Nuevo filtro de grupo</value>
+  </data>
+  <data name="RenameGroups" xml:space="preserve">
+    <value>Cambiar el nombre de todos los grupos</value>
+  </data>
+  <data name="Style_GroupList" xml:space="preserve">
+    <value>Lista de grupo</value>
+  </data>
+  <data name="Style_GroupList_MediumDetail" xml:space="preserve">
+    <value>Detalle medio</value>
+  </data>
+  <data name="Style_GroupList_Simple" xml:space="preserve">
+    <value>Simple</value>
+  </data>
+  <data name="TAB_SettingsImageSizes" xml:space="preserve">
+    <value>Tamaños de imagen</value>
+  </data>
+  <data name="TAB_SettingsStyle" xml:space="preserve">
+    <value>Estilos</value>
+  </data>
+  <data name="Tooltip_ImageSize_GroupList" xml:space="preserve">
+    <value>Las imágenes mostradas en la lista principal al ver la serie y los grupos</value>
+  </data>
+  <data name="Tooltip_ImageSize_SeriesPoster" xml:space="preserve">
+    <value>Las imágenes mostradas en el panel derecho para todas las series que pertenecen a un grupo</value>
+  </data>
+  <data name="Tooltip_ImageSize_SubGroupList" xml:space="preserve">
+    <value>Las imágenes mostradas en la lista principal al ver la serie o sub grupos</value>
+  </data>
+  <data name="Tooltip_Style_GroupList" xml:space="preserve">
+    <value>El estilo de los grupos cuando se muestran en la lista principal (también sub grupos)</value>
+  </data>
+  <data name="FilterValue" xml:space="preserve">
+    <value>Valor de filtro</value>
+  </data>
+  <data name="MSG_ERR_EnterValue" xml:space="preserve">
+    <value>Por favor, introduzca un valor</value>
+  </data>
+  <data name="PreviewFilter" xml:space="preserve">
+    <value>Avance de resultados del filtro</value>
+  </data>
+  <data name="GroupFilter_ApplyToSeries" xml:space="preserve">
+    <value>Aplicar filtro a nivel de serie en lugar de nivel de grupo</value>
+  </data>
+  <data name="GroupFilter_BaseCondition" xml:space="preserve">
+    <value>Condición base</value>
+  </data>
+  <data name="GroupFilter_BaseCondition_ExcludeAll" xml:space="preserve">
+    <value>Excluir todos los</value>
+  </data>
+  <data name="GroupFilter_BaseCondition_IncludeAll" xml:space="preserve">
+    <value>Incluyen todos los</value>
+  </data>
+  <data name="Tooltip_GroupFilter_BaseCondition" xml:space="preserve">
+    <value>Incluir a todos para que todos los grupos se incluyen por defecto. Excluir a todos para que los grupos no se incluyen, esto está destinado a ser utilizado cuando desea especificar manualmente los grupos de forma individual.</value>
+  </data>
+  <data name="GroupFilterOperator_In" xml:space="preserve">
+    <value>En</value>
+  </data>
+  <data name="GroupFilterOperator_NotIn" xml:space="preserve">
+    <value>No en</value>
+  </data>
+  <data name="GroupFilter_Category_Help" xml:space="preserve">
+    <value>Haga doble clic en obstructividad para añadirlos a la lista seleccionada</value>
+  </data>
+  <data name="GroupFilterConditionType_AniDBRating" xml:space="preserve">
+    <value>Calificación - AniDB</value>
+  </data>
+  <data name="GroupFilterConditionType_UserRating" xml:space="preserve">
+    <value>Calificación - usuario</value>
+  </data>
+  <data name="MSG_ERR_RatingValue" xml:space="preserve">
+    <value>Clasificación debe ser un valor entre 0 y 10. Se admiten decimales.</value>
+  </data>
+  <data name="ScanFolder" xml:space="preserve">
+    <value>Analizar esta carpeta ahora</value>
+  </data>
+  <data name="GroupFilterConditionType_EpisodeAddedDate" xml:space="preserve">
+    <value>Episodio añadido fecha</value>
+  </data>
+  <data name="GroupFilterConditionType_EpisodeWatchedDate" xml:space="preserve">
+    <value>Episodio visto fecha</value>
+  </data>
+  <data name="GroupFilterConditionType_SeriesDate" xml:space="preserve">
+    <value>La serie ha añadido fecha</value>
+  </data>
+  <data name="GroupFilterOperator_LastXDays" xml:space="preserve">
+    <value>Pasado 'X' días</value>
+  </data>
+  <data name="SelectDate" xml:space="preserve">
+    <value>Seleccione fecha</value>
+  </data>
+  <data name="MSG_ERR_DaysValue" xml:space="preserve">
+    <value>Introduce el número de días como un entero (el mínimo es 1)</value>
+  </data>
+  <data name="SyncVotes" xml:space="preserve">
+    <value>Sync AniDB votos</value>
+  </data>
+  <data name="UserVote" xml:space="preserve">
+    <value>Mi voto</value>
+  </data>
+  <data name="VoteNow" xml:space="preserve">
+    <value>¡ Vota ya</value>
+  </data>
+  <data name="VoteRevoke" xml:space="preserve">
+    <value>Revocar</value>
+  </data>
+  <data name="GroupFilterConditionType_FinishedAiring" xml:space="preserve">
+    <value>Ventilación final</value>
+  </data>
+  <data name="VoteTypeAnimePermanent" xml:space="preserve">
+    <value>Permanente</value>
+  </data>
+  <data name="VoteTypeAnimeTemporary" xml:space="preserve">
+    <value>Temporal</value>
+  </data>
+  <data name="AniDBMyListLocalActions" xml:space="preserve">
+    <value>Acciones locales</value>
+  </data>
+  <data name="AniDBMyListSyncAndImport" xml:space="preserve">
+    <value>Sincronización de MyList y opciones de importación</value>
+  </data>
+  <data name="EpisodeMarkAllUnwatched" xml:space="preserve">
+    <value>Marca todo</value>
+  </data>
+  <data name="EpisodeMarkAllWatched" xml:space="preserve">
+    <value>Marca todos vistos</value>
+  </data>
+  <data name="EpisodeMarkAllWatchedPrevious" xml:space="preserve">
+    <value>Marcar todo anterior visto incluyendo EP #</value>
+  </data>
+  <data name="GroupFilter_VideoQuality_Help" xml:space="preserve">
+    <value>Haga doble clic en las entradas para agregar a la lista</value>
+  </data>
+  <data name="GroupFilterConditionType_MissingEpisodesCollecting" xml:space="preserve">
+    <value>Episodios perdidos (recogiendo)</value>
+  </data>
+  <data name="GroupFilterOperator_InAllEpisodes" xml:space="preserve">
+    <value>En (todos los episodios)</value>
+  </data>
+  <data name="GroupFilterOperator_NotInAllEpisodes" xml:space="preserve">
+    <value>No en (todos los episodios)</value>
+  </data>
+  <data name="GroupFilterConditionType_AudioLanguage" xml:space="preserve">
+    <value>Idioma de audio</value>
+  </data>
+  <data name="GroupFilterConditionType_SubtitleLanguage" xml:space="preserve">
+    <value>Idioma de los subtítulos</value>
+  </data>
+  <data name="GroupFilterSortDirection_Asc" xml:space="preserve">
+    <value>ASC</value>
+  </data>
+  <data name="GroupFilterSortDirection_Desc" xml:space="preserve">
+    <value>DESC</value>
+  </data>
+  <data name="GroupFilterSorting_AniDBRating" xml:space="preserve">
+    <value>AniDB calificación</value>
+  </data>
+  <data name="GroupFilterSorting_EpisodeAddedDate" xml:space="preserve">
+    <value>Episodio añadido fecha</value>
+  </data>
+  <data name="GroupFilterSorting_EpisodeAirDate" xml:space="preserve">
+    <value>Episodio fecha de aire</value>
+  </data>
+  <data name="GroupFilterSorting_EpisodeWatchedDate" xml:space="preserve">
+    <value>Episodio visto fecha</value>
+  </data>
+  <data name="GroupFilterSorting_GroupName" xml:space="preserve">
+    <value>Nombre del grupo</value>
+  </data>
+  <data name="GroupFilterSorting_MissingEpisodeCount" xml:space="preserve">
+    <value>Falta el episodio cuenta</value>
+  </data>
+  <data name="GroupFilterSorting_SeriesAddedDate" xml:space="preserve">
+    <value>La serie ha añadido fecha</value>
+  </data>
+  <data name="GroupFilterSorting_SeriesCount" xml:space="preserve">
+    <value>La serie cuenta</value>
+  </data>
+  <data name="GroupFilterSorting_UnwatchedEpisodeCount" xml:space="preserve">
+    <value>Episodio cuenta</value>
+  </data>
+  <data name="GroupFilterSorting_UserRating" xml:space="preserve">
+    <value>Calificación del usuario</value>
+  </data>
+  <data name="GroupFilterSorting_Year" xml:space="preserve">
+    <value>Año</value>
+  </data>
+  <data name="GroupFilterSorting_SortName" xml:space="preserve">
+    <value>Nombre de la especie</value>
+  </data>
+  <data name="GroupFilterDirection" xml:space="preserve">
+    <value>Dirección</value>
+  </data>
+  <data name="GroupFilterSortType" xml:space="preserve">
+    <value>Tipo de especie</value>
+  </data>
+  <data name="QuickSort" xml:space="preserve">
+    <value>Especie rápido</value>
+  </data>
+  <data name="TAB_DuplicateFiles" xml:space="preserve">
+    <value>Archivos duplicados</value>
+  </data>
+  <data name="INFO_DuplicateFiles" xml:space="preserve">
+    <value>Archivos duplicados son donde hay dos o más archivos que son exactamente iguales, excepto que se encuentran en diferentes carpetas o se nombran diferentemente. JMM solo permite un archivo con el mismo hash de la colección.</value>
+  </data>
+  <data name="Tooltip_DeleteDuplicateFileAll" xml:space="preserve">
+    <value>Eliminar la entrada de la base de datos y el archivo seleccionado en el disco.</value>
+  </data>
+  <data name="Tooltip_DeleteDuplicateFileEntry" xml:space="preserve">
+    <value>Eliminar la entrada de la base de datos solamente. Archivos en el disco no será afectados.</value>
+  </data>
+  <data name="Files" xml:space="preserve">
+    <value>Archivos</value>
+  </data>
+  <data name="ReevaluateDuplicateFiles" xml:space="preserve">
+    <value>Volver a evaluar todas las entradas</value>
+  </data>
+  <data name="Tooltip_ReevaluateDuplicateFiles" xml:space="preserve">
+    <value>Ver todas las entradas de archivos duplicados para ver si los archivos todavía existen. Si no puedes borrar la entrada de la base de datos</value>
+  </data>
+  <data name="TAB_MultipleFiles" xml:space="preserve">
+    <value>Varios archivos</value>
+  </data>
+  <data name="INFO_MultipleFiles" xml:space="preserve">
+    <value>Varios archivos son donde hay dos o más archivos para el mismo episodio. Esta utilidad le permitirá examinar todas estas ocurrencias y decidir cuáles quieres mantener</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Cargando...</value>
+  </data>
+  <data name="TotalFileCount" xml:space="preserve">
+    <value>Total archivo de cuenta</value>
+  </data>
+  <data name="ImportSettings_UseEpisodeStatus" xml:space="preserve">
+    <value>Conjunto de archivos mientras miraba si el episodio es visto</value>
+  </data>
+  <data name="Tooltip_TvDB_Schedule_Updates" xml:space="preserve">
+    <value>Actualizar la información de la serie y episodio cada 12 horas y también descargar cualquier nuevo fanart, carteles y pancartas amplia</value>
+  </data>
+  <data name="TvDB_Schedule_Updates" xml:space="preserve">
+    <value>Actualización información cada 12 horas</value>
+  </data>
+  <data name="RescanAll" xml:space="preserve">
+    <value>Volver a escanear todos los</value>
+  </data>
+  <data name="DeleteAll" xml:space="preserve">
+    <value>Borrar todo</value>
+  </data>
+  <data name="CrossRefSummary" xml:space="preserve">
+    <value>TvDB y otros enlaces de AniDB no</value>
+  </data>
+  <data name="FileSummary" xml:space="preserve">
+    <value>Extracto de archivo</value>
+  </data>
+  <data name="TheTvDB" xml:space="preserve">
+    <value>El TvDB</value>
+  </data>
+  <data name="SeasonNumber" xml:space="preserve">
+    <value>Temporada #</value>
+  </data>
+  <data name="CommunityRecommendation" xml:space="preserve">
+    <value>Recomendación de la comunidad</value>
+  </data>
+  <data name="TvDBSearchPrompt" xml:space="preserve">
+    <value>Buscar en el TvDB o entrar en TvDB serie ID</value>
+  </data>
+  <data name="TvDBShow" xml:space="preserve">
+    <value>Ir a TvDB</value>
+  </data>
+  <data name="UseThis" xml:space="preserve">
+    <value>Utilice esta</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Cerrar</value>
+  </data>
+  <data name="SwitchSeason" xml:space="preserve">
+    <value>Interruptor de temporada</value>
+  </data>
+  <data name="AniDB" xml:space="preserve">
+    <value>AniDB</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>Actualización</value>
+  </data>
+  <data name="UpdateAniDBInfo" xml:space="preserve">
+    <value>Actualizar información de AniDB</value>
+  </data>
+  <data name="UpdateInfo" xml:space="preserve">
+    <value>Actualización de información</value>
+  </data>
+  <data name="ImageSize_EpisodeImage" xml:space="preserve">
+    <value>Imagen del episodio</value>
+  </data>
+  <data name="Tooltip_ImageSize_EpisodeImage" xml:space="preserve">
+    <value>La imágenes muestran en el detalle del episodio</value>
+  </data>
+  <data name="EpisodeDetailStyle" xml:space="preserve">
+    <value>Episodio detalle estilo</value>
+  </data>
+  <data name="EpisodeDetailStyle_Option1" xml:space="preserve">
+    <value>Imágenes/Resumen en Resumen</value>
+  </data>
+  <data name="EpisodeDetailStyle_Option2" xml:space="preserve">
+    <value>Imágenes/Resumen cuando sólo se expande</value>
+  </data>
+  <data name="EpisodeDetailStyle_Option3" xml:space="preserve">
+    <value>Imágenes/Resumen discapacitados</value>
+  </data>
+  <data name="HideEpisodeImageWhenUnwatched" xml:space="preserve">
+    <value>Ocultar imagen del episodio cuando</value>
+  </data>
+  <data name="HideEpisodeOverviewWhenUnwatched" xml:space="preserve">
+    <value>Ocultar Resumen episodio cuando</value>
+  </data>
+  <data name="Tooltip_HideEpisodeImageWhenUnwatched" xml:space="preserve">
+    <value>La imagen del episodio se ocultará hasta que el episodio es visto</value>
+  </data>
+  <data name="Tooltip_HideEpisodeOverviewWhenUnwatched" xml:space="preserve">
+    <value>El resumen del episodio (descripción) se ocultará hasta que el episodio es visto</value>
+  </data>
+  <data name="Fanart" xml:space="preserve">
+    <value>Fanart</value>
+  </data>
+  <data name="Images" xml:space="preserve">
+    <value>Imágenes</value>
+  </data>
+  <data name="Image_Disabled" xml:space="preserve">
+    <value>Imagen está actualmente desactivada</value>
+  </data>
+  <data name="Image_Dynamic" xml:space="preserve">
+    <value>Establecer esta imagen como la única imagen que se mostrará</value>
+  </data>
+  <data name="Image_Enabled" xml:space="preserve">
+    <value>Actualmente está habilitada la imagen</value>
+  </data>
+  <data name="Image_Static" xml:space="preserve">
+    <value>Esta imagen es la única imagen que se mostrará</value>
+  </data>
+  <data name="Image_View" xml:space="preserve">
+    <value>Ver imagen</value>
+  </data>
+  <data name="Posters" xml:space="preserve">
+    <value>Carteles</value>
+  </data>
+  <data name="WideBanners" xml:space="preserve">
+    <value>Banners amplia</value>
+  </data>
+  <data name="TheMovieDB" xml:space="preserve">
+    <value>La película de DB</value>
+  </data>
+  <data name="MovieDBShow" xml:space="preserve">
+    <value>Ir a MovieDB</value>
+  </data>
+  <data name="MovieDBSearchPrompt" xml:space="preserve">
+    <value>Buscar en el MovieDB o introducir ID MovieDB</value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedTvDBOrMovieDBInfo" xml:space="preserve">
+    <value>Tiene TvDB o MovieDB enlace</value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedMovieDBInfo" xml:space="preserve">
+    <value>Tiene enlace MovieDB</value>
+  </data>
+  <data name="Image_Default" xml:space="preserve">
+    <value>Sólo esta imagen se utilizará</value>
+  </data>
+  <data name="Image_NotDefault" xml:space="preserve">
+    <value>Esta imagen no es el predeterminado</value>
+  </data>
+  <data name="PlayNextEpisode" xml:space="preserve">
+    <value>Jugar próximo episodio</value>
+  </data>
+  <data name="AllEpisodesWatched" xml:space="preserve">
+    <value>Ya se han visto todos los episodios</value>
+  </data>
+  <data name="FinishEditing" xml:space="preserve">
+    <value>Terminado de editar</value>
+  </data>
+  <data name="TAB_Dashboard" xml:space="preserve">
+    <value>Tablero de instrumentos</value>
+  </data>
+  <data name="Dash_WatchNextEp_Recent" xml:space="preserve">
+    <value>Seguir viendo... (Recientemente visto)</value>
+  </data>
+  <data name="DeleteSeries" xml:space="preserve">
+    <value>Borrar serie</value>
+  </data>
+  <data name="DeleteSeriesConfirm" xml:space="preserve">
+    <value>¿Está seguro que desea eliminar este grupo de serie?</value>
+  </data>
+  <data name="DeleteSeriesConfirm_Files" xml:space="preserve">
+    <value>¿También puedes borrar todos los archivos físicos?</value>
+  </data>
+  <data name="Dash_SeriesMissingEps" xml:space="preserve">
+    <value>Faltan episodios (por recientemente visto)</value>
+  </data>
+  <data name="LatestEp_Anime" xml:space="preserve">
+    <value>Último episodio</value>
+  </data>
+  <data name="LatestEp_Yours" xml:space="preserve">
+    <value>Su último episodio</value>
+  </data>
+  <data name="MissingEpisodeCount" xml:space="preserve">
+    <value>Episodios que falta</value>
+  </data>
+  <data name="Dash_MiniCalendar" xml:space="preserve">
+    <value>Mini calendario</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Inicio de sesión</value>
+  </data>
+  <data name="ImageSize" xml:space="preserve">
+    <value>Tamaño de la imagen</value>
+  </data>
+  <data name="INFO_SettingsUserAdmin" xml:space="preserve">
+    <value>Agregar o editar usuarios aquí. Los usuarios son almacenados en la base de datos y compartidos a través de diferentes clientes. Siempre debe tener al menos un usuario administrador.</value>
+  </data>
+  <data name="TAB_SettingsUsers" xml:space="preserve">
+    <value>Usuarios de</value>
+  </data>
+  <data name="User_HideCategories" xml:space="preserve">
+    <value>Ocultar categorías</value>
+  </data>
+  <data name="User_IsAdmin" xml:space="preserve">
+    <value>Administrador de</value>
+  </data>
+  <data name="User_Password" xml:space="preserve">
+    <value>Contraseña</value>
+  </data>
+  <data name="User_Username" xml:space="preserve">
+    <value>Nombre de usuario</value>
+  </data>
+  <data name="Items" xml:space="preserve">
+    <value>Artículos</value>
+  </data>
+  <data name="Days" xml:space="preserve">
+    <value>Días</value>
+  </data>
+  <data name="DashWatchNextStyle_Detailed" xml:space="preserve">
+    <value>Detallada</value>
+  </data>
+  <data name="DashWatchNextStyle_Simple" xml:space="preserve">
+    <value>Simple</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_Trakt" xml:space="preserve">
+    <value>Trakt TV</value>
+  </data>
+  <data name="Trakt_Password" xml:space="preserve">
+    <value>Contraseña</value>
+  </data>
+  <data name="Trakt_Username" xml:space="preserve">
+    <value>Nombre de usuario</value>
+  </data>
+  <data name="UpdateFrequency" xml:space="preserve">
+    <value>Actualizar automáticamente los datos</value>
+  </data>
+  <data name="UpdateFrequency_12Hours" xml:space="preserve">
+    <value>Cada 12 horas</value>
+  </data>
+  <data name="UpdateFrequency_6Hours" xml:space="preserve">
+    <value>Cada 6 horas</value>
+  </data>
+  <data name="UpdateFrequency_Daily" xml:space="preserve">
+    <value>Cada 24 horas</value>
+  </data>
+  <data name="UpdateFrequency_Never" xml:space="preserve">
+    <value>Nunca</value>
+  </data>
+  <data name="TraktSyncFrequency" xml:space="preserve">
+    <value>Sincronizar automáticamente la colección</value>
+  </data>
+  <data name="TraktSearchPrompt" xml:space="preserve">
+    <value>Buscar en Trakt o introducir ID de Trakt (slug)</value>
+  </data>
+  <data name="TraktShow" xml:space="preserve">
+    <value>Ir a Trakt</value>
+  </data>
+  <data name="TAB_Pinned" xml:space="preserve">
+    <value>Cubrió a</value>
+  </data>
+  <data name="Tooltip_ViewSeries" xml:space="preserve">
+    <value>Abrir esta serie de Anime en una nueva ventana</value>
+  </data>
+  <data name="GroupFilterConditionType_UserVotedAny" xml:space="preserve">
+    <value>Usuario ha votado (cualquiera)</value>
+  </data>
+  <data name="Tooltip_User_IsAniDB" xml:space="preserve">
+    <value>Cualquier usuario marcado como usuario AniDB se mantendrá en sintonía con otros usuarios de AniDB. Si el usuario no es un usuario de AniDB visto episodios no se verán reflejados en la Página Web de AniDB.</value>
+  </data>
+  <data name="User_IsAniDB" xml:space="preserve">
+    <value>Usuario de AniDB</value>
+  </data>
+  <data name="User_IsTrakt" xml:space="preserve">
+    <value>Usuario de Trakt</value>
+  </data>
+  <data name="ERROR_SeriesExists" xml:space="preserve">
+    <value>Ya existe una serie de este anime</value>
+  </data>
+  <data name="Tooltip_CreateSeries" xml:space="preserve">
+    <value>Crear serie de este anime</value>
+  </data>
+  <data name="SimilarAnime" xml:space="preserve">
+    <value>Anime similar</value>
+  </data>
+  <data name="RelatedAndSimilar" xml:space="preserve">
+    <value>Conexos y similares</value>
+  </data>
+  <data name="GetMissingData" xml:space="preserve">
+    <value>¡ Ahora faltan datos</value>
+  </data>
+  <data name="NoSimilarAnime" xml:space="preserve">
+    <value>No anime similar podría encontrarse</value>
+  </data>
+  <data name="NoRelatedAnime" xml:space="preserve">
+    <value>No anime relacionado se encuentran</value>
+  </data>
+  <data name="RelatedAnime" xml:space="preserve">
+    <value>Relacionados con Anime</value>
+  </data>
+  <data name="Dash_RecWatch" xml:space="preserve">
+    <value>Recomendaciones para ver</value>
+  </data>
+  <data name="Dash_RecDownload" xml:space="preserve">
+    <value>Recomendaciones para descargar</value>
+  </data>
+  <data name="ImportSettings_AutoGroupSeries" xml:space="preserve">
+    <value>Colocar automáticamente series relacionadas en el mismo grupo</value>
+  </data>
+  <data name="GroupFilterConditionType_HasWatchedEpisodes" xml:space="preserve">
+    <value>Ha visto episodios</value>
+  </data>
+  <data name="MyList" xml:space="preserve">
+    <value>MyList</value>
+  </data>
+  <data name="Tooltip_MyList" xml:space="preserve">
+    <value>Con fuerza añadir este archivo a la lista en AniDB</value>
+  </data>
+  <data name="TAB_MissingFiles" xml:space="preserve">
+    <value>Faltan archivos de MyList</value>
+  </data>
+  <data name="TAB_Utilities" xml:space="preserve">
+    <value>Utilidades</value>
+  </data>
+  <data name="TAB_SeriesWithoutFiles" xml:space="preserve">
+    <value>Serie sin archivos</value>
+  </data>
+  <data name="DeleteSeriesConfirm_Groups" xml:space="preserve">
+    <value>Eliminar ningún grupo de padres, si están vacías</value>
+  </data>
+  <data name="Export" xml:space="preserve">
+    <value>De la exportación</value>
+  </data>
+  <data name="TAB_MissingEpisodes" xml:space="preserve">
+    <value>Episodios que falta</value>
+  </data>
+  <data name="MyGroupsOnly" xml:space="preserve">
+    <value>Sólo grupos de liberación que estoy recogiendo</value>
+  </data>
+  <data name="RegularEpisodesOnly" xml:space="preserve">
+    <value>Episodios regulares sólo</value>
+  </data>
+  <data name="Dash_TraktFriends" xml:space="preserve">
+    <value>Actividad de amigos (Trakt TV)</value>
+  </data>
+  <data name="Tooltip_IgnoreAnimeDownload" xml:space="preserve">
+    <value>Ignorar este Anime para descargar</value>
+  </data>
+  <data name="Tooltip_IgnoreAnimeWatch" xml:space="preserve">
+    <value>Ignorar este Anime para ver recomendaciones</value>
+  </data>
+  <data name="VisitWebsite" xml:space="preserve">
+    <value>Visite el sitio web</value>
+  </data>
+  <data name="AniDBSignup" xml:space="preserve">
+    <value>Registro por ahora AniDB</value>
+  </data>
+  <data name="AvdumpHeader" xml:space="preserve">
+    <value>AVDump2 (opcional)</value>
+  </data>
+  <data name="AvdumpInfoLink" xml:space="preserve">
+    <value>Más información en AVDump2</value>
+  </data>
+  <data name="AvdumpKey" xml:space="preserve">
+    <value>API Key</value>
+  </data>
+  <data name="AvdumpKeyEditLink" xml:space="preserve">
+    <value>Editar tu AVDump2 UDP API Key aquí</value>
+  </data>
+  <data name="Avdump" xml:space="preserve">
+    <value>Avdump2</value>
+  </data>
+  <data name="AvdumpRequiredFilesLink" xml:space="preserve">
+    <value>Asegúrese de que tener todos los archivos necesarios en la misma carpeta como fondo de escritorio de JMM</value>
+  </data>
+  <data name="AvdumpSettingsError" xml:space="preserve">
+    <value>No has especificado tu API Key y puerto del cliente</value>
+  </data>
+  <data name="AvdumpAddRelease" xml:space="preserve">
+    <value>Añadir nueva versión</value>
+  </data>
+  <data name="CopyED2KClipboard" xml:space="preserve">
+    <value>Copia descarga ED2K</value>
+  </data>
+  <data name="Tooltip_CopyED2KClipboard" xml:space="preserve">
+    <value>Copiar la descarga ED2K en el portapapeles</value>
+  </data>
+  <data name="TAB_IgnoredAnime" xml:space="preserve">
+    <value>Anime ignorado</value>
+  </data>
+  <data name="Anime" xml:space="preserve">
+    <value>Anime</value>
+  </data>
+  <data name="RemoveDefaultSeries" xml:space="preserve">
+    <value>Quitar la serie por defecto</value>
+  </data>
+  <data name="SetDefaultSeries" xml:space="preserve">
+    <value>Añadir serie por defecto</value>
+  </data>
+  <data name="DefSeries1" xml:space="preserve">
+    <value>Seleccione la serie de</value>
+  </data>
+  <data name="DefSeries2" xml:space="preserve">
+    <value>Selección de una serie por defecto significa que todas las imágenes que son dsiplayed para un grupo utilice </value>
+  </data>
+  <data name="DefSeries3" xml:space="preserve">
+    <value>serie por defecto en lugar de una serie al azar dentro del grupo</value>
+  </data>
+  <data name="ChangeLanguage" xml:space="preserve">
+    <value>Cambiar idioma</value>
+  </data>
+  <data name="EpisodeTitleSourceStyle" xml:space="preserve">
+    <value>Episodio título fuente</value>
+  </data>
+  <data name="SeriesNameSourceStyle" xml:space="preserve">
+    <value>Origen del nombre de la serie</value>
+  </data>
+  <data name="SeriesOverviewSourceStyle" xml:space="preserve">
+    <value>Fuente de serie Resumen</value>
+  </data>
+  <data name="Tooltip_EpisodeTitleSourceStyle" xml:space="preserve">
+    <value>Fuente preferida de información cuando se muestra el título de un episodio</value>
+  </data>
+  <data name="Tooltip_SeriesNameSourceStyle" xml:space="preserve">
+    <value>Fuente preferida de información cuando se muestran el nombre de la serie de anime</value>
+  </data>
+  <data name="Tooltip_SeriesOverviewSourceStyle" xml:space="preserve">
+    <value>Fuente preferida de información cuando se muestran la descripción (descripción) de una serie de anime</value>
+  </data>
+  <data name="User_EditSettings" xml:space="preserve">
+    <value>Editar configuración del servidor</value>
+  </data>
+  <data name="Tooltip_RemoveMissingFiles" xml:space="preserve">
+    <value>Esto eliminará todas las entradas de archivos de vídeo de la base de datos, donde no se encuentra físicamente el archivo. Asegúrese de que están disponibles todas las acciones de red o unidades USB conectado antes de ejecutar este.</value>
+  </data>
+  <data name="Tooltip_UpdateMediaInfo" xml:space="preserve">
+    <value>La información de los medios de comunicación es la información sobre los archivos tales como velocidad de bits, resolución codecs etc que se lee y almacena la primera vez le importa un archivo</value>
+  </data>
+  <data name="UpdateMediaInfo" xml:space="preserve">
+    <value>Actualizar su información de todos los medios de comunicación</value>
+  </data>
+  <data name="Video_Hi10P" xml:space="preserve">
+    <value>10 bit</value>
+  </data>
+  <data name="Tooltip_TraktAnimeOnly" xml:space="preserve">
+    <value>Sólo Mostrar actividad se relaciona con anime (es decir excluye otra serie de tv)</value>
+  </data>
+  <data name="TraktAnimeOnly" xml:space="preserve">
+    <value>Solo en el anime</value>
+  </data>
+  <data name="ForceRefresh" xml:space="preserve">
+    <value>Actualización de la fuerza</value>
+  </data>
+  <data name="TraktFriendNotes" xml:space="preserve">
+    <value>Información se actualiza en el servidor cada 20 minutos</value>
+  </data>
+  <data name="Dash_RecentEpisodes" xml:space="preserve">
+    <value>Recientemente vistos episodios</value>
+  </data>
+  <data name="PromptRateSeries" xml:space="preserve">
+    <value>Sugerirán el serie de tasa de terminación</value>
+  </data>
+  <data name="Tooltip_PromptRateSeries" xml:space="preserve">
+    <value>Cuando usted mira el último episodio de una serie, un mensaje aparecerá para pedirte una calificación</value>
+  </data>
+  <data name="MALSearchPrompt" xml:space="preserve">
+    <value>Buscar en MyAnimelist o introducir ID de MAL</value>
+  </data>
+  <data name="MALShow" xml:space="preserve">
+    <value>Ir a MyAnimeList</value>
+  </data>
+  <data name="Tooltip_WebCache_MALAssociations" xml:space="preserve">
+    <value>Para ver enlaces entre AniDB y MyAnimeList, usar la caché web. Si no ha seleccionado tendrá que buscar manualmente todos los enlaces MAL.</value>
+  </data>
+  <data name="WebCache_MALAssociations" xml:space="preserve">
+    <value>Enlaces de MyAnimeList</value>
+  </data>
+  <data name="Tooltip_MAL_UpdateFrequency" xml:space="preserve">
+    <value>Con qué frecuencia se actualización los datos, y con qué frecuencia se realiza una búsqueda automática para buscar anime en tu colección que no tiene un enlace MAL</value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedMALInfo" xml:space="preserve">
+    <value>Tiene enlace MAL</value>
+  </data>
+  <data name="Tooltip_UseFanartOnSeries" xml:space="preserve">
+    <value>Fanart de usuario en lugar de carteles (donde estén disponibles) en la pantalla de serie</value>
+  </data>
+  <data name="UseFanartOnSeries" xml:space="preserve">
+    <value>Fanart de usuario en pantalla de serie</value>
+  </data>
+  <data name="MAL_NeverDecrease" xml:space="preserve">
+    <value>Nunca disminución visto cuentas</value>
+  </data>
+  <data name="Tooltip_MAL_NeverDecrease" xml:space="preserve">
+    <value>Asegúrese de que miraba las cuentas siempre se mantienen. Esto requiere descargar la lista completa cada vez que ves un episodio, así que puede ser desperdiciador de tiempo</value>
+  </data>
+  <data name="GroupFilterConditionType_EpisodeCount" xml:space="preserve">
+    <value>Episodio cuenta</value>
+  </data>
+  <data name="SyncMalDown" xml:space="preserve">
+    <value>Descargar ver Estados de MAL</value>
+  </data>
+  <data name="SyncMalUp" xml:space="preserve">
+    <value>Cargar Estados vistos en MAL</value>
+  </data>
+  <data name="Tooltip_SyncMalDown" xml:space="preserve">
+    <value>Descargar Estados vistos de MAL y actualizar su colección local y AniDB.</value>
+  </data>
+  <data name="Tooltip_SyncMalUp" xml:space="preserve">
+    <value>Actualización de MAL uso de las estadísticas de seguimiento de su colección local</value>
+  </data>
+  <data name="Tooltip_WebCache_AniDB_File" xml:space="preserve">
+    <value>Se trata de los datos asociados con cada archivo individual. Recomendado para grandes colecciones</value>
+  </data>
+  <data name="WebCache_AniDB_File" xml:space="preserve">
+    <value>Datos de archivo AniDB</value>
+  </data>
+  <data name="PlaylistPlayOrderRandom" xml:space="preserve">
+    <value>Al azar</value>
+  </data>
+  <data name="PlaylistPlayOrderSeq" xml:space="preserve">
+    <value>Secuencial</value>
+  </data>
+  <data name="AniDBScheduleMyListStats" xml:space="preserve">
+    <value>Obtener automáticamente estadísticas de MyList de AniDB</value>
+  </data>
+  <data name="GroupFilter_Predefined" xml:space="preserve">
+    <value>Filtros predefinidos</value>
+  </data>
+  <data name="BakaBTResetBody" xml:space="preserve">
+    <value>Restablece la cookie si no obtiene ningún resultado de BakaBT cuando debe. Esto obligará a un inicio de sesión en BakaBT otra vez.</value>
+  </data>
+  <data name="BakaBTResetTitle" xml:space="preserve">
+    <value>Cookie de RESET</value>
+  </data>
+  <data name="BakaBTSeriesBody" xml:space="preserve">
+    <value>Cuando buscando una serie, BakaBT (y AnimeBytes) será la fuente de torrent solo en la búsqueda inicial</value>
+  </data>
+  <data name="BakaBTSeriesTitle" xml:space="preserve">
+    <value>BakaBT (y AnimeBytes) solamente</value>
+  </data>
+  <data name="AnimeBytesResetBody" xml:space="preserve">
+    <value>Restablece la cookie si no obtiene ningún resultado de AnimeBytes cuando debe ser. Esto obligará a un inicio de sesión para AnimeBytes otra vez.</value>
+  </data>
+  <data name="AnimeBytesResetTitle" xml:space="preserve">
+    <value>Cookie de RESET</value>
+  </data>
+  <data name="AnimeBytesSeriesBody" xml:space="preserve">
+    <value>En la búsqueda de una serie, AnimeBytes (y BakaBT) será la fuente de torrent solo en la búsqueda inicial</value>
+  </data>
+  <data name="AnimeBytesSeriesTitle" xml:space="preserve">
+    <value>AnimeBytes (y BakaBT) sólo</value>
+  </data>
+  <data name="IsVariation" xml:space="preserve">
+    <value>Es la variación</value>
+  </data>
+  <data name="Tooltip_IsVariation" xml:space="preserve">
+    <value>Utilícelo cuando no desee que un archivo aparezca en el Control de archivos múltiples. Esto puede ser el caso donde usted tiene varias versiones de un OP/ED para limpiar/no limpia, corte del director y otros tipos de variaciones</value>
+  </data>
+  <data name="AniDBDownloadCharacters" xml:space="preserve">
+    <value>Descargar imágenes de carácter</value>
+  </data>
+  <data name="AniDBDownloadCreators" xml:space="preserve">
+    <value>Descargar creador de imagenes</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadCharacters" xml:space="preserve">
+    <value>Estas imágenes se muestran en 3 MyAnime y Anime amigo</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadCreators" xml:space="preserve">
+    <value>Estas imágenes se muestran en 3 MyAnime y Anime Buddy (actores de voz)</value>
+  </data>
+  <data name="AniDBMyListDeleteAction" xml:space="preserve">
+    <value>Eliminar la acción</value>
+  </data>
+  <data name="Tooltip_AniDBMyListDeleteAction" xml:space="preserve">
+    <value>Acción a tomar para un archivo cuando eliminas de ti colección local.
+Borrar archivo (AniDB) - elimina de tu AniDB MyList.
+Eliminar archivo (Local DB) - eliminar el archivo de la DB local solamente.
+Marca Deleted - deja el archivo en la lista, pero cambia el estado de borrado.
+Marca externa (CD/DVD) - deja el archivo en la lista, pero cambia el estado a almacenamiento externo.
+Desconocido de la marca - deja el archivo en la lista, pero cambia el estado a desconocido.</value>
+  </data>
+  <data name="GroupFilterConditionType_CustomTag" xml:space="preserve">
+    <value>Etiqueta personalizada</value>
+  </data>
+  <data name="Tooltip_WebCache_UserInfo" xml:space="preserve">
+    <value>Envía info del uso anónimo a la caché de web como el tipo de base de datos, versión de Windows etc.. Consulte la ayuda de enlace para todos los datos que se envía</value>
+  </data>
+  <data name="WebCache_UserInfo" xml:space="preserve">
+    <value>Enviar Info del uso anónimo</value>
+  </data>
+  <data name="NewSeries_Search" xml:space="preserve">
+    <value>Búsqueda por título o identificación</value>
+  </data>
+  <data name="Tooltip_NewSeries_Search" xml:space="preserve">
+    <value>Ingrese parte del nombre del anime, o si sabes el ID AniDB solo accede directamente</value>
+  </data>
+  <data name="Link_CommunityRecommendation" xml:space="preserve">
+    <value>http://jmediamanager.org/FAQ/#What-are-Community-Recommendations</value>
+  </data>
+  <data name="WhatsThis" xml:space="preserve">
+    <value>¿Qué es esto?</value>
+  </data>
+  <data name="Override" xml:space="preserve">
+    <value>Reemplazar</value>
+  </data>
+  <data name="Tooltip_NameOverride" xml:space="preserve">
+    <value>Manualmente puede escribir el nombre preferido o utilizar las flechas verdes a la derecha para seleccionar un nombre de AniDB.</value>
+  </data>
+  <data name="Tooltip_NameOverride2" xml:space="preserve">
+    <value>Seleccione un nombre de una lista de nombres de AniDB.</value>
+  </data>
+  <data name="AdminMessageTitle" xml:space="preserve">
+    <value>Mensaje de admin</value>
+  </data>
+  <data name="CheckForUpdate" xml:space="preserve">
+    <value>Buscar actualizaciones</value>
+  </data>
+  <data name="Link_Blog" xml:space="preserve">
+    <value>http://jmediamanager.org/blog</value>
+  </data>
+  <data name="Link_AniDBBanned" xml:space="preserve">
+    <value>http://jmediamanager.org/FAQ/#Banned-From-AniDB</value>
+  </data>
+  <data name="Link_AniDBSettings" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#AniDB</value>
+  </data>
+  <data name="Link_FileRenaming" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Utilities/File-Renaming/</value>
+  </data>
+  <data name="Link_GroupFilters" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Collection/#What-are-filters</value>
+  </data>
+  <data name="Link_ImportFolders" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Server/Configuring-JMM-Server/#Import-folders</value>
+  </data>
+  <data name="Link_MAL" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#Community-Sites</value>
+  </data>
+  <data name="Link_MPC" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#MPC</value>
+  </data>
+  <data name="Link_PotPlayer" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#Pot-Player</value>
+  </data>
+  <data name="Link_TMDb" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#Community-Sites</value>
+  </data>
+  <data name="Link_Trakt" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#Community-Sites</value>
+  </data>
+  <data name="Link_TvDB" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#Community-Sites</value>
+  </data>
+  <data name="Link_uTorrent" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/downloads/#uTorrent</value>
+  </data>
+  <data name="Link_VLC" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#VLC</value>
+  </data>
+  <data name="Link_WebCache" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#web-cache</value>
+  </data>
+  <data name="UpdateFrequency_OneMonth" xml:space="preserve">
+    <value>Una vez al mes</value>
+  </data>
+  <data name="UpdateFrequency_OneWeek" xml:space="preserve">
+    <value>Una vez por semana</value>
+  </data>
+  <data name="SettingAlwaysAniDBPoster" xml:space="preserve">
+    <value>Utilice siempre el cartel de AniDB</value>
+  </data>
+  <data name="Tooltip_SettingAlwaysAniDBPoster" xml:space="preserve">
+    <value>Esta configuración se invalidar cualquier otra configuración de cartel para que se utiliza sólo el cartel AniDB. Esto es generalmente más rápido que usando carteles al azar</value>
+  </data>
+  <data name="MoreInfo" xml:space="preserve">
+    <value>Más Info</value>
+  </data>
+  <data name="Link_Changelog" xml:space="preserve">
+    <value>http://jmediamanager.org/changelog/</value>
+  </data>
+  <data name="Link_Download" xml:space="preserve">
+    <value>http://jmediamanager.org/downloads/</value>
+  </data>
+  <data name="Link_Site" xml:space="preserve">
+    <value>http://jmediamanager.org/</value>
+  </data>
+  <data name="ReenterPassword" xml:space="preserve">
+    <value>Re-enter Password</value>
+  </data>
+  <data name="ChangePassword" xml:space="preserve">
+    <value>Cambiar contraseña</value>
+  </data>
+  <data name="ChangingPassword" xml:space="preserve">
+    <value>Cambio de contraseña para: </value>
+  </data>
+  <data name="WhatDoesThisMean" xml:space="preserve">
+    <value>¿Qué significa esto?</value>
+  </data>
+  <data name="DetailedExplanation" xml:space="preserve">
+    <value>Para una explicación detallada de opciones, haga clic en</value>
+  </data>
+  <data name="CustomTag_Name" xml:space="preserve">
+    <value>Nombre de la etiqueta</value>
+  </data>
+  <data name="CustomTag_Description" xml:space="preserve">
+    <value>Etiqueta Descripción</value>
+  </data>
+  <data name="Add" xml:space="preserve">
+    <value>Añadir</value>
+  </data>
+  <data name="MissingEpisodes_AnimeName" xml:space="preserve">
+    <value>Nombre de anime</value>
+  </data>
+  <data name="MissingEpisodes_AnimeID" xml:space="preserve">
+    <value>Anime ID</value>
+  </data>
+  <data name="MissingEpisodes_EpisodeNumber" xml:space="preserve">
+    <value>Número de episodio</value>
+  </data>
+  <data name="MissingEpisodes_EpisodeID" xml:space="preserve">
+    <value>ID del episodio</value>
+  </data>
+  <data name="MissingEpisodes_GroupSummary" xml:space="preserve">
+    <value>Grupo Extracto</value>
+  </data>
+  <data name="MissingEpisodes_AnimeLink" xml:space="preserve">
+    <value>Enlace a Anime</value>
+  </data>
+  <data name="MissingEpisodes_EpisodeLink" xml:space="preserve">
+    <value>Enlace al episodio</value>
+  </data>
+  <data name="MissingEpisodes_FileSummary" xml:space="preserve">
+    <value>Extracto de archivo</value>
+  </data>
+  <data name="NewSeries_AlreadyAttached" xml:space="preserve">
+    <value>Una serie ya ha sido fijada para este anime</value>
+  </data>
+  <data name="NewSeries_Step1" xml:space="preserve">
+    <value>Paso 1 - Seleccione un Anime</value>
+  </data>
+  <data name="NewSeries_SearchBy" xml:space="preserve">
+    <value>Búsqueda por título o identificación</value>
+  </data>
+  <data name="NewSeries_Step2" xml:space="preserve">
+    <value>Seleccione un Grupo Local</value>
+  </data>
+  <data name="NewSeries_BackToStep1" xml:space="preserve">
+    <value>Regresar al paso 1</value>
+  </data>
+  <data name="TryAgain" xml:space="preserve">
+    <value>¡Vuelve a intentarlo!</value>
+  </data>
+  <data name="Random_Tags" xml:space="preserve">
+    <value>Etiquetas</value>
+  </data>
+  <data name="Finish" xml:space="preserve">
+    <value>Acabado</value>
+  </data>
+  <data name="Clear" xml:space="preserve">
+    <value>Claro</value>
+  </data>
+  <data name="Matches" xml:space="preserve">
+    <value>Acerca de los partidos</value>
+  </data>
+  <data name="Random_Watched" xml:space="preserve">
+    <value>Visto</value>
+  </data>
+  <data name="Random_Unwatched" xml:space="preserve">
+    <value>No</value>
+  </data>
+  <data name="Random_PartiallyWatched" xml:space="preserve">
+    <value>Visto parcialmente</value>
+  </data>
+  <data name="Random_CompleteOnly" xml:space="preserve">
+    <value>Completar solamente</value>
+  </data>
+  <data name="Random_View" xml:space="preserve">
+    <value>Ver esta serie</value>
+  </data>
+  <data name="RateSeries_Rate" xml:space="preserve">
+    <value>Serie de tipo:</value>
+  </data>
+  <data name="RateSeries_TraktShout" xml:space="preserve">
+    <value>Tu opinión sobre Trakt</value>
+  </data>
+  <data name="Search_Episodes" xml:space="preserve">
+    <value>Episodios:</value>
+  </data>
+  <data name="Search_StartingAt" xml:space="preserve">
+    <value>A partir de las</value>
+  </data>
+  <data name="Search_ID" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="Search_Title" xml:space="preserve">
+    <value>Título</value>
+  </data>
+  <data name="Search_AniDBStart" xml:space="preserve">
+    <value>Inicio AniDB:</value>
+  </data>
+  <data name="Search_Trakt" xml:space="preserve">
+    <value>Trakt: </value>
+  </data>
+  <data name="Search_Approved" xml:space="preserve">
+    <value>Admin aprobado</value>
+  </data>
+  <data name="Search_TvDB" xml:space="preserve">
+    <value>TvDB: </value>
+  </data>
+  <data name="Search_MAL" xml:space="preserve">
+    <value>MAL: </value>
+  </data>
+  <data name="SelectAniDBTitle_SelectName" xml:space="preserve">
+    <value>Seleccione un nombre de reemplazo</value>
+  </data>
+  <data name="SelectGroupSeries_Select" xml:space="preserve">
+    <value>Seleccione un </value>
+  </data>
+  <data name="Select_MyAnimeList" xml:space="preserve">
+    <value>MyAnimeList</value>
+  </data>
+  <data name="Select_StartingEpisode" xml:space="preserve">
+    <value>A partir de episodio #</value>
+  </data>
+  <data name="Select_EpisodeType" xml:space="preserve">
+    <value>Tipo de episodio:</value>
+  </data>
+  <data name="Select_TraktTV" xml:space="preserve">
+    <value>Trakt TV</value>
+  </data>
+  <data name="Select_TvDBDetails" xml:space="preserve">
+    <value>Seleccione detalles de TvDB</value>
+  </data>
+  <data name="Select_Season" xml:space="preserve">
+    <value>Temporada</value>
+  </data>
+  <data name="Select_DefaultLanguage" xml:space="preserve">
+    <value>Seleccione el idioma predeterminado</value>
+  </data>
+  <data name="Update_Update" xml:space="preserve">
+    <value>JMM escritorio actualización disponible!</value>
+  </data>
+  <data name="Update_UpdatePage" xml:space="preserve">
+    <value>Página de la actualización</value>
+  </data>
+  <data name="Update_Changelog" xml:space="preserve">
+    <value>Registro de cambios</value>
+  </data>
+  <data name="Update_AvailableVersion" xml:space="preserve">
+    <value>Disponible la versión</value>
+  </data>
+  <data name="Update_YourVersion" xml:space="preserve">
+    <value>Su versión</value>
+  </data>
+  <data name="ViewComments_FromTrakt" xml:space="preserve">
+    <value>De Trakt</value>
+  </data>
+  <data name="ViewComments_Username" xml:space="preserve">
+    <value>Nombre de usuario</value>
+  </data>
+  <data name="ViewComments_CommentDate" xml:space="preserve">
+    <value>Fecha del comentario</value>
+  </data>
+  <data name="ViewComments_Comments" xml:space="preserve">
+    <value>Comentarios</value>
+  </data>
+  <data name="ViewComments_Website" xml:space="preserve">
+    <value>Ver en página web</value>
+  </data>
+  <data name="JMMDesktop" xml:space="preserve">
+    <value>Escritorio JMM</value>
+  </data>
+  <data name="MoreInformation" xml:space="preserve">
+    <value>Más información</value>
+  </data>
+  <data name="Metro_Continue" xml:space="preserve">
+    <value>Seguir viendo</value>
+  </data>
+  <data name="Metro_New" xml:space="preserve">
+    <value>Nuevos episodios</value>
+  </data>
+  <data name="Metro_Random" xml:space="preserve">
+    <value>Serie al azar</value>
+  </data>
+  <data name="Metro_Trakt" xml:space="preserve">
+    <value>Actividad de Trakt</value>
+  </data>
+  <data name="MarkedFavorite" xml:space="preserve">
+    <value>Este grupo está marcado como favorito</value>
+  </data>
+  <data name="Community_TraktValid" xml:space="preserve">
+    <value>Ver que mis enlaces son todavía válidos en el Trakt</value>
+  </data>
+  <data name="Community_TraktRemoveBad" xml:space="preserve">
+    <value>Eliminar automáticamente mala información de la base de datos (muy recomendada)</value>
+  </data>
+  <data name="Community_CommunityCheck" xml:space="preserve">
+    <value>Comprobar si mis enlaces son diferentes de las recomendaciones de la comunidad</value>
+  </data>
+  <data name="Community_ProblemStop" xml:space="preserve">
+    <value>Parar después de encontrar tantos problemas</value>
+  </data>
+  <data name="Trakt" xml:space="preserve">
+    <value>Trakt</value>
+  </data>
+  <data name="Start" xml:space="preserve">
+    <value>Inicio</value>
+  </data>
+  <data name="Stop" xml:space="preserve">
+    <value>Parada</value>
+  </data>
+  <data name="Community_Filter" xml:space="preserve">
+    <value>Filtro:</value>
+  </data>
+  <data name="Community_Refresh" xml:space="preserve">
+    <value>Actualizar los datos de esta serie</value>
+  </data>
+  <data name="Community_SeriesName" xml:space="preserve">
+    <value>Nombre de la serie</value>
+  </data>
+  <data name="Community_Status" xml:space="preserve">
+    <value>Estado</value>
+  </data>
+  <data name="Community_ValidTraktLink" xml:space="preserve">
+    <value>Vínculo válido Trakt</value>
+  </data>
+  <data name="Community_HasTraktLink" xml:space="preserve">
+    <value>Tiene enlace Trakt</value>
+  </data>
+  <data name="Community_CommunityLink" xml:space="preserve">
+    <value>Comunidad enlace</value>
+  </data>
+  <data name="Community_Match" xml:space="preserve">
+    <value>¿Enlaces partido?</value>
+  </data>
+  <data name="Download_Bookmark" xml:space="preserve">
+    <value>Marcar este anime a descargar más tarde</value>
+  </data>
+  <data name="Download_SeriesSearch" xml:space="preserve">
+    <value>Búsqueda de descargas de esta serie</value>
+  </data>
+  <data name="Download_Approval" xml:space="preserve">
+    <value>Aprobación</value>
+  </data>
+  <data name="Download_YourVote" xml:space="preserve">
+    <value>Su voto</value>
+  </data>
+  <data name="Download_RecommendPrompt" xml:space="preserve">
+    <value>Esta utilidad muestra una lista de anime recomendada que no están en su colección basada en sus calificaciones y comentarios de los usuarios de AniDB</value>
+  </data>
+  <data name="Torrent" xml:space="preserve">
+    <value>Torrent</value>
+  </data>
+  <data name="Torrents" xml:space="preserve">
+    <value>Torrents</value>
+  </data>
+  <data name="Download_Name" xml:space="preserve">
+    <value>Nombre</value>
+  </data>
+  <data name="Download_Size" xml:space="preserve">
+    <value>Tamaño</value>
+  </data>
+  <data name="Download_Seeders" xml:space="preserve">
+    <value>Sembradoras</value>
+  </data>
+  <data name="Download_Leechers" xml:space="preserve">
+    <value>Leechers</value>
+  </data>
+  <data name="Download_ExtraInfo" xml:space="preserve">
+    <value>Info extra</value>
+  </data>
+  <data name="Download_WrongSeries" xml:space="preserve">
+    <value>¿Serie equivocada?</value>
+  </data>
+  <data name="Tooltip_WrongSeries" xml:space="preserve">
+    <value>Se trata de JMMs intento adivinar qué serie estás mirando por lo que se puede comparar a tu colección local. Si no tienes la serie en su colección será incorrecta.</value>
+  </data>
+  <data name="Download_ResetCookie" xml:space="preserve">
+    <value>Cookie de RESET</value>
+  </data>
+  <data name="Download_AnimeBytesOnly" xml:space="preserve">
+    <value>AnimeBytes sólo para la serie</value>
+  </data>
+  <data name="Download_BakaBTOnly" xml:space="preserve">
+    <value>BakaBT sólo para la serie</value>
+  </data>
+  <data name="Available" xml:space="preserve">
+    <value>Disponible</value>
+  </data>
+  <data name="Selected" xml:space="preserve">
+    <value>Seleccionado</value>
+  </data>
+  <data name="Download_Source" xml:space="preserve">
+    <value>Fuente</value>
+  </data>
+  <data name="Download_Server" xml:space="preserve">
+    <value>Servidor</value>
+  </data>
+  <data name="Download_RefreshInterval" xml:space="preserve">
+    <value>Actualizar intervalo (segundos)</value>
+  </data>
+  <data name="Download_AutoRefresh" xml:space="preserve">
+    <value>Actualización automática</value>
+  </data>
+  <data name="Download_UseBlackHole" xml:space="preserve">
+    <value>Agujero negro de uso Torrent</value>
+  </data>
+  <data name="Download_FolderLocation" xml:space="preserve">
+    <value>Ubicación de la carpeta</value>
+  </data>
+  <data name="Download_Hash" xml:space="preserve">
+    <value>Hash</value>
+  </data>
+  <data name="Download_Queue" xml:space="preserve">
+    <value>#</value>
+  </data>
+  <data name="Download_Done" xml:space="preserve">
+    <value>Hecho</value>
+  </data>
+  <data name="Download_Peers" xml:space="preserve">
+    <value>Compañeros</value>
+  </data>
+  <data name="Download_DownSpeed" xml:space="preserve">
+    <value>Velocidad</value>
+  </data>
+  <data name="Download_UpSpeed" xml:space="preserve">
+    <value>Velocidad de subida</value>
+  </data>
+  <data name="Download_Ratio" xml:space="preserve">
+    <value>Relación de</value>
+  </data>
+  <data name="Download_InvalidCred" xml:space="preserve">
+    <value>No se han especificado credenciales válidas de uTorrent</value>
+  </data>
+  <data name="Download_EnterCred" xml:space="preserve">
+    <value>Por favor, introduzca sus credenciales en la ficha Configuración y luego regresar</value>
+  </data>
+  <data name="Download_Priority" xml:space="preserve">
+    <value>Prioridad</value>
+  </data>
+  <data name="Download_Downloaded" xml:space="preserve">
+    <value>Descargado</value>
+  </data>
+  <data name="Settings_DeleteAction" xml:space="preserve">
+    <value>Eliminar la acción</value>
+  </data>
+  <data name="Settings_AutoUpdateInfo" xml:space="preserve">
+    <value>Actualizar automáticamente los archivos con la información que falta</value>
+  </data>
+  <data name="Settings_HideDownloadButton" xml:space="preserve">
+    <value>Ocultar botón de Download episodio cuando ya tenga archivos</value>
+  </data>
+  <data name="Settings_RecreateGroups" xml:space="preserve">
+    <value>Volver a crear todos los grupos</value>
+  </data>
+  <data name="Settings_ScanOnStart" xml:space="preserve">
+    <value>Analizar carpetas gota en Inicio</value>
+  </data>
+  <data name="Settings_ImagePath" xml:space="preserve">
+    <value>Ruta de la imagen</value>
+  </data>
+  <data name="Settings_SelectFolder" xml:space="preserve">
+    <value>Seleccionar carpeta</value>
+  </data>
+  <data name="Settings_FilePort" xml:space="preserve">
+    <value>Puerto de archivo</value>
+  </data>
+  <data name="WebCache_TraktLinks" xml:space="preserve">
+    <value>Enlaces de Trakt</value>
+  </data>
+  <data name="VideoPlayer_MPC" xml:space="preserve">
+    <value>Media Player Classic</value>
+  </data>
+  <data name="VideoPlayer_MPCNote" xml:space="preserve">
+    <value>Para la integración de MPC que debe habilitar las dos opciones (1) tienda configuración al archivo .ini y (2) mantener historia de recientemente visto archivos. Ver la siguiente captura de pantalla para más detalles. La ubicación del MPC es generalmente algo como C:\Program Files (x 86) \Combined Community Codec Pack\MPC</value>
+  </data>
+  <data name="VideoPlayer_MPCOptions" xml:space="preserve">
+    <value>Opciones de MPC</value>
+  </data>
+  <data name="VideoPlayer_VLC" xml:space="preserve">
+    <value>VLC</value>
+  </data>
+  <data name="VideoPlayer_VLCNote" xml:space="preserve">
+    <value>VLC 2.2 + graba archivos recientes y marcas de tiempo por defecto, y es una opción 'Avanzadas'. Versiones anteriores no admiten la funcionalidad 'Reanudar desde la última posición'. La ubicación del archivo .ini VLC es generalmente algo como C:\Users\username\AppData\Roaming\vlc\vlc-qt-interface.ini</value>
+  </data>
+  <data name="VideoPlayer_VLCOptions" xml:space="preserve">
+    <value>Opciones de VLC</value>
+  </data>
+  <data name="VideoPlayer_PotPlayer" xml:space="preserve">
+    <value>PotPlayer</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerNote" xml:space="preserve">
+    <value>Para integración de PotPlayer debes activar las siguientes opciones (1) Preferencias &amp;gt; General &amp;gt; Tienda de configuración .ini archivo (2) Preferencias &gt; reproducción &gt; jugar desde el último punto. Ver la siguiente captura de pantalla para más detalles. La ubicación del archivo PlotPlayer. ini está generalmente algo como C:\Users\username\AppData\Roaming\PotPlayer64\PotPlayer64.ini</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerOptions" xml:space="preserve">
+    <value>Opciones de PotPlayer</value>
+  </data>
+  <data name="VideoPlayer_MPCINI" xml:space="preserve">
+    <value>Seleccione la carpeta INI de MPC</value>
+  </data>
+  <data name="VideoPlayer_VLCINI" xml:space="preserve">
+    <value>Seleccione la carpeta INI de VLC</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerINI" xml:space="preserve">
+    <value>Seleccione la carpeta INI de PotPlayer</value>
+  </data>
+  <data name="VideoPlayer_MPCTest" xml:space="preserve">
+    <value>Archivo de prueba de MPC</value>
+  </data>
+  <data name="VideoPlayer_VLCTest" xml:space="preserve">
+    <value>Prueba VLC archivo</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerTest" xml:space="preserve">
+    <value>Archivo de prueba de PotPlayer</value>
+  </data>
+  <data name="VideoPlayer_AutoMark" xml:space="preserve">
+    <value>Marcar automáticamente archivos mientras miraba cuando se observó el siguiente porcentaje</value>
+  </data>
+  <data name="VideoPlayer_MPCFolder" xml:space="preserve">
+    <value>Carpeta de MPC INI</value>
+  </data>
+  <data name="VideoPlayer_VLCFolder" xml:space="preserve">
+    <value>Carpeta de VLC INI</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerFolder" xml:space="preserve">
+    <value>Carpeta de PotPlayer INI</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote1" xml:space="preserve">
+    <value>Preferencias de selección de archivo automáticos - se refiere a cuando tienes más de archivo para un episodio</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote2" xml:space="preserve">
+    <value>Para una lista de reproducción debe elegir un archivo, que se basará en que preferencias abajo.</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote3" xml:space="preserve">
+    <value>Para un solo episodio puede activar selección de archivo de auto o tiene JMM le pedirá que seleccione un archivo cuando tenga más de una</value>
+  </data>
+  <data name="VideoPlayer_AutoFileFirstEpisode" xml:space="preserve">
+    <value>Selección automática de archivo - primer episodio de la serie</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNextEpisode" xml:space="preserve">
+    <value>Selección automática de archivo - episodios posteriores en serie</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote4" xml:space="preserve">
+    <value>Si selecciona 'Comunicado de grupo de previamente jugado episodio' en el ajuste anterior también debe hacer lo siguiente</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote5" xml:space="preserve">
+    <value>Desmarca 'Set archivo mientras miraba si el episodio es visto' bajo - esencial - importación ajustes</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote6" xml:space="preserve">
+    <value>Siempre marca un archivo como visto y no un episodio</value>
+  </data>
+  <data name="VideoPlayer_AutoFileEnable" xml:space="preserve">
+    <value>Habilitar auto archivo selección de episodios individuales</value>
+  </data>
+  <data name="TvDB_WideBannerMax" xml:space="preserve">
+    <value>Banners ancho máximo</value>
+  </data>
+  <data name="TvDB_PostersMax" xml:space="preserve">
+    <value>Carteles máxima</value>
+  </data>
+  <data name="Trakt_Enable" xml:space="preserve">
+    <value>Permiten Trakt</value>
+  </data>
+  <data name="Trakt_PIN" xml:space="preserve">
+    <value>Trakt PIN</value>
+  </data>
+  <data name="Trakt_GetPIN" xml:space="preserve">
+    <value>Obtener Pin</value>
+  </data>
+  <data name="Trakt_Authorize" xml:space="preserve">
+    <value>Autorizar a JMM</value>
+  </data>
+  <data name="Trakt_CurrentToken" xml:space="preserve">
+    <value>Token actual es válida hasta:</value>
+  </data>
+  <data name="Trakt_AutoFanart" xml:space="preserve">
+    <value>Auto descargar Fanart</value>
+  </data>
+  <data name="Trakt_AutoPosters" xml:space="preserve">
+    <value>Auto descargar carteles</value>
+  </data>
+  <data name="Trakt_AutoEpisodeImages" xml:space="preserve">
+    <value>Imágenes de auto descargar episodio</value>
+  </data>
+  <data name="MovieDB_MaxPosters" xml:space="preserve">
+    <value>Carteles máxima</value>
+  </data>
+  <data name="AnimeGroup_Random" xml:space="preserve">
+    <value>Episodio al azar</value>
+  </data>
+  <data name="AnimeGroup_AllSeries" xml:space="preserve">
+    <value>Todas las Series</value>
+  </data>
+  <data name="AnimeGroup_DoubleClick" xml:space="preserve">
+    <value>Haga doble clic en una serie para ver directamente</value>
+  </data>
+  <data name="PinnedSeries_Simple" xml:space="preserve">
+    <value>Mostrar vista simplificada</value>
+  </data>
+  <data name="Playlist_Add" xml:space="preserve">
+    <value>Añadir a lista de reproducción</value>
+  </data>
+  <data name="Series_Overview" xml:space="preserve">
+    <value>Resumen</value>
+  </data>
+  <data name="Series_MoreInfo" xml:space="preserve">
+    <value>Más información</value>
+  </data>
+  <data name="Series_CustomTags" xml:space="preserve">
+    <value>Etiquetas personalizadas</value>
+  </data>
+  <data name="Series_ManageCustom" xml:space="preserve">
+    <value>Administrar etiquetas personalizadas</value>
+  </data>
+  <data name="Series_Tag" xml:space="preserve">
+    <value>Etiqueta</value>
+  </data>
+  <data name="Series_Add" xml:space="preserve">
+    <value>Añadir</value>
+  </data>
+  <data name="Series_Files" xml:space="preserve">
+    <value>Archivos</value>
+  </data>
+  <data name="Series_Folder" xml:space="preserve">
+    <value>Carpeta de</value>
+  </data>
+  <data name="SeriesSimple_TraktLink" xml:space="preserve">
+    <value>Vaya este episodio en Trakt.TV</value>
+  </data>
+  <data name="SeriesSimple_Comments" xml:space="preserve">
+    <value>Comentarios</value>
+  </data>
+  <data name="SeriesSimple_Play" xml:space="preserve">
+    <value>Juego</value>
+  </data>
+  <data name="SeriesSimple_Watched" xml:space="preserve">
+    <value>Visto:</value>
+  </data>
+  <data name="SeriesSimple_From" xml:space="preserve">
+    <value>De:</value>
+  </data>
+  <data name="SeriesSimple_AlreadyHave" xml:space="preserve">
+    <value>Ya tienes este anime en su colección</value>
+  </data>
+  <data name="SeriesSimple_Details" xml:space="preserve">
+    <value>Detalles:</value>
+  </data>
+  <data name="SeriesSimple_Voteup" xml:space="preserve">
+    <value>Voto para arriba</value>
+  </data>
+  <data name="SeriesSimple_VoteDown" xml:space="preserve">
+    <value>Votar en contra</value>
+  </data>
+  <data name="SeriesSimple_FromTrakt" xml:space="preserve">
+    <value>De Trakt</value>
+  </data>
+  <data name="SeriesSimple_View" xml:space="preserve">
+    <value>Ver</value>
+  </data>
+  <data name="SeriesSimple_FromAniDB" xml:space="preserve">
+    <value>Desde AniDB</value>
+  </data>
+  <data name="SeriesSimple_Aired" xml:space="preserve">
+    <value>Salió al aire</value>
+  </data>
+  <data name="SeriesSimple_Episodes" xml:space="preserve">
+    <value>Episodios</value>
+  </data>
+  <data name="SeriesSimple_MyVote" xml:space="preserve">
+    <value>Mi voto</value>
+  </data>
+  <data name="SeriesSimple_PlayNext" xml:space="preserve">
+    <value>Jugar próximo episodio</value>
+  </data>
+  <data name="SeriesSimple_PlayUnWatched" xml:space="preserve">
+    <value>Jugar (todos</value>
+  </data>
+  <data name="SeriesSimple_YourSay" xml:space="preserve">
+    <value>Dar su opinión...</value>
+  </data>
+  <data name="SeriesSimple_Spoiler" xml:space="preserve">
+    <value>Spoiler</value>
+  </data>
+  <data name="SeriesSimple_CommentTrakt" xml:space="preserve">
+    <value>Comentario de Trakt</value>
+  </data>
+  <data name="SeriesSimple_Characters" xml:space="preserve">
+    <value>Personajes</value>
+  </data>
+  <data name="SeriesSimple_AlsoLike" xml:space="preserve">
+    <value>Posiblemente le gustan también</value>
+  </data>
+  <data name="SeriesSimple_PeopleSaying" xml:space="preserve">
+    <value>Qué dice la gente</value>
+  </data>
+  <data name="SeriesSimple_Loading" xml:space="preserve">
+    <value>Cargando...</value>
+  </data>
+  <data name="AvDump_Remove" xml:space="preserve">
+    <value>Eliminar de lista de</value>
+  </data>
+  <data name="AvDump_Clear" xml:space="preserve">
+    <value>Borrar lista</value>
+  </data>
+  <data name="AvDump_Dump" xml:space="preserve">
+    <value>Archivos de volcado</value>
+  </data>
+  <data name="Bookmarks_Downloading" xml:space="preserve">
+    <value>Descargar</value>
+  </data>
+  <data name="Bookmarks_NotDownloading" xml:space="preserve">
+    <value>No descarga</value>
+  </data>
+  <data name="Dashboard_YourVote" xml:space="preserve">
+    <value>Su voto</value>
+  </data>
+  <data name="Dashboard_Bookmark" xml:space="preserve">
+    <value>Marcar este anime a descargar más tarde</value>
+  </data>
+  <data name="Dashboard_Download" xml:space="preserve">
+    <value>Búsqueda de descargas de esta serie</value>
+  </data>
+  <data name="Dashboard_NoRecommend" xml:space="preserve">
+    <value>No se pudo encontrar ninguna recomendación.</value>
+  </data>
+  <data name="Dashboard_DownloadVotes" xml:space="preserve">
+    <value>Descargar ahora sus votos, o su voto sobre un anime para empezar a recibir recomendaciones.</value>
+  </data>
+  <data name="Dashboard_SyncVotes" xml:space="preserve">
+    <value>Votos de sincronización</value>
+  </data>
+  <data name="Dashboard_Added" xml:space="preserve">
+    <value>Añadido</value>
+  </data>
+  <data name="Dashboard_Metro" xml:space="preserve">
+    <value>Metro tablero de instrumentos</value>
+  </data>
+  <data name="Dashboard_UpdateCalendar" xml:space="preserve">
+    <value>Actualizar los datos de calendario</value>
+  </data>
+  <data name="Dashboard_Recent" xml:space="preserve">
+    <value>Incorporaciones recientes</value>
+  </data>
+  <data name="Metro_Options" xml:space="preserve">
+    <value>Opciones</value>
+  </data>
+  <data name="Metro_General" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="Metro_ImageType" xml:space="preserve">
+    <value>Tipo de imagen</value>
+  </data>
+  <data name="Metro_Sections" xml:space="preserve">
+    <value>Secciones</value>
+  </data>
+  <data name="Metro_Items" xml:space="preserve">
+    <value>Artículos</value>
+  </data>
+  <data name="Metro_Refresh" xml:space="preserve">
+    <value>Actualización</value>
+  </data>
+  <data name="PlayVideo" xml:space="preserve">
+    <value>Reproducir Video</value>
+  </data>
+  <data name="Episode_MoreInfo" xml:space="preserve">
+    <value>Más Info...</value>
+  </data>
+  <data name="Episode_LessInfo" xml:space="preserve">
+    <value>Menos información...</value>
+  </data>
+  <data name="Episode_Manual" xml:space="preserve">
+    <value>Enlace Manual</value>
+  </data>
+  <data name="Episode_ForceAniDBUpdate" xml:space="preserve">
+    <value>Información de actualización de la fuerza de AniDB</value>
+  </data>
+  <data name="Episode_RecalculateHash" xml:space="preserve">
+    <value>Volver a calcular el Hash</value>
+  </data>
+  <data name="Episode_Hash" xml:space="preserve">
+    <value>Hash</value>
+  </data>
+  <data name="Episode_CRC32" xml:space="preserve">
+    <value>CRC32</value>
+  </data>
+  <data name="Episode_SHA1" xml:space="preserve">
+    <value>SHA1</value>
+  </data>
+  <data name="Episode_MD5" xml:space="preserve">
+    <value>MD5</value>
+  </data>
+  <data name="Episode_DownloadSearch" xml:space="preserve">
+    <value>Buscar descargas para este episodio</value>
+  </data>
+  <data name="Episode_PlaylistAdd" xml:space="preserve">
+    <value>Añadir a lista de reproducción</value>
+  </data>
+  <data name="Episode_TvDBOverride" xml:space="preserve">
+    <value>Reemplazar el enlace TvDB para este episodio</value>
+  </data>
+  <data name="Episode_TvDBRemove" xml:space="preserve">
+    <value>El enlace de TvDB para este episodio</value>
+  </data>
+  <data name="Episode_AniDBForceUpdate" xml:space="preserve">
+    <value>Información de actualización de la fuerza de AniDB</value>
+  </data>
+  <data name="Episode_Type" xml:space="preserve">
+    <value>Tipo</value>
+  </data>
+  <data name="Episode_Availability" xml:space="preserve">
+    <value>Disponibilidad de</value>
+  </data>
+  <data name="Episode_WatchedState" xml:space="preserve">
+    <value>Seguimiento del estado</value>
+  </data>
+  <data name="Rename_Script" xml:space="preserve">
+    <value>Secuencia de comandos</value>
+  </data>
+  <data name="Rename_New" xml:space="preserve">
+    <value>Nuevo</value>
+  </data>
+  <data name="Rename_Save" xml:space="preserve">
+    <value>Guardar</value>
+  </data>
+  <data name="Rename_Delete" xml:space="preserve">
+    <value>Eliminar</value>
+  </data>
+  <data name="Rename_Tag" xml:space="preserve">
+    <value>Etiqueta</value>
+  </data>
+  <data name="Rename_Add" xml:space="preserve">
+    <value>Añadir</value>
+  </data>
+  <data name="Rename_Test" xml:space="preserve">
+    <value>Prueba</value>
+  </data>
+  <data name="Rename_ScriptingHelp" xml:space="preserve">
+    <value>Ayuda con secuencias de comandos</value>
+  </data>
+  <data name="Rename_ImportRun" xml:space="preserve">
+    <value>Ejecute este script al importar archivos de colección</value>
+  </data>
+  <data name="Rename_Filter" xml:space="preserve">
+    <value>Filtro:</value>
+  </data>
+  <data name="Rename_Clear" xml:space="preserve">
+    <value>Claro</value>
+  </data>
+  <data name="Rename_AddFiles" xml:space="preserve">
+    <value>Agregar archivos</value>
+  </data>
+  <data name="Rename_Rename" xml:space="preserve">
+    <value>Cambiar el nombre ahora</value>
+  </data>
+  <data name="Rename_Preview" xml:space="preserve">
+    <value>Vista previa</value>
+  </data>
+  <data name="FileSearch_Rescan" xml:space="preserve">
+    <value>Vuelva a examinar</value>
+  </data>
+  <data name="FileSearch_AniDBForceUpdate" xml:space="preserve">
+    <value>Información de actualización de la fuerza de AniDB</value>
+  </data>
+  <data name="GroupFilter_RandomSeries" xml:space="preserve">
+    <value>Serie al azar</value>
+  </data>
+  <data name="GroupFilter_RandomEpisode" xml:space="preserve">
+    <value>Episodio al azar</value>
+  </data>
+  <data name="IgnoredAnime_Delete" xml:space="preserve">
+    <value>Eliminar esta entrada</value>
+  </data>
+  <data name="IgnoredAnime_Note" xml:space="preserve">
+    <value>Esta utilidad te muestra todo el anime que ha elegido hacer caso omiso de las recomendaciones. Eliminar estos registros significa que pueden volver a mostrar en las recomendaciones.</value>
+  </data>
+  <data name="ImportFolder_Watched" xml:space="preserve">
+    <value>Esta carpeta está siendo vigilada para los nuevos archivos</value>
+  </data>
+  <data name="MissingEpisodes_SelectColumns" xml:space="preserve">
+    <value>Seleccione las columnas que se utilizará en la importación</value>
+  </data>
+  <data name="MissingEpisodes_AiringState" xml:space="preserve">
+    <value>Estado de la ventilación:</value>
+  </data>
+  <data name="RefreshWait" xml:space="preserve">
+    <value>Presionar el botón de actualización puede tardar varios minutos, así que por favor sea paciente</value>
+  </data>
+  <data name="MissingEpisodes_Note" xml:space="preserve">
+    <value>Esta utilidad le mostrará un resumen de todos los episodios de sus falta.</value>
+  </data>
+  <data name="MissingMyList_Missing" xml:space="preserve">
+    <value>Ve el archivo que falta</value>
+  </data>
+  <data name="MissingMyList_RemoveAll" xml:space="preserve">
+    <value>Quitar todas las entradas de AniDB</value>
+  </data>
+  <data name="MissingMyList_Note" xml:space="preserve">
+    <value>Esta utilidad se descarga su lista de archivos desde AniDB y compararlo con los archivos localmente. Entonces tendrás la oportunidad de eliminar los archivos de AniDB si no existen.</value>
+  </data>
+  <data name="Episode" xml:space="preserve">
+    <value>Episodio</value>
+  </data>
+  <data name="Playlist_Random" xml:space="preserve">
+    <value>Episodio al azar</value>
+  </data>
+  <data name="Playlist_Default" xml:space="preserve">
+    <value>Orden de juego por defecto</value>
+  </data>
+  <data name="Playlist_Items" xml:space="preserve">
+    <value>Elementos de la lista de reproducción</value>
+  </data>
+  <data name="PlayNext_Hidden" xml:space="preserve">
+    <value>Ocultos para evitar spoilers</value>
+  </data>
+  <data name="Rankings_Overall" xml:space="preserve">
+    <value>Por valoración general del usuario</value>
+  </data>
+  <data name="Rankings_GroupedByYear" xml:space="preserve">
+    <value>Agrupados por año</value>
+  </data>
+  <data name="Rankings_CollectionState" xml:space="preserve">
+    <value>Estado de colección</value>
+  </data>
+  <data name="Rankings_Voted" xml:space="preserve">
+    <value>Votado en</value>
+  </data>
+  <data name="Rankings_Completed" xml:space="preserve">
+    <value>Completado</value>
+  </data>
+  <data name="Rankings_Anime" xml:space="preserve">
+    <value> Anime</value>
+  </data>
+  <data name="Rankings_AniDB" xml:space="preserve">
+    <value>AniDB calificación</value>
+  </data>
+  <data name="Rankings_User" xml:space="preserve">
+    <value>Su calificación de</value>
+  </data>
+  <data name="Rankings_Year" xml:space="preserve">
+    <value>Año</value>
+  </data>
+  <data name="Rankings_View" xml:space="preserve">
+    <value>Ver serie</value>
+  </data>
+  <data name="Rankings_MyVote" xml:space="preserve">
+    <value>Mi voto</value>
+  </data>
+  <data name="Related_Bookmark" xml:space="preserve">
+    <value>Marcar este anime a descargar más tarde</value>
+  </data>
+  <data name="Related_Search" xml:space="preserve">
+    <value>Búsqueda de descargas de esta serie</value>
+  </data>
+  <data name="SeriesWithoutFiles_Delete" xml:space="preserve">
+    <value>Eliminar esta serie de la base de datos</value>
+  </data>
+  <data name="SeriesWithoutFiles_Note" xml:space="preserve">
+    <value>Esta utilidad te muestra todas las series que no tienen los archivos. Eliminar la serie también eliminará el grupo si no hay otra serie de ese grupo tiene archivos.</value>
+  </data>
+  <data name="TraktShouts_View" xml:space="preserve">
+    <value>Ver</value>
+  </data>
+  <data name="TraktShouts_FromAniDB" xml:space="preserve">
+    <value>Desde AniDB</value>
+  </data>
+  <data name="TraktShouts_Spoiler" xml:space="preserve">
+    <value>Spoiler</value>
+  </data>
+  <data name="TraktShouts_Loading" xml:space="preserve">
+    <value>Cargando...</value>
+  </data>
+  <data name="TraktShouts_Comments" xml:space="preserve">
+    <value>Comentarios</value>
+  </data>
+  <data name="CommunityLinks_Start" xml:space="preserve">
+    <value>Inicio:</value>
+  </data>
+  <data name="CommunityLinks_Edit" xml:space="preserve">
+    <value>Editar detalles</value>
+  </data>
+  <data name="CommunityLinks_AniDBStart" xml:space="preserve">
+    <value>Inicio AniDB:</value>
+  </data>
+  <data name="CommunityLinks_TvDB" xml:space="preserve">
+    <value>TvDB: </value>
+  </data>
+  <data name="CommunityLinks_Trakt" xml:space="preserve">
+    <value>Trakt: </value>
+  </data>
+  <data name="CommunityLinks_TMDb" xml:space="preserve">
+    <value>La película de DB</value>
+  </data>
+  <data name="CommunityLinks_MAL" xml:space="preserve">
+    <value>MyAnimeList</value>
+  </data>
+  <data name="CommunityLinks_AutoLink" xml:space="preserve">
+    <value>Auto Link</value>
+  </data>
+  <data name="Tooltip_DeleteTitle" xml:space="preserve">
+    <value>Eliminar</value>
+  </data>
+  <data name="Tooltip_DeleteInfo" xml:space="preserve">
+    <value>Eliminar este enlace</value>
+  </data>
+  <data name="Tooltip_EditTitle" xml:space="preserve">
+    <value>Editar</value>
+  </data>
+  <data name="Tooltip_EditInfo" xml:space="preserve">
+    <value>Editar los detalles de este enlace</value>
+  </data>
+  <data name="Tooltip_UpdateTitle" xml:space="preserve">
+    <value>Actualización</value>
+  </data>
+  <data name="Tooltip_UpdateTvDB" xml:space="preserve">
+    <value>Descargar nuevos datos de The TvDB y actualizar la base de datos local</value>
+  </data>
+  <data name="Tooltip_ReportLinkTitle" xml:space="preserve">
+    <value>Informe de Error enlace</value>
+  </data>
+  <data name="Tooltip_ReportLinkInfo" xml:space="preserve">
+    <value>Si esto está relacionado con la serie mal haga clic aquí para que los desarrolladores conozcan</value>
+  </data>
+  <data name="Tooltip_UpdateTrakt" xml:space="preserve">
+    <value>Descargar nuevos datos de Trakt y actualizar la base de datos local</value>
+  </data>
+  <data name="Tooltip_Sync" xml:space="preserve">
+    <value>Sync</value>
+  </data>
+  <data name="Tooltip_SyncTrakt" xml:space="preserve">
+    <value>Sincronizar los datos de colección y de la historia con Trakt</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTitle" xml:space="preserve">
+    <value>Auto a discapacitados</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTvDB" xml:space="preserve">
+    <value>Auto vincular de este anime con una serie de TvDB está actualmente desactivado</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTitle" xml:space="preserve">
+    <value>Auto enlazan a activado</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTvDB" xml:space="preserve">
+    <value>Auto vincular de este anime con una serie de TvDB está habilitado actualmente. Si JMM Server encuentra una recomendación de fósforo o comunidad cercana creará automáticamente un enlace</value>
+  </data>
+  <data name="CommunityLinks_TraktTV" xml:space="preserve">
+    <value>Trakt TV</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTrakt" xml:space="preserve">
+    <value>Auto vincular de este anime con una serie de Trakt está actualmente desactivado</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTrakt" xml:space="preserve">
+    <value>Auto vincular de este anime con una serie de Trakt está habilitado actualmente. Si JMM Server encuentra una recomendación de fósforo o comunidad cercana creará automáticamente un enlace</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledMAL" xml:space="preserve">
+    <value>Auto de vinculación de este anime una serie MAL está actualmente desactivado</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledMAL" xml:space="preserve">
+    <value>Auto de vinculación de este anime una serie MAL está habilitado actualmente. Si JMM Server encuentra una recomendación de fósforo o comunidad cercana creará automáticamente un enlace</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTMDb" xml:space="preserve">
+    <value>Auto de vinculación de este anime una serie MovieDB está actualmente desactivado</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTMDb" xml:space="preserve">
+    <value>Auto de vinculación de este anime una serie MovieDB está habilitado actualmente. Si JMM Server encuentra una recomendación de fósforo o comunidad cercana creará automáticamente un enlace</value>
+  </data>
+  <data name="Tooltip_CommunityAdminTitle" xml:space="preserve">
+    <value>Administración de la comunidad</value>
+  </data>
+  <data name="Tooltip_CommunityAdminInfo" xml:space="preserve">
+    <value>Ir a la pestaña de administración de la comunidad y editar los enlaces recomendados para este anime</value>
+  </data>
+  <data name="Unrecognized_Rescan" xml:space="preserve">
+    <value>Vuelva a examinar</value>
+  </data>
+  <data name="Unrecognized_ForceAniDB" xml:space="preserve">
+    <value>Información de actualización de la fuerza de AniDB</value>
+  </data>
+  <data name="Unrecognized_Hash" xml:space="preserve">
+    <value>Hash</value>
+  </data>
+  <data name="Unrecognized_CRC32" xml:space="preserve">
+    <value>CRC32</value>
+  </data>
+  <data name="Unrecognized_Rehash" xml:space="preserve">
+    <value>Re-hash de todos los</value>
+  </data>
+  <data name="Unrecognized_Logs" xml:space="preserve">
+    <value>Registros de</value>
+  </data>
+  <data name="Unrecognized_NA" xml:space="preserve">
+    <value>NA</value>
+  </data>
+  <data name="Unrecognized_RefreshSeries" xml:space="preserve">
+    <value>Actualice la lista de la serie</value>
+  </data>
+  <data name="Unrecognized_To" xml:space="preserve">
+    <value>Para</value>
+  </data>
+  <data name="UpdateAniDB_UpdateLocal" xml:space="preserve">
+    <value>Actualizar datos de archivo Local AniDB</value>
+  </data>
+  <data name="UpdateAniDB_Info1" xml:space="preserve">
+    <value>Datos relativos a los archivos se descargar desde AniDB y almacena en su base de datos local al primero importar un archivo. En algunos casos esta información puede no ser completa cuando primero lo descargar. O datos adicionales pueden ser descargadas pero más nuevas versiones de JMM. Esta utilidad le permitirá obtener una copia fresca de esa información en AniDB</value>
+  </data>
+  <data name="UpdateAniDB_MissingInfo" xml:space="preserve">
+    <value>Actualizar archivos con la información que falta</value>
+  </data>
+  <data name="UpdateAniDB_Info2" xml:space="preserve">
+    <value>Datos faltantes se refiere generalmente a falta información del códec y la resolución. Se puede ver Resolución: 0 x 0 al lado de estos archivos</value>
+  </data>
+  <data name="UpdateAniDB_Version" xml:space="preserve">
+    <value>Archivos de actualización a versión interna 2</value>
+  </data>
+  <data name="UpdateAniDB_Info3" xml:space="preserve">
+    <value>Interna versión 2 añade la siguiente información - archivo de la versión (v2, v3 etc), es censurado, está obsoleto</value>
+  </data>
+  <data name="UpdateAniDB_Info4" xml:space="preserve">
+    <value>Envía demasiados comandos AniDB, puede provocar una prohibición temporal. Usar bajo su propio riesgo</value>
+  </data>
+  <data name="UpdateAniDB_HowManyQueued" xml:space="preserve">
+    <value>¿Cuántos comandos se cola?</value>
+  </data>
+  <data name="UpdateAniDB_Queued" xml:space="preserve">
+    <value>Cola de comandos</value>
+  </data>
+  <data name="User_HideTags" xml:space="preserve">
+    <value>Ocultar etiquetas</value>
+  </data>
+  <data name="User_ChangePassword" xml:space="preserve">
+    <value>Cambiar contraseña</value>
+  </data>
+  <data name="Sort_Error" xml:space="preserve">
+    <value>Error intentando ordenar la lista de </value>
+  </data>
+  <data name="Sort_Using" xml:space="preserve">
+    <value> utilizando </value>
+  </data>
+  <data name="Sort_Property" xml:space="preserve">
+    <value>propiedad </value>
+  </data>
+  <data name="Sort_Field" xml:space="preserve">
+    <value>campo </value>
+  </data>
+  <data name="Sort_Exception" xml:space="preserve">
+    <value>Excepción en MultiSort al ordenar una lista de </value>
+  </data>
+  <data name="Sort_PassedEmpty" xml:space="preserve">
+    <value>RgSortBy parámetro multiSort pasó un nombre de campo vacío en rgSortBy [</value>
+  </data>
+  <data name="Selected_DoesNotExist" xml:space="preserve">
+    <value>No existe el archivo especificado o la carpeta: </value>
+  </data>
+  <data name="ValueCompare_PropertyName" xml:space="preserve">
+    <value>Nombre de la propiedad </value>
+  </data>
+  <data name="ValueCompare_NotFound" xml:space="preserve">
+    <value> no se encontró al intentar comparar los objetos de tipo </value>
+  </data>
+  <data name="ValueCompare_FieldName" xml:space="preserve">
+    <value>Nombre del campo </value>
+  </data>
+  <data name="Video_VLCError1" xml:space="preserve">
+    <value>No se puede analizar la URI en el archivo ini VLC</value>
+  </data>
+  <data name="Video_VLCError2" xml:space="preserve">
+    <value>El recuento de los archivos recientes y marcas de tiempo en el archivo ini VLC difieren</value>
+  </data>
+  <data name="Video_Complete" xml:space="preserve">
+    <value>Completa</value>
+  </data>
+  <data name="Video_Position" xml:space="preserve">
+    <value>Vídeo posición de</value>
+  </data>
+  <data name="Video_HasChanged" xml:space="preserve">
+    <value>ha cambiado a</value>
+  </data>
+  <data name="Video_Updating" xml:space="preserve">
+    <value>Actualización vigilados por reproductor: </value>
+  </data>
+  <data name="AniDB_DataMissing" xml:space="preserve">
+    <value>Datos que faltan</value>
+  </data>
+  <data name="AniDB_Votes" xml:space="preserve">
+    <value>Votos</value>
+  </data>
+  <data name="AniDB_GotVids" xml:space="preserve">
+    <value>Tiene videos de anime de servicio:</value>
+  </data>
+  <data name="AniDB_In" xml:space="preserve">
+    <value>en</value>
+  </data>
+  <data name="AniDB_ForFans" xml:space="preserve">
+    <value>Para los fanáticos</value>
+  </data>
+  <data name="AniDB_Recommended" xml:space="preserve">
+    <value>Recomienda</value>
+  </data>
+  <data name="AniDB_MustSee" xml:space="preserve">
+    <value>Hay que ver</value>
+  </data>
+  <data name="AniDB_Collecting" xml:space="preserve">
+    <value>Que recoge:</value>
+  </data>
+  <data name="AniDB_Files" xml:space="preserve">
+    <value>Archivos:</value>
+  </data>
+  <data name="AnimeEpisode_Previous" xml:space="preserve">
+    <value>Episodio anterior</value>
+  </data>
+  <data name="AnimeEpisode_Next" xml:space="preserve">
+    <value>Próximo episodio</value>
+  </data>
+  <data name="AnimeEpisode_NoOverview" xml:space="preserve">
+    <value>Episodio Resumen no disponible</value>
+  </data>
+  <data name="Anime_Groups" xml:space="preserve">
+    <value>Grupos</value>
+  </data>
+  <data name="Anime_Series" xml:space="preserve">
+    <value>Serie</value>
+  </data>
+  <data name="Anime_GroupName" xml:space="preserve">
+    <value>Nombre del grupo debe rellenarse</value>
+  </data>
+  <data name="Anime_SortName" xml:space="preserve">
+    <value>Nombre de clase debe rellenarse</value>
+  </data>
+  <data name="Anime_GotVids" xml:space="preserve">
+    <value>Tiene videos de anime de servicio:</value>
+  </data>
+  <data name="Anime_GotEpisodes" xml:space="preserve">
+    <value>Obtuvo datos de episodio de servicio:</value>
+  </data>
+  <data name="Anime_In" xml:space="preserve">
+    <value>en</value>
+  </data>
+  <data name="Anime_Contracts" xml:space="preserve">
+    <value>Tiene contratos de episodio:</value>
+  </data>
+  <data name="Anime_Sorted" xml:space="preserve">
+    <value>Clasificar el episodio contratos:</value>
+  </data>
+  <data name="AVDump_ToBe" xml:space="preserve">
+    <value>Para ser procesados</value>
+  </data>
+  <data name="Group_Groups" xml:space="preserve">
+    <value>Grupos</value>
+  </data>
+  <data name="Group_FilterName" xml:space="preserve">
+    <value>Nombre del filtro debe rellenarse</value>
+  </data>
+  <data name="Ignore_RecDown" xml:space="preserve">
+    <value>Recomendaciones - descargar</value>
+  </data>
+  <data name="Ignore_RecWatch" xml:space="preserve">
+    <value>Recomendaciones - reloj</value>
+  </data>
+  <data name="Ignore_AnimeID" xml:space="preserve">
+    <value>Anime ID:</value>
+  </data>
+  <data name="JMMServer_TraktAuth" xml:space="preserve">
+    <value>Trakt Auth</value>
+  </data>
+  <data name="JMMServer_Success" xml:space="preserve">
+    <value>Éxito</value>
+  </data>
+  <data name="JMMServer_Error" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="Missing_Episode" xml:space="preserve">
+    <value>Episodio</value>
+  </data>
+  <data name="Missing_File" xml:space="preserve">
+    <value>Archivo</value>
+  </data>
+  <data name="Playlist_Name" xml:space="preserve">
+    <value>Introduzca el nombre de la lista de reproducción: </value>
+  </data>
+  <data name="Playlist_NameBlank" xml:space="preserve">
+    <value>Introduzca un nombre de lista de reproducción</value>
+  </data>
+  <data name="Recommendation_Missing" xml:space="preserve">
+    <value>Datos que faltan</value>
+  </data>
+  <data name="Recommendation_NoOverview" xml:space="preserve">
+    <value>Resumen no disponible</value>
+  </data>
+  <data name="uTorrent_NotConnected" xml:space="preserve">
+    <value>No conectado</value>
+  </data>
+  <data name="uTorrent_Connecting" xml:space="preserve">
+    <value>Conexión de...</value>
+  </data>
+  <data name="Constants_Continue" xml:space="preserve">
+    <value>Seguir viendo (sistema)</value>
+  </data>
+  <data name="Constants_MainCharacter" xml:space="preserve">
+    <value>personaje principal en</value>
+  </data>
+  <data name="Group_GroupCount" xml:space="preserve">
+    <value> Grupos</value>
+  </data>
+  <data name="Tab_Playlists" xml:space="preserve">
+    <value>Listas de reproducción</value>
+  </data>
+  <data name="Playlist_NewPlaylist" xml:space="preserve">
+    <value>Nueva lista de reproducción</value>
+  </data>
+  <data name="Tab_Bookmarks" xml:space="preserve">
+    <value>Marcadores</value>
+  </data>
+  <data name="JMMServer_ImportFolders" xml:space="preserve">
+    <value>Carpetas de importación</value>
+  </data>
+  <data name="JMMServer_ServerStatus" xml:space="preserve">
+    <value>Estado del servidor</value>
+  </data>
+  <data name="Tooltip_ClearHash" xml:space="preserve">
+    <value>Despejar todos los comandos hash cola</value>
+  </data>
+  <data name="JMMServer_Running" xml:space="preserve">
+    <value>Funcionamiento</value>
+  </data>
+  <data name="JMMServer_Paused" xml:space="preserve">
+    <value>Hizo una pausa</value>
+  </data>
+  <data name="Tooltip_ClearGeneral" xml:space="preserve">
+    <value>Despejar todos los comandos general cola</value>
+  </data>
+  <data name="Tooltip_ClearImages" xml:space="preserve">
+    <value>Despejar todos los comandos de servidor cola imagen descargar</value>
+  </data>
+  <data name="JMMServer_ServerImage" xml:space="preserve">
+    <value>Cola de imágenes de servidor</value>
+  </data>
+  <data name="Tab_AniDBAVDump" xml:space="preserve">
+    <value>AniDB AV descarga</value>
+  </data>
+  <data name="Tab_FileSearch" xml:space="preserve">
+    <value>Búsqueda del archivo de</value>
+  </data>
+  <data name="Tab_FileRename" xml:space="preserve">
+    <value>Renombrar un archivo</value>
+  </data>
+  <data name="Tab_UpdateAniDB" xml:space="preserve">
+    <value>Actualizar datos AniDB</value>
+  </data>
+  <data name="Tab_CommunityData" xml:space="preserve">
+    <value>Datos de la comunidad</value>
+  </data>
+  <data name="Tab_MyVotes" xml:space="preserve">
+    <value>Mis votos</value>
+  </data>
+  <data name="VideoPlayer_MPCI" xml:space="preserve">
+    <value>Media Player Classic integración</value>
+  </data>
+  <data name="VideoPlayer_AutoFile" xml:space="preserve">
+    <value>Selección automática de archivos</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_MAL" xml:space="preserve">
+    <value>Mi lista de Anime</value>
+  </data>
+  <data name="Tab_Downloads" xml:space="preserve">
+    <value>Descargas</value>
+  </data>
+  <data name="Downloads_uTorrentInfo" xml:space="preserve">
+    <value>Usa el uTorrent WebUI API, que es necesario activar primero en el cliente de uTorrent</value>
+  </data>
+  <data name="Downloads_uTorrentWebUI" xml:space="preserve">
+    <value>detalles de WebUI de uTorrent</value>
+  </data>
+  <data name="Downloads_TorrentBlackHole" xml:space="preserve">
+    <value>Ajustes de agujero negro torrent</value>
+  </data>
+  <data name="Downloads_TorrentDefault" xml:space="preserve">
+    <value>Fuentes de Torrent por defecto para la búsqueda</value>
+  </data>
+  <data name="Downloads_BakaBT" xml:space="preserve">
+    <value>BakaBT ajustes</value>
+  </data>
+  <data name="Downloads_AnimeBytes" xml:space="preserve">
+    <value>Configuración de AnimeBytes</value>
+  </data>
+  <data name="Downloads_BakaBTInfo" xml:space="preserve">
+    <value>BakaBT es un sitio de torrent de anime que se especializa en las descargas de series completas, sin embargo requiere una cuenta primero</value>
+  </data>
+  <data name="Downloads_AnimeBytesInfo" xml:space="preserve">
+    <value>AnimeBytes es un sitio de torrent de anime que se especializa en las descargas de series completas, sin embargo requiere una cuenta primero</value>
+  </data>
+  <data name="Downloads_GoTo" xml:space="preserve">
+    <value>Ir al sitio web</value>
+  </data>
+  <data name="Tab_Search" xml:space="preserve">
+    <value>Búsqueda de</value>
+  </data>
+  <data name="Tab_Community" xml:space="preserve">
+    <value>Comunidad</value>
+  </data>
+  <data name="Main_Messages" xml:space="preserve">
+    <value>Mensajes</value>
+  </data>
+  <data name="Main_Paused" xml:space="preserve">
+    <value>Hizo una pausa debido a la prohibición de (AniDB</value>
+  </data>
+  <data name="Main_User" xml:space="preserve">
+    <value>Usuario</value>
+  </data>
+  <data name="Main_Feed" xml:space="preserve">
+    <value>De la alimentación</value>
+  </data>
+  <data name="Main_About" xml:space="preserve">
+    <value>Acerca de</value>
+  </data>
+  <data name="Tab_uTorrent" xml:space="preserve">
+    <value>uTorrent</value>
+  </data>
+  <data name="Tab_BrowseTorrents" xml:space="preserve">
+    <value>Buscar Torrents</value>
+  </data>
+  <data name="Tab_SearchTorrents" xml:space="preserve">
+    <value>Buscar Torrents</value>
+  </data>
+  <data name="Tab_Recommendations" xml:space="preserve">
+    <value>Recomendaciones</value>
+  </data>
+  <data name="Tab_Settings" xml:space="preserve">
+    <value>Configuración</value>
+  </data>
+  <data name="Tab_SeriesInfo" xml:space="preserve">
+    <value>Información de la serie</value>
+  </data>
+  <data name="Tab_Comments" xml:space="preserve">
+    <value>Comentarios de usuarios</value>
+  </data>
+  <data name="Tab_Files" xml:space="preserve">
+    <value>Archivos</value>
+  </data>
+  <data name="Download_TorrentFolder" xml:space="preserve">
+    <value>Ubicación de la carpeta de torrent</value>
+  </data>
+  <data name="Search_TitleOnly" xml:space="preserve">
+    <value>Sólo título</value>
+  </data>
+</root>

--- a/JMMClient/Properties/Resources.fr.resx
+++ b/JMMClient/Properties/Resources.fr.resx
@@ -1,0 +1,3179 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AirDate" xml:space="preserve">
+    <value>Date de diffusion</value>
+  </data>
+  <data name="AniDBRating" xml:space="preserve">
+    <value>AniDB Rating</value>
+  </data>
+  <data name="AniDBVoteCount" xml:space="preserve">
+    <value>Décompte des voix AniDB</value>
+  </data>
+  <data name="Episodes" xml:space="preserve">
+    <value>Épisodes</value>
+  </data>
+  <data name="EpisodeType" xml:space="preserve">
+    <value>Type d'épisode</value>
+  </data>
+  <data name="EpisodeType_Credits" xml:space="preserve">
+    <value>Crédits</value>
+  </data>
+  <data name="EpisodeType_Normal" xml:space="preserve">
+    <value>Épisodes</value>
+  </data>
+  <data name="EpisodeType_Other" xml:space="preserve">
+    <value>Autres</value>
+  </data>
+  <data name="EpisodeType_Parody" xml:space="preserve">
+    <value>Parodie</value>
+  </data>
+  <data name="EpisodeType_Specials" xml:space="preserve">
+    <value>Offres spéciales</value>
+  </data>
+  <data name="EpisodeType_Trailer" xml:space="preserve">
+    <value>Remorques</value>
+  </data>
+  <data name="Favorite" xml:space="preserve">
+    <value>Favori</value>
+  </data>
+  <data name="GroupFilter_All" xml:space="preserve">
+    <value>Tous les</value>
+  </data>
+  <data name="GroupFilter_Favorites" xml:space="preserve">
+    <value>Favoris</value>
+  </data>
+  <data name="IsWatched" xml:space="preserve">
+    <value>Est surveillée</value>
+  </data>
+  <data name="MyRating" xml:space="preserve">
+    <value>MyRating</value>
+  </data>
+  <data name="Refresh" xml:space="preserve">
+    <value>Actualisation</value>
+  </data>
+  <data name="RunTime" xml:space="preserve">
+    <value>Moment de l'exécution</value>
+  </data>
+  <data name="SortName" xml:space="preserve">
+    <value>Nom tri</value>
+  </data>
+  <data name="Series" xml:space="preserve">
+    <value>Série</value>
+  </data>
+  <data name="TAB_Config" xml:space="preserve">
+    <value>Config</value>
+  </data>
+  <data name="TAB_Episodes" xml:space="preserve">
+    <value>Épisodes</value>
+  </data>
+  <data name="TAB_FileManager" xml:space="preserve">
+    <value>Gestionnaire de fichiers</value>
+  </data>
+  <data name="TAB_Images" xml:space="preserve">
+    <value>Images</value>
+  </data>
+  <data name="TAB_Relations" xml:space="preserve">
+    <value>Relations</value>
+  </data>
+  <data name="TAB_SeriesEpisodes" xml:space="preserve">
+    <value>Collection</value>
+  </data>
+  <data name="TAB_Server" xml:space="preserve">
+    <value>Serveur</value>
+  </data>
+  <data name="TAB_TvDB" xml:space="preserve">
+    <value>TvDB</value>
+  </data>
+  <data name="ViewLabel" xml:space="preserve">
+    <value>Vue : </value>
+  </data>
+  <data name="Back" xml:space="preserve">
+    <value>Précédent</value>
+  </data>
+  <data name="Language" xml:space="preserve">
+    <value>Langue</value>
+  </data>
+  <data name="Delete" xml:space="preserve">
+    <value>Supprimer</value>
+  </data>
+  <data name="RunImport" xml:space="preserve">
+    <value>Exécuter l'importation</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Enregistrer</value>
+  </data>
+  <data name="AnimeTitles" xml:space="preserve">
+    <value>Titres</value>
+  </data>
+  <data name="AnimeTitlesMain" xml:space="preserve">
+    <value>Titre principal</value>
+  </data>
+  <data name="AnimeTitlesOfficial" xml:space="preserve">
+    <value>Officiel</value>
+  </data>
+  <data name="AnimeTitlesShort" xml:space="preserve">
+    <value>Court</value>
+  </data>
+  <data name="AnimeTitlesSynonym" xml:space="preserve">
+    <value>Synonyme</value>
+  </data>
+  <data name="Categories" xml:space="preserve">
+    <value>Catégories</value>
+  </data>
+  <data name="Tags" xml:space="preserve">
+    <value>Tags (peut contenir des Spoilers)</value>
+  </data>
+  <data name="CategoryWeighting" xml:space="preserve">
+    <value>Pondération</value>
+  </data>
+  <data name="TagApproval" xml:space="preserve">
+    <value>Approbation</value>
+  </data>
+  <data name="Episodes_AvAll" xml:space="preserve">
+    <value>Tous les épisodes</value>
+  </data>
+  <data name="Episodes_AvMissing" xml:space="preserve">
+    <value>Aucun des fichiers d</value>
+  </data>
+  <data name="Episodes_AvOnly" xml:space="preserve">
+    <value>Fichiers disponibles uniquement</value>
+  </data>
+  <data name="Episodes_Watched_All" xml:space="preserve">
+    <value>Tous les</value>
+  </data>
+  <data name="Episodes_Watched_Unwatched" xml:space="preserve">
+    <value>Espionné</value>
+  </data>
+  <data name="Episodes_Watched_Watched" xml:space="preserve">
+    <value>Regardé</value>
+  </data>
+  <data name="Play" xml:space="preserve">
+    <value>Jouer</value>
+  </data>
+  <data name="Tooltip_FileFound" xml:space="preserve">
+    <value>Ce fichier est disponible</value>
+  </data>
+  <data name="Tooltip_FileNotFound" xml:space="preserve">
+    <value>Ce fichier n'existe pas</value>
+  </data>
+  <data name="Tooltip_FutureDated" xml:space="preserve">
+    <value>Cet épisode n'a pas encore diffusé</value>
+  </data>
+  <data name="Tooltip_Unwatched" xml:space="preserve">
+    <value>Espionné - cliquez sur marquer comme surveillés</value>
+  </data>
+  <data name="Tooltip_Watched" xml:space="preserve">
+    <value>Vu - cliquez sur marquer comme sans surveillance</value>
+  </data>
+  <data name="Tooltip_ZeroFiles" xml:space="preserve">
+    <value>Il n'y a pas de fichiers disponibles pour cet épisode</value>
+  </data>
+  <data name="Unwatched" xml:space="preserve">
+    <value>Espionné</value>
+  </data>
+  <data name="Watched" xml:space="preserve">
+    <value>Regardé</value>
+  </data>
+  <data name="Rating" xml:space="preserve">
+    <value>De note</value>
+  </data>
+  <data name="Votes" xml:space="preserve">
+    <value>Votes</value>
+  </data>
+  <data name="AnimeType_Movie" xml:space="preserve">
+    <value>Film</value>
+  </data>
+  <data name="AnimeType_Other" xml:space="preserve">
+    <value>Autres</value>
+  </data>
+  <data name="AnimeType_OVA" xml:space="preserve">
+    <value>OVULES</value>
+  </data>
+  <data name="AnimeType_TVSeries" xml:space="preserve">
+    <value>Série TV</value>
+  </data>
+  <data name="AnimeType_TVSpecial" xml:space="preserve">
+    <value>Émission spéciale</value>
+  </data>
+  <data name="AnimeType_Web" xml:space="preserve">
+    <value>Web</value>
+  </data>
+  <data name="Ongoing" xml:space="preserve">
+    <value>En cours</value>
+  </data>
+  <data name="To" xml:space="preserve">
+    <value>À</value>
+  </data>
+  <data name="LastWatched" xml:space="preserve">
+    <value>Dernière regardé</value>
+  </data>
+  <data name="Today" xml:space="preserve">
+    <value>Aujourd'hui</value>
+  </data>
+  <data name="Yesterday" xml:space="preserve">
+    <value>Hier</value>
+  </data>
+  <data name="GroupsAvailableFrom" xml:space="preserve">
+    <value>Disponible auprès du :</value>
+  </data>
+  <data name="Missing" xml:space="preserve">
+    <value>Manque de</value>
+  </data>
+  <data name="Tooltip_MissingEps" xml:space="preserve">
+    <value>Épisodes manquants de tous les groupes de libération</value>
+  </data>
+  <data name="Tooltip_MissingEpsGroups" xml:space="preserve">
+    <value>Épisodes manquants de groupes que je collecte</value>
+  </data>
+  <data name="Tooltip_QueueImages" xml:space="preserve">
+    <value>Téléchargement des images en file d'attente en attente</value>
+  </data>
+  <data name="Specials" xml:space="preserve">
+    <value>Offres spéciales</value>
+  </data>
+  <data name="GroupFilter_Missing" xml:space="preserve">
+    <value>Épisodes manquants</value>
+  </data>
+  <data name="RemoveMissingFiles" xml:space="preserve">
+    <value>Supprimer les fichiers manquants</value>
+  </data>
+  <data name="ServerActions" xml:space="preserve">
+    <value>Actions du serveur</value>
+  </data>
+  <data name="NewGroup" xml:space="preserve">
+    <value>Nouveau groupe</value>
+  </data>
+  <data name="AllFilters" xml:space="preserve">
+    <value>Tous les filtres</value>
+  </data>
+  <data name="Filter" xml:space="preserve">
+    <value>Filtre</value>
+  </data>
+  <data name="Group" xml:space="preserve">
+    <value>Groupe</value>
+  </data>
+  <data name="AddSubGroup" xml:space="preserve">
+    <value>Nouveau groupe de Sub</value>
+  </data>
+  <data name="Edit" xml:space="preserve">
+    <value>Edit</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
+  <data name="SubGroup" xml:space="preserve">
+    <value>Sous-groupe</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Paramètres</value>
+  </data>
+  <data name="NewSeries" xml:space="preserve">
+    <value>Nouvelle série</value>
+  </data>
+  <data name="MoveSeries" xml:space="preserve">
+    <value>Déplacer la série</value>
+  </data>
+  <data name="MoveToGroup" xml:space="preserve">
+    <value>Déplacer vers le groupe sélectionné</value>
+  </data>
+  <data name="OK" xml:space="preserve">
+    <value>Bien</value>
+  </data>
+  <data name="QueueGeneral" xml:space="preserve">
+    <value>File d'attente AniDB</value>
+  </data>
+  <data name="QueueHasher" xml:space="preserve">
+    <value>File d'attente de Hasher</value>
+  </data>
+  <data name="Tooltip_QueueGeneral" xml:space="preserve">
+    <value>AniDB commandes en file d'attente</value>
+  </data>
+  <data name="Tooltip_QueueHasher" xml:space="preserve">
+    <value>Files d'attente qui sera haché</value>
+  </data>
+  <data name="Pause" xml:space="preserve">
+    <value>Pause</value>
+  </data>
+  <data name="Resume" xml:space="preserve">
+    <value>Curriculum vitae</value>
+  </data>
+  <data name="Video_Bluray" xml:space="preserve">
+    <value>BluRay</value>
+  </data>
+  <data name="Video_DVD" xml:space="preserve">
+    <value>DVD</value>
+  </data>
+  <data name="Video_FullHD" xml:space="preserve">
+    <value>Full HD</value>
+  </data>
+  <data name="Video_HD" xml:space="preserve">
+    <value>HD</value>
+  </data>
+  <data name="NewFolder" xml:space="preserve">
+    <value>Nouveau dossier</value>
+  </data>
+  <data name="DropDestination" xml:space="preserve">
+    <value>Chute de Destination</value>
+  </data>
+  <data name="DropSource" xml:space="preserve">
+    <value>Source de déplacement</value>
+  </data>
+  <data name="ImportFolderName" xml:space="preserve">
+    <value>Nom du dossier Import</value>
+  </data>
+  <data name="ImportFolderPath" xml:space="preserve">
+    <value>Chemin de dossier d'importation</value>
+  </data>
+  <data name="LocalMapping" xml:space="preserve">
+    <value>Mappage local</value>
+  </data>
+  <data name="LocalPath" xml:space="preserve">
+    <value>Chemin d'accès local</value>
+  </data>
+  <data name="ServerDetails" xml:space="preserve">
+    <value>Details du serveur</value>
+  </data>
+  <data name="MSG_ERR_DropSourceDestCheck" xml:space="preserve">
+    <value>Un dossier d'importation ne peut pas être aussi bien la source de déplacement et la destination de la goutte</value>
+  </data>
+  <data name="MSG_ERR_ImportFolderLocationCheck" xml:space="preserve">
+    <value>L'emplacement du dossier import ne peut pas être vide. Entrez un chemin d'accès valide sur le serveur de l'OMM</value>
+  </data>
+  <data name="TAB_UnrecognisedFiles" xml:space="preserve">
+    <value>Non reconnu</value>
+  </data>
+  <data name="Confirm" xml:space="preserve">
+    <value>Confirmer</value>
+  </data>
+  <data name="NothingSelected" xml:space="preserve">
+    <value>Rien n'est sélectionné</value>
+  </data>
+  <data name="SelectSeriesEp" xml:space="preserve">
+    <value>Sélectionnez une série et épisode</value>
+  </data>
+  <data name="AssociateFile" xml:space="preserve">
+    <value>Lier un fichier avec un épisode</value>
+  </data>
+  <data name="Ignore" xml:space="preserve">
+    <value>Ignorer</value>
+  </data>
+  <data name="OpenFolder" xml:space="preserve">
+    <value>Ouvrir le dossier</value>
+  </data>
+  <data name="MSG_ERR_FileNotFound" xml:space="preserve">
+    <value>Le fichier est introuvable</value>
+  </data>
+  <data name="FilesSelected" xml:space="preserve">
+    <value>Fichiers sélectionnés</value>
+  </data>
+  <data name="StartingEpisodeNumber" xml:space="preserve">
+    <value>À partir des numéros d'épisodes</value>
+  </data>
+  <data name="Existing" xml:space="preserve">
+    <value>Existant</value>
+  </data>
+  <data name="SelectGroup" xml:space="preserve">
+    <value>Sélectionnez un groupe</value>
+  </data>
+  <data name="SelectAnime" xml:space="preserve">
+    <value>Sélectionnez-y Anime AniDB</value>
+  </data>
+  <data name="New" xml:space="preserve">
+    <value>Nouveau</value>
+  </data>
+  <data name="GroupName" xml:space="preserve">
+    <value>Nom du groupe</value>
+  </data>
+  <data name="AniDBID" xml:space="preserve">
+    <value>ID AniDB</value>
+  </data>
+  <data name="MSG_ERR_AnimeIDRequired" xml:space="preserve">
+    <value>Veuillez entrer un ID valide de AniDB Anime</value>
+  </data>
+  <data name="MSG_ERR_AnimeSelectionRequired" xml:space="preserve">
+    <value>Veuillez sélectionner un anime existant</value>
+  </data>
+  <data name="MSG_ERR_GroupNameRequired" xml:space="preserve">
+    <value>Veuillez entrer un nom de groupe</value>
+  </data>
+  <data name="MSG_ERR_GroupSelectionRequired" xml:space="preserve">
+    <value>Veuillez sélectionner un groupe existant</value>
+  </data>
+  <data name="MSG_ERR_InvalidEpGetAnime" xml:space="preserve">
+    <value>La plage de numéros d'épisode que vous avez entré n'est pas valide, vous souhaitez actualiser les données de AniDB ?</value>
+  </data>
+  <data name="MSG_ERR_InvalidEp" xml:space="preserve">
+    <value>La gamme épisode que vous avez entré n'est pas valide.</value>
+  </data>
+  <data name="DeleteLink" xml:space="preserve">
+    <value>Supprimer le lien</value>
+  </data>
+  <data name="Tooltip_DeleteLink" xml:space="preserve">
+    <value>Supprimer le lien entre ce fichier et l'épisode.</value>
+  </data>
+  <data name="TAB_IgnoredFiles" xml:space="preserve">
+    <value>Ignorés</value>
+  </data>
+  <data name="Restore" xml:space="preserve">
+    <value>Restauration</value>
+  </data>
+  <data name="TAB_ManuallyLinked" xml:space="preserve">
+    <value>Liés manuellement</value>
+  </data>
+  <data name="AniDBLogin" xml:space="preserve">
+    <value>Login AniDB</value>
+  </data>
+  <data name="Client" xml:space="preserve">
+    <value>Client</value>
+  </data>
+  <data name="ImportFolders" xml:space="preserve">
+    <value>Importer les dossiers</value>
+  </data>
+  <data name="JMMServer" xml:space="preserve">
+    <value>Serveur JMM</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Mot de passe</value>
+  </data>
+  <data name="Port" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Server" xml:space="preserve">
+    <value>Serveur</value>
+  </data>
+  <data name="ServerPath" xml:space="preserve">
+    <value>Chemin du serveur</value>
+  </data>
+  <data name="TAB_SettingsAniDB" xml:space="preserve">
+    <value>AniDB</value>
+  </data>
+  <data name="TAB_SettingsDisplay" xml:space="preserve">
+    <value>Affichage</value>
+  </data>
+  <data name="TAB_SettingsEssential" xml:space="preserve">
+    <value>Essentiel</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB" xml:space="preserve">
+    <value>Sites communautaires</value>
+  </data>
+  <data name="Test" xml:space="preserve">
+    <value>Test</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Nom d'utilisateur</value>
+  </data>
+  <data name="TestAndSave" xml:space="preserve">
+    <value>Test et Save</value>
+  </data>
+  <data name="Success" xml:space="preserve">
+    <value>Succès !</value>
+  </data>
+  <data name="INFO_SettingsEssential" xml:space="preserve">
+    <value>Tous les paramètres sur cette page doivent être renseignées. Veillez à tester et enregistrer le serveur JMM et AniDB détails avant de procéder. Si c'est votre première fois qui exécute l'application entrez importer au moins un dossier et la presse le bouton lancer l'importation.</value>
+  </data>
+  <data name="Search" xml:space="preserve">
+    <value>Recherche</value>
+  </data>
+  <data name="Tooltip_GroupSearch" xml:space="preserve">
+    <value>Groupes de recherche par nom (dans n'importe quelle langue), catégorie ou par mot-clé</value>
+  </data>
+  <data name="AniDBDownloadChar" xml:space="preserve">
+    <value>Télécharger caractères/créateurs</value>
+  </data>
+  <data name="AniDBDownloadOptions" xml:space="preserve">
+    <value>Options de téléchargement AniDB</value>
+  </data>
+  <data name="AniDBDownloadRelated" xml:space="preserve">
+    <value>Télécharger Anime connexe</value>
+  </data>
+  <data name="AniDBDownloadReleaseGroups" xml:space="preserve">
+    <value>Télécharger les groupes de libération</value>
+  </data>
+  <data name="AniDBDownloadReviews" xml:space="preserve">
+    <value>Télécharger commentaires</value>
+  </data>
+  <data name="AniDBDownloadSimilar" xml:space="preserve">
+    <value>Télécharger Anime similaire</value>
+  </data>
+  <data name="AniDBMyListAddFiles" xml:space="preserve">
+    <value>Ajouter des fichiers</value>
+  </data>
+  <data name="AniDBMylistOptions" xml:space="preserve">
+    <value>Options de AniDB MyList</value>
+  </data>
+  <data name="AniDBMyListReadUnwatched" xml:space="preserve">
+    <value>Lire espionné</value>
+  </data>
+  <data name="AniDBMyListReadWatched" xml:space="preserve">
+    <value>Lire regardé</value>
+  </data>
+  <data name="AniDBMyListSetUnwatched" xml:space="preserve">
+    <value>La valeur sans surveillance</value>
+  </data>
+  <data name="AniDBMyListSetWatched" xml:space="preserve">
+    <value>Jeu regardé</value>
+  </data>
+  <data name="AniDBMyListState" xml:space="preserve">
+    <value>État de stockage</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadChar" xml:space="preserve">
+    <value>Télécharger les informations et images sur les personnages et seiyuu qui apparaissent dans l'anime</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadRelated" xml:space="preserve">
+    <value>Lors du téléchargement d'informations sur une adaptation en anime, aussi télécharger des informations sur tous l'anime connexe. Ceci est nécessaire pour regrouper correctement connexe anime pendant le processus d'importation.</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadReleaseGroups" xml:space="preserve">
+    <value>Télécharger des informations détaillées sur la libération/ancrage groupes pour votre anime</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadReviews" xml:space="preserve">
+    <value>Téléchargé anime révisions effectuées par les utilisateurs de AniDB</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadSimilar" xml:space="preserve">
+    <value>Lors du téléchargement d'informations sur une adaptation en anime, aussi télécharger des informations sur des titres similaires et recommandées</value>
+  </data>
+  <data name="Tooltip_AniDBMyListAddFiles" xml:space="preserve">
+    <value>Si sélectionné lors de l'importation de fichiers, les fichiers seront ajoutés à votre compte AniDB</value>
+  </data>
+  <data name="Tooltip_AniDBMyListReadUnwatched" xml:space="preserve">
+    <value>Si le fichier est défini comme non surveillés sur AniDB, il sera également défini comme non surveillés sur votre collection locale</value>
+  </data>
+  <data name="Tooltip_AniDBMyListReadWatched" xml:space="preserve">
+    <value>Si le fichier est défini comme regardé sur AniDB, il sera aussi définie comme regardé sur votre collection locale</value>
+  </data>
+  <data name="Tooltip_AniDBMyListSetUnwatched" xml:space="preserve">
+    <value>Lorsque vous marquez manuellement une vidéo comme regardé, AniDB met également à jour</value>
+  </data>
+  <data name="Tooltip_AniDBMyListSetWatched" xml:space="preserve">
+    <value>Lorsque vous terminez le visionnage d'une vidéo, ou marquez manuellement une vidéo comme regardé, AniDB met également à jour</value>
+  </data>
+  <data name="Tooltip_AniDBMyListState" xml:space="preserve">
+    <value>Les fichiers d'état de stockage seront fixées ajouté à votre liste</value>
+  </data>
+  <data name="SyncMyList" xml:space="preserve">
+    <value>Sync AniDB MyList</value>
+  </data>
+  <data name="Rehash" xml:space="preserve">
+    <value>Ressasser</value>
+  </data>
+  <data name="MSG_INFO_AddedQueueCmds" xml:space="preserve">
+    <value>Ou les commandes ont été ajoutées à la file d'attente</value>
+  </data>
+  <data name="MultiTypeRange" xml:space="preserve">
+    <value>Gamme de l'épisode</value>
+  </data>
+  <data name="MultiTypeSingle" xml:space="preserve">
+    <value>Seul épisode</value>
+  </data>
+  <data name="AniDBScheduleCalendar" xml:space="preserve">
+    <value>Automatiquement mise à jour calendrier</value>
+  </data>
+  <data name="AniDBScheduleHTTP" xml:space="preserve">
+    <value>Mettre à jour automatiquement les Anime et les informations de l'épisode</value>
+  </data>
+  <data name="AniDBScheduleMyList" xml:space="preserve">
+    <value>Automatiquement les informations de synchronisation MyList</value>
+  </data>
+  <data name="AniDBScheduleOptions" xml:space="preserve">
+    <value>Mises à jour planifiées</value>
+  </data>
+  <data name="Tooltip_AniDBScheduleCalendar" xml:space="preserve">
+    <value>Télécharger des informations sur l'anime à venir.</value>
+  </data>
+  <data name="Tooltip_AniDBScheduleHTTP" xml:space="preserve">
+    <value>Mise à jour des informations sur l'anime et obtenir de nouvelles informations de l'épisode. Seules les données qui ont changé depuis la dernière mise à jour seront téléchargées.</value>
+  </data>
+  <data name="Tooltip_AniDBScheduleMyList" xml:space="preserve">
+    <value>Synchroniser les informations de AniDB selon les options spécifiées dans la section MyList.</value>
+  </data>
+  <data name="TAB_SettingsWebCache" xml:space="preserve">
+    <value>Cache Web</value>
+  </data>
+  <data name="DetailedInformationLink" xml:space="preserve">
+    <value>Suivez ce lien pour une profondeur en explication</value>
+  </data>
+  <data name="Get" xml:space="preserve">
+    <value>Télécharger</value>
+  </data>
+  <data name="INFO_SettingsWebCache" xml:space="preserve">
+    <value>Le cache web est une base de données en ligne créé par les développeurs de JMM et MyAnime. Son but est de combler les lacunes, les autres bases de données ne s'adressent pour et aussi faire le processus d'importation plus rapide en partageant des informations avec d'autres utilisateurs de JMM.</value>
+  </data>
+  <data name="Send" xml:space="preserve">
+    <value>Envoyer</value>
+  </data>
+  <data name="Tooltip_WebCache_Anonymous" xml:space="preserve">
+    <value>En sélectionnant cette option votre identifiant AniDB ne sera pas envoyé au cache web. Cependant cela signifie que vous n'obtiendrez pas l'avantage de se souvenir de vos propres sélections personnelles.</value>
+  </data>
+  <data name="Tooltip_WebCache_FileEpisodes" xml:space="preserve">
+    <value>Lorsque les fichiers n'apparaissent pas dans AniDB, le cache web peut avoir des informations sur l'épisode concernant ce fichier. Ceci est particulièrement utile lorsque vous attachez des fichiers et ne veux pas perdre ces informations manuellement.</value>
+  </data>
+  <data name="Tooltip_WebCache_FileHashes" xml:space="preserve">
+    <value>Essayez d'obtenir le fichier de hachage de cache web avant de le hacher localement. Cela peut sauver beaucoup de temps lors de l'importation.</value>
+  </data>
+  <data name="Tooltip_WebCache_TvDBAssociations" xml:space="preserve">
+    <value>Utilisez le cache web pour rechercher des liens entre AniDB et TvDB. Si ne pas sélectionné vous devrez rechercher manuellement tous les liens de TvDB.</value>
+  </data>
+  <data name="TvDB_FanartAutoDownload" xml:space="preserve">
+    <value>Fanart de téléchargement automatique</value>
+  </data>
+  <data name="TvDB_FanartCount" xml:space="preserve">
+    <value>Fanarts maximum</value>
+  </data>
+  <data name="TvDB_PosterAutoDownload" xml:space="preserve">
+    <value>Affiches de téléchargement automatique</value>
+  </data>
+  <data name="TvDB_WideBannerAutoDownload" xml:space="preserve">
+    <value>Auto téléchargement large bannières</value>
+  </data>
+  <data name="WebCache_Anonymous" xml:space="preserve">
+    <value>Rester anonyme</value>
+  </data>
+  <data name="WebCache_FileEpisodes" xml:space="preserve">
+    <value>Fichier de liens de l'épisode</value>
+  </data>
+  <data name="WebCache_FileHashes" xml:space="preserve">
+    <value>Hachages de fichier</value>
+  </data>
+  <data name="WebCache_TvDBAssociations" xml:space="preserve">
+    <value>Liens TvDB</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_MovieDB" xml:space="preserve">
+    <value>Le film DB</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_TvDB" xml:space="preserve">
+    <value>Le TvDB</value>
+  </data>
+  <data name="Tooltip_TvDB_FanartAutoDownload" xml:space="preserve">
+    <value>Nouveau fanart de télécharger automatiquement chaque fois qu'une importation est effectuée.</value>
+  </data>
+  <data name="Tooltip_TvDB_FanartCount" xml:space="preserve">
+    <value>Le montant maximum de téléchargement des images fanart</value>
+  </data>
+  <data name="Tooltip_TvDB_PosterAutoDownload" xml:space="preserve">
+    <value>Télécharger automatiquement les nouvelles affiches chaque fois qu'une importation est effectuée.</value>
+  </data>
+  <data name="Tooltip_TvDB_WideBannerAutoDownload" xml:space="preserve">
+    <value>Télécharger automatiquement les nouvelles bannières larges chaque fois qu'une importation est effectuée.</value>
+  </data>
+  <data name="ImportSettings_HashCRC32" xml:space="preserve">
+    <value>Calculer les CRC32</value>
+  </data>
+  <data name="ImportSettings_HashMD5" xml:space="preserve">
+    <value>Calculer le MD5</value>
+  </data>
+  <data name="ImportSettings_ImportOnStart" xml:space="preserve">
+    <value>Importer sur Démarrer</value>
+  </data>
+  <data name="ImportSettings_SHA1" xml:space="preserve">
+    <value>Calculer SHA1</value>
+  </data>
+  <data name="ImportSettings_VideoExtensions" xml:space="preserve">
+    <value>Extensions de vidéo</value>
+  </data>
+  <data name="ImportSettings_WatchFiles" xml:space="preserve">
+    <value>Attention aux nouveaux fichiers</value>
+  </data>
+  <data name="MovieDB_FanartAutoDownload" xml:space="preserve">
+    <value>Fanart de téléchargement automatique</value>
+  </data>
+  <data name="MovieDB_FanartCount" xml:space="preserve">
+    <value>Fanarts maximum</value>
+  </data>
+  <data name="MovieDB_PosterAutoDownload" xml:space="preserve">
+    <value>Affiches de téléchargement automatique</value>
+  </data>
+  <data name="TAB_Settings_ImportSettings" xml:space="preserve">
+    <value>Paramètres d'importation</value>
+  </data>
+  <data name="Tooltip_MovieDB_FanartAutoDownload" xml:space="preserve">
+    <value>Nouveau fanart de télécharger automatiquement chaque fois qu'une importation est effectuée.</value>
+  </data>
+  <data name="Tooltip_MovieDB_FanartCount" xml:space="preserve">
+    <value>Le montant maximum de téléchargement des images fanart</value>
+  </data>
+  <data name="Tooltip_MovieDB_PosterAutoDownload" xml:space="preserve">
+    <value>Télécharger automatiquement les nouvelles affiches chaque fois qu'une importation est effectuée.</value>
+  </data>
+  <data name="Down" xml:space="preserve">
+    <value>Vers le bas</value>
+  </data>
+  <data name="LanguageUseSynonyms" xml:space="preserve">
+    <value>Également utiliser des synonymes</value>
+  </data>
+  <data name="TAB_Settings_Language" xml:space="preserve">
+    <value>Préférences de langue</value>
+  </data>
+  <data name="Tooltip_LanguageUseSynonyms" xml:space="preserve">
+    <value>Également utiliser des synonymes de la langue sélectionnée pour l'affichage des séries et des groupes. Anglais et Romaji synonymes servira pas</value>
+  </data>
+  <data name="Up" xml:space="preserve">
+    <value>Vers le haut</value>
+  </data>
+  <data name="GroupFilterConditions" xml:space="preserve">
+    <value>Conditions de filtre</value>
+  </data>
+  <data name="GroupFilterConditionType" xml:space="preserve">
+    <value>Type de condition</value>
+  </data>
+  <data name="GroupFilterConditionType_AirDate" xml:space="preserve">
+    <value>Date de diffusion</value>
+  </data>
+  <data name="GroupFilterConditionType_AllEpisodesWatched" xml:space="preserve">
+    <value>Regardé tous les épisodes</value>
+  </data>
+  <data name="GroupFilterConditionType_AnimeGroup" xml:space="preserve">
+    <value>Groupe</value>
+  </data>
+  <data name="GroupFilterConditionType_AnimeType" xml:space="preserve">
+    <value>Type d'anime</value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedTvDBInfo" xml:space="preserve">
+    <value>A TvDB lien</value>
+  </data>
+  <data name="GroupFilterConditionType_Category" xml:space="preserve">
+    <value>Catégorie</value>
+  </data>
+  <data name="GroupFilterConditionType_CompletedSeries" xml:space="preserve">
+    <value>Série terminée</value>
+  </data>
+  <data name="GroupFilterConditionType_Favourite" xml:space="preserve">
+    <value>Favori</value>
+  </data>
+  <data name="GroupFilterConditionType_HasUnwatchedEpisodes" xml:space="preserve">
+    <value>A espionné des épisodes</value>
+  </data>
+  <data name="GroupFilterConditionType_MissingEpisodes" xml:space="preserve">
+    <value>Épisodes manquants</value>
+  </data>
+  <data name="GroupFilterConditionType_ReleaseGroup" xml:space="preserve">
+    <value>Groupe des rejets</value>
+  </data>
+  <data name="GroupFilterConditionType_Studio" xml:space="preserve">
+    <value>Studio</value>
+  </data>
+  <data name="GroupFilterConditionType_Tag" xml:space="preserve">
+    <value>Balise</value>
+  </data>
+  <data name="GroupFilterConditionType_UserVoted" xml:space="preserve">
+    <value>Utilisateur a voté (Perm)</value>
+  </data>
+  <data name="GroupFilterConditionType_VideoQuality" xml:space="preserve">
+    <value>Qualité vidéo</value>
+  </data>
+  <data name="GroupFilterOperator" xml:space="preserve">
+    <value>Opérateur</value>
+  </data>
+  <data name="GroupFilterOperator_Equals" xml:space="preserve">
+    <value>Est égal à</value>
+  </data>
+  <data name="GroupFilterOperator_Exclude" xml:space="preserve">
+    <value>Exclure les</value>
+  </data>
+  <data name="GroupFilterOperator_GreaterThan" xml:space="preserve">
+    <value>Supérieur ou égal à</value>
+  </data>
+  <data name="GroupFilterOperator_Include" xml:space="preserve">
+    <value>Inclure</value>
+  </data>
+  <data name="GroupFilterOperator_LessThan" xml:space="preserve">
+    <value>Inférieur ou égal à</value>
+  </data>
+  <data name="GroupFilterOperator_NotEquals" xml:space="preserve">
+    <value>Pas égal à</value>
+  </data>
+  <data name="GroupFilterSorting" xml:space="preserve">
+    <value>Tri</value>
+  </data>
+  <data name="ImageSize_GroupList" xml:space="preserve">
+    <value>Groupe et la liste des séries</value>
+  </data>
+  <data name="ImageSize_SeriesPoster" xml:space="preserve">
+    <value>Affiche de la série</value>
+  </data>
+  <data name="ImageSize_SubGroupList" xml:space="preserve">
+    <value>Sous groupes de liste et série</value>
+  </data>
+  <data name="INFO_SettingsDisplayStyle" xml:space="preserve">
+    <value>Vous devez actualiser votre liste de groupe afin de voir les effets des changements</value>
+  </data>
+  <data name="MSG_ERR_SelectDate" xml:space="preserve">
+    <value>Sélectionnez d'abord une date</value>
+  </data>
+  <data name="NewGroupFilter" xml:space="preserve">
+    <value>Nouveau filtre de groupe</value>
+  </data>
+  <data name="RenameGroups" xml:space="preserve">
+    <value>Renommez tous les groupes</value>
+  </data>
+  <data name="Style_GroupList" xml:space="preserve">
+    <value>Liste des groupes</value>
+  </data>
+  <data name="Style_GroupList_MediumDetail" xml:space="preserve">
+    <value>Détail moyen</value>
+  </data>
+  <data name="Style_GroupList_Simple" xml:space="preserve">
+    <value>Simple</value>
+  </data>
+  <data name="TAB_SettingsImageSizes" xml:space="preserve">
+    <value>Tailles d'image</value>
+  </data>
+  <data name="TAB_SettingsStyle" xml:space="preserve">
+    <value>Styles</value>
+  </data>
+  <data name="Tooltip_ImageSize_GroupList" xml:space="preserve">
+    <value>Les images affichées dans la liste principale lorsque vous affichez les séries et les groupes</value>
+  </data>
+  <data name="Tooltip_ImageSize_SeriesPoster" xml:space="preserve">
+    <value>Les images montrées dans le volet droit pour toutes les séries appartenant à un groupe</value>
+  </data>
+  <data name="Tooltip_ImageSize_SubGroupList" xml:space="preserve">
+    <value>Les images affichées dans la liste principale lors de la visualisation des sous-groupes ou série</value>
+  </data>
+  <data name="Tooltip_Style_GroupList" xml:space="preserve">
+    <value>Le style des groupes lorsque affiché dans la liste principale (aussi les sous-groupes)</value>
+  </data>
+  <data name="FilterValue" xml:space="preserve">
+    <value>Valeur de filtre</value>
+  </data>
+  <data name="MSG_ERR_EnterValue" xml:space="preserve">
+    <value>Veuillez entrer une valeur</value>
+  </data>
+  <data name="PreviewFilter" xml:space="preserve">
+    <value>Aperçu des résultats du filtre</value>
+  </data>
+  <data name="GroupFilter_ApplyToSeries" xml:space="preserve">
+    <value>Appliquer le filtre au niveau de la série au lieu de niveau groupe</value>
+  </data>
+  <data name="GroupFilter_BaseCondition" xml:space="preserve">
+    <value>Condition de base</value>
+  </data>
+  <data name="GroupFilter_BaseCondition_ExcludeAll" xml:space="preserve">
+    <value>Exclure tout</value>
+  </data>
+  <data name="GroupFilter_BaseCondition_IncludeAll" xml:space="preserve">
+    <value>Inclure tous les</value>
+  </data>
+  <data name="Tooltip_GroupFilter_BaseCondition" xml:space="preserve">
+    <value>Inclure tous afin que tous les groupes sont inclus par défaut. Exclure tout afin qu'aucun groupe n'est inclus, c'est censé être utilisé lorsque vous souhaitez spécifier manuellement les groupes sur une base indvidual.</value>
+  </data>
+  <data name="GroupFilterOperator_In" xml:space="preserve">
+    <value>Dans</value>
+  </data>
+  <data name="GroupFilterOperator_NotIn" xml:space="preserve">
+    <value>Pas en</value>
+  </data>
+  <data name="GroupFilter_Category_Help" xml:space="preserve">
+    <value>Double-cliquez sur catgeories pour les ajouter à la liste sélectionnée</value>
+  </data>
+  <data name="GroupFilterConditionType_AniDBRating" xml:space="preserve">
+    <value>Cotation - AniDB</value>
+  </data>
+  <data name="GroupFilterConditionType_UserRating" xml:space="preserve">
+    <value>Cotation - utilisateur</value>
+  </data>
+  <data name="MSG_ERR_RatingValue" xml:space="preserve">
+    <value>Valeur nominale doit être une valeur comprise entre 0 et 10. Décimales sont autorisés.</value>
+  </data>
+  <data name="ScanFolder" xml:space="preserve">
+    <value>Scannez ce dossier suite</value>
+  </data>
+  <data name="GroupFilterConditionType_EpisodeAddedDate" xml:space="preserve">
+    <value>Épisode ajouté Date</value>
+  </data>
+  <data name="GroupFilterConditionType_EpisodeWatchedDate" xml:space="preserve">
+    <value>Épisode regardé la Date</value>
+  </data>
+  <data name="GroupFilterConditionType_SeriesDate" xml:space="preserve">
+    <value>Série ajoutée le Date</value>
+  </data>
+  <data name="GroupFilterOperator_LastXDays" xml:space="preserve">
+    <value>Dernier « X » jours</value>
+  </data>
+  <data name="SelectDate" xml:space="preserve">
+    <value>Sélectionnez la Date</value>
+  </data>
+  <data name="MSG_ERR_DaysValue" xml:space="preserve">
+    <value>Veuillez entrer le nombre de jours sous forme d'entier (Minimum est 1)</value>
+  </data>
+  <data name="SyncVotes" xml:space="preserve">
+    <value>Sync AniDB Votes</value>
+  </data>
+  <data name="UserVote" xml:space="preserve">
+    <value>Mon Vote</value>
+  </data>
+  <data name="VoteNow" xml:space="preserve">
+    <value>Votez maintenant</value>
+  </data>
+  <data name="VoteRevoke" xml:space="preserve">
+    <value>Revoke</value>
+  </data>
+  <data name="GroupFilterConditionType_FinishedAiring" xml:space="preserve">
+    <value>Fini de diffusion</value>
+  </data>
+  <data name="VoteTypeAnimePermanent" xml:space="preserve">
+    <value>Permanente</value>
+  </data>
+  <data name="VoteTypeAnimeTemporary" xml:space="preserve">
+    <value>Temporaire</value>
+  </data>
+  <data name="AniDBMyListLocalActions" xml:space="preserve">
+    <value>Actions locales</value>
+  </data>
+  <data name="AniDBMyListSyncAndImport" xml:space="preserve">
+    <value>MyList Sync et les Options d'importation</value>
+  </data>
+  <data name="EpisodeMarkAllUnwatched" xml:space="preserve">
+    <value>Mark tout sans surveillance</value>
+  </data>
+  <data name="EpisodeMarkAllWatched" xml:space="preserve">
+    <value>Mark tout regardé</value>
+  </data>
+  <data name="EpisodeMarkAllWatchedPrevious" xml:space="preserve">
+    <value>Marquer tout précédent vu y compris EP #</value>
+  </data>
+  <data name="GroupFilter_VideoQuality_Help" xml:space="preserve">
+    <value>Double-cliquez sur les entrées pour les ajouter à la liste</value>
+  </data>
+  <data name="GroupFilterConditionType_MissingEpisodesCollecting" xml:space="preserve">
+    <value>Épisodes manquants (collecte)</value>
+  </data>
+  <data name="GroupFilterOperator_InAllEpisodes" xml:space="preserve">
+    <value>(Tous les épisodes)</value>
+  </data>
+  <data name="GroupFilterOperator_NotInAllEpisodes" xml:space="preserve">
+    <value>Pas dans (tous les épisodes)</value>
+  </data>
+  <data name="GroupFilterConditionType_AudioLanguage" xml:space="preserve">
+    <value>Langue audio</value>
+  </data>
+  <data name="GroupFilterConditionType_SubtitleLanguage" xml:space="preserve">
+    <value>Langue des sous-titres</value>
+  </data>
+  <data name="GroupFilterSortDirection_Asc" xml:space="preserve">
+    <value>ASC</value>
+  </data>
+  <data name="GroupFilterSortDirection_Desc" xml:space="preserve">
+    <value>/ / DESC</value>
+  </data>
+  <data name="GroupFilterSorting_AniDBRating" xml:space="preserve">
+    <value>AniDB Rating</value>
+  </data>
+  <data name="GroupFilterSorting_EpisodeAddedDate" xml:space="preserve">
+    <value>Épisode ajouté Date</value>
+  </data>
+  <data name="GroupFilterSorting_EpisodeAirDate" xml:space="preserve">
+    <value>Date de diffusion d'épisode</value>
+  </data>
+  <data name="GroupFilterSorting_EpisodeWatchedDate" xml:space="preserve">
+    <value>Épisode regardé la Date</value>
+  </data>
+  <data name="GroupFilterSorting_GroupName" xml:space="preserve">
+    <value>Nom du groupe</value>
+  </data>
+  <data name="GroupFilterSorting_MissingEpisodeCount" xml:space="preserve">
+    <value>Nombre d'épisode manquant</value>
+  </data>
+  <data name="GroupFilterSorting_SeriesAddedDate" xml:space="preserve">
+    <value>Série ajoutée le Date</value>
+  </data>
+  <data name="GroupFilterSorting_SeriesCount" xml:space="preserve">
+    <value>Comte de série</value>
+  </data>
+  <data name="GroupFilterSorting_UnwatchedEpisodeCount" xml:space="preserve">
+    <value>Nombre d'épisode sans surveillance</value>
+  </data>
+  <data name="GroupFilterSorting_UserRating" xml:space="preserve">
+    <value>Note des utilisateurs</value>
+  </data>
+  <data name="GroupFilterSorting_Year" xml:space="preserve">
+    <value>Année</value>
+  </data>
+  <data name="GroupFilterSorting_SortName" xml:space="preserve">
+    <value>Nom tri</value>
+  </data>
+  <data name="GroupFilterDirection" xml:space="preserve">
+    <value>Direction</value>
+  </data>
+  <data name="GroupFilterSortType" xml:space="preserve">
+    <value>Type de tri</value>
+  </data>
+  <data name="QuickSort" xml:space="preserve">
+    <value>Tri rapide</value>
+  </data>
+  <data name="TAB_DuplicateFiles" xml:space="preserve">
+    <value>Les fichiers en double</value>
+  </data>
+  <data name="INFO_DuplicateFiles" xml:space="preserve">
+    <value>Les fichiers en double sont où vous avez deux ou plusieurs fichiers qui sont exactement les mêmes, sauf qu'ils sont dans des dossiers différents ou sont nommés différemment. JMM autorise uniquement un seul fichier avec le même hachage de la collection.</value>
+  </data>
+  <data name="Tooltip_DeleteDuplicateFileAll" xml:space="preserve">
+    <value>Supprimez l'entrée de la base de données et le fichier sélectionné sur le disque.</value>
+  </data>
+  <data name="Tooltip_DeleteDuplicateFileEntry" xml:space="preserve">
+    <value>Supprimez l'entrée de la base de données uniquement. Ne souffrira pas des fichiers sur le disque.</value>
+  </data>
+  <data name="Files" xml:space="preserve">
+    <value>Fichiers</value>
+  </data>
+  <data name="ReevaluateDuplicateFiles" xml:space="preserve">
+    <value>Réévaluer toutes les entrées</value>
+  </data>
+  <data name="Tooltip_ReevaluateDuplicateFiles" xml:space="preserve">
+    <value>Vérifiez toutes les entrées de fichiers dupliqués pour voir si les fichiers existent toujours. Dans le cas contraire, supprimez l'entrée de la base de données</value>
+  </data>
+  <data name="TAB_MultipleFiles" xml:space="preserve">
+    <value>Plusieurs fichiers</value>
+  </data>
+  <data name="INFO_MultipleFiles" xml:space="preserve">
+    <value>Plusieurs fichiers sont où vous avez deux ou plusieurs fichiers du même épisode. Cet utilitaire vous permettra d'examiner tous ces événements et de décider quels sont ceux que vous souhaitez conserver</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Chargement...</value>
+  </data>
+  <data name="TotalFileCount" xml:space="preserve">
+    <value>Nombre de fichiers au total</value>
+  </data>
+  <data name="ImportSettings_UseEpisodeStatus" xml:space="preserve">
+    <value>Définir le fichier comme regardé si l'épisode est surveillée</value>
+  </data>
+  <data name="Tooltip_TvDB_Schedule_Updates" xml:space="preserve">
+    <value>Mettre à jour les informations série et épisode toutes les 12 heures et également télécharger tout nouveau fanart, les affiches et les bannières larges</value>
+  </data>
+  <data name="TvDB_Schedule_Updates" xml:space="preserve">
+    <value>Info mise à jour toutes les 12 heures</value>
+  </data>
+  <data name="RescanAll" xml:space="preserve">
+    <value>Re-analyser tous</value>
+  </data>
+  <data name="DeleteAll" xml:space="preserve">
+    <value>Supprimer tous les</value>
+  </data>
+  <data name="CrossRefSummary" xml:space="preserve">
+    <value>TvDB et autres liens AniDB Non</value>
+  </data>
+  <data name="FileSummary" xml:space="preserve">
+    <value>Résumé de fichier</value>
+  </data>
+  <data name="TheTvDB" xml:space="preserve">
+    <value>Le TvDB</value>
+  </data>
+  <data name="SeasonNumber" xml:space="preserve">
+    <value>Saison #</value>
+  </data>
+  <data name="CommunityRecommendation" xml:space="preserve">
+    <value>Recommandation de la communauté</value>
+  </data>
+  <data name="TvDBSearchPrompt" xml:space="preserve">
+    <value>Rechercher sur le TvDB ou entrez l'identifiant des séries TvDB</value>
+  </data>
+  <data name="TvDBShow" xml:space="preserve">
+    <value>Aller à TvDB</value>
+  </data>
+  <data name="UseThis" xml:space="preserve">
+    <value>Utilisez cette</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Fermer</value>
+  </data>
+  <data name="SwitchSeason" xml:space="preserve">
+    <value>Saison de commutateur</value>
+  </data>
+  <data name="AniDB" xml:space="preserve">
+    <value>AniDB</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>Mise à jour</value>
+  </data>
+  <data name="UpdateAniDBInfo" xml:space="preserve">
+    <value>Mise à jour d'informations AniDB</value>
+  </data>
+  <data name="UpdateInfo" xml:space="preserve">
+    <value>Mise à jour d'informations</value>
+  </data>
+  <data name="ImageSize_EpisodeImage" xml:space="preserve">
+    <value>Image de l'épisode</value>
+  </data>
+  <data name="Tooltip_ImageSize_EpisodeImage" xml:space="preserve">
+    <value>Le spectacle d'images dans le détail de l'épisode</value>
+  </data>
+  <data name="EpisodeDetailStyle" xml:space="preserve">
+    <value>Épisode détail Style</value>
+  </data>
+  <data name="EpisodeDetailStyle_Option1" xml:space="preserve">
+    <value>Images/Résumé en résumé</value>
+  </data>
+  <data name="EpisodeDetailStyle_Option2" xml:space="preserve">
+    <value>Images/aperçu lorsqu'il est développé uniquement</value>
+  </data>
+  <data name="EpisodeDetailStyle_Option3" xml:space="preserve">
+    <value>Personnes handicapées images/aperçu</value>
+  </data>
+  <data name="HideEpisodeImageWhenUnwatched" xml:space="preserve">
+    <value>Masquer l'Image de l'épisode lorsque espionné</value>
+  </data>
+  <data name="HideEpisodeOverviewWhenUnwatched" xml:space="preserve">
+    <value>Masquer l'aperçu de l'épisode lorsque espionné</value>
+  </data>
+  <data name="Tooltip_HideEpisodeImageWhenUnwatched" xml:space="preserve">
+    <value>L'image de l'épisode sera cachée jusqu'à ce que l'épisode est regardé</value>
+  </data>
+  <data name="Tooltip_HideEpisodeOverviewWhenUnwatched" xml:space="preserve">
+    <value>La vue d'ensemble de l'épisode (description) est masqué jusqu'à ce que l'épisode est regardé</value>
+  </data>
+  <data name="Fanart" xml:space="preserve">
+    <value>Fanart</value>
+  </data>
+  <data name="Images" xml:space="preserve">
+    <value>Images</value>
+  </data>
+  <data name="Image_Disabled" xml:space="preserve">
+    <value>Image est actuellement désactivé</value>
+  </data>
+  <data name="Image_Dynamic" xml:space="preserve">
+    <value>Définir cette image comme la seule image qui s'affichera</value>
+  </data>
+  <data name="Image_Enabled" xml:space="preserve">
+    <value>Image est actuellement activé</value>
+  </data>
+  <data name="Image_Static" xml:space="preserve">
+    <value>Cette image est la seule qui sera affiché</value>
+  </data>
+  <data name="Image_View" xml:space="preserve">
+    <value>Voir l'Image</value>
+  </data>
+  <data name="Posters" xml:space="preserve">
+    <value>Affiches</value>
+  </data>
+  <data name="WideBanners" xml:space="preserve">
+    <value>Larges bannières</value>
+  </data>
+  <data name="TheMovieDB" xml:space="preserve">
+    <value>Le film DB</value>
+  </data>
+  <data name="MovieDBShow" xml:space="preserve">
+    <value>Aller à MovieDB</value>
+  </data>
+  <data name="MovieDBSearchPrompt" xml:space="preserve">
+    <value>Rechercher sur le MovieDB ou entrez l'ID MovieDB</value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedTvDBOrMovieDBInfo" xml:space="preserve">
+    <value>A TvDB ou MovieDB lien</value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedMovieDBInfo" xml:space="preserve">
+    <value>A lien MovieDB</value>
+  </data>
+  <data name="Image_Default" xml:space="preserve">
+    <value>Seulement cette image sera utilisée</value>
+  </data>
+  <data name="Image_NotDefault" xml:space="preserve">
+    <value>Cette image n'est pas la valeur par défaut</value>
+  </data>
+  <data name="PlayNextEpisode" xml:space="preserve">
+    <value>Jouer le prochain épisode</value>
+  </data>
+  <data name="AllEpisodesWatched" xml:space="preserve">
+    <value>Tous les épisodes ont déjà été visionnées</value>
+  </data>
+  <data name="FinishEditing" xml:space="preserve">
+    <value>Terminez</value>
+  </data>
+  <data name="TAB_Dashboard" xml:space="preserve">
+    <value>Tableau de bord</value>
+  </data>
+  <data name="Dash_WatchNextEp_Recent" xml:space="preserve">
+    <value>Continuer à regarder... (Récemment regardé)</value>
+  </data>
+  <data name="DeleteSeries" xml:space="preserve">
+    <value>Supprimer la série</value>
+  </data>
+  <data name="DeleteSeriesConfirm" xml:space="preserve">
+    <value>Êtes-vous sûr de que vouloir supprimer cet série/groupe ?</value>
+  </data>
+  <data name="DeleteSeriesConfirm_Files" xml:space="preserve">
+    <value>Également supprimer tous les fichiers physiques ?</value>
+  </data>
+  <data name="Dash_SeriesMissingEps" xml:space="preserve">
+    <value>Manque d'épisodes (par récemment regardé)</value>
+  </data>
+  <data name="LatestEp_Anime" xml:space="preserve">
+    <value>Dernier épisode</value>
+  </data>
+  <data name="LatestEp_Yours" xml:space="preserve">
+    <value>Votre dernier épisode</value>
+  </data>
+  <data name="MissingEpisodeCount" xml:space="preserve">
+    <value>Épisodes manquants</value>
+  </data>
+  <data name="Dash_MiniCalendar" xml:space="preserve">
+    <value>Calendrier mini</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Ouverture de session</value>
+  </data>
+  <data name="ImageSize" xml:space="preserve">
+    <value>Taille de l'image</value>
+  </data>
+  <data name="INFO_SettingsUserAdmin" xml:space="preserve">
+    <value>Ajouter ou modifier des utilisateurs ici. Les utilisateurs sont stockées dans la base de données et partagées entre différents clients. Vous devez toujours avoir au moins un utilisateur admin.</value>
+  </data>
+  <data name="TAB_SettingsUsers" xml:space="preserve">
+    <value>Utilisateurs</value>
+  </data>
+  <data name="User_HideCategories" xml:space="preserve">
+    <value>Masquer les catégories</value>
+  </data>
+  <data name="User_IsAdmin" xml:space="preserve">
+    <value>Administrateur</value>
+  </data>
+  <data name="User_Password" xml:space="preserve">
+    <value>Mot de passe</value>
+  </data>
+  <data name="User_Username" xml:space="preserve">
+    <value>Nom d'utilisateur</value>
+  </data>
+  <data name="Items" xml:space="preserve">
+    <value>Éléments</value>
+  </data>
+  <data name="Days" xml:space="preserve">
+    <value>Jours</value>
+  </data>
+  <data name="DashWatchNextStyle_Detailed" xml:space="preserve">
+    <value>Détaillées</value>
+  </data>
+  <data name="DashWatchNextStyle_Simple" xml:space="preserve">
+    <value>Simple</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_Trakt" xml:space="preserve">
+    <value>Trakt TV</value>
+  </data>
+  <data name="Trakt_Password" xml:space="preserve">
+    <value>Mot de passe</value>
+  </data>
+  <data name="Trakt_Username" xml:space="preserve">
+    <value>Nom d'utilisateur</value>
+  </data>
+  <data name="UpdateFrequency" xml:space="preserve">
+    <value>Mise à jour automatique des données</value>
+  </data>
+  <data name="UpdateFrequency_12Hours" xml:space="preserve">
+    <value>Toutes les 12 heures</value>
+  </data>
+  <data name="UpdateFrequency_6Hours" xml:space="preserve">
+    <value>Toutes les 6 heures</value>
+  </data>
+  <data name="UpdateFrequency_Daily" xml:space="preserve">
+    <value>Toutes les 24 heures</value>
+  </data>
+  <data name="UpdateFrequency_Never" xml:space="preserve">
+    <value>Jamais</value>
+  </data>
+  <data name="TraktSyncFrequency" xml:space="preserve">
+    <value>Synchroniser automatiquement la Collection</value>
+  </data>
+  <data name="TraktSearchPrompt" xml:space="preserve">
+    <value>Rechercher sur Trakt ou entrez Trakt ID (slug)</value>
+  </data>
+  <data name="TraktShow" xml:space="preserve">
+    <value>Aller à Trakt</value>
+  </data>
+  <data name="TAB_Pinned" xml:space="preserve">
+    <value>Épinglés</value>
+  </data>
+  <data name="Tooltip_ViewSeries" xml:space="preserve">
+    <value>Ouvrir cette série animée dans une nouvelle fenêtre</value>
+  </data>
+  <data name="GroupFilterConditionType_UserVotedAny" xml:space="preserve">
+    <value>Utilisateur a voté (tout)</value>
+  </data>
+  <data name="Tooltip_User_IsAniDB" xml:space="preserve">
+    <value>N'importe quel utilisateur marqué en tant qu'utilisateur AniDB resteront synchronisé avec d'autres utilisateurs de AniDB. Si l'utilisateur n'est pas un utilisateur de AniDB regardé des épisodes n'apparaîtra pas sur le site AniDB.</value>
+  </data>
+  <data name="User_IsAniDB" xml:space="preserve">
+    <value>Utilisateur AniDB</value>
+  </data>
+  <data name="User_IsTrakt" xml:space="preserve">
+    <value>Trakt utilisateur</value>
+  </data>
+  <data name="ERROR_SeriesExists" xml:space="preserve">
+    <value>Une série existe déjà pour cet anime</value>
+  </data>
+  <data name="Tooltip_CreateSeries" xml:space="preserve">
+    <value>Créer des séries pour cet anime</value>
+  </data>
+  <data name="SimilarAnime" xml:space="preserve">
+    <value>Anime similaire</value>
+  </data>
+  <data name="RelatedAndSimilar" xml:space="preserve">
+    <value>Connexes et similaires</value>
+  </data>
+  <data name="GetMissingData" xml:space="preserve">
+    <value>Téléchargez dès maintenant les données manquantes</value>
+  </data>
+  <data name="NoSimilarAnime" xml:space="preserve">
+    <value>Aucun anime similaire a pu être trouvé</value>
+  </data>
+  <data name="NoRelatedAnime" xml:space="preserve">
+    <value>Aucun anime connexe a pu être trouvé</value>
+  </data>
+  <data name="RelatedAnime" xml:space="preserve">
+    <value>Anime connexe</value>
+  </data>
+  <data name="Dash_RecWatch" xml:space="preserve">
+    <value>Recommandations à surveiller</value>
+  </data>
+  <data name="Dash_RecDownload" xml:space="preserve">
+    <value>Recommandations à télécharger</value>
+  </data>
+  <data name="ImportSettings_AutoGroupSeries" xml:space="preserve">
+    <value>Placer automatiquement des séries connexes dans le même groupe</value>
+  </data>
+  <data name="GroupFilterConditionType_HasWatchedEpisodes" xml:space="preserve">
+    <value>A regardé les épisodes</value>
+  </data>
+  <data name="MyList" xml:space="preserve">
+    <value>MyList</value>
+  </data>
+  <data name="Tooltip_MyList" xml:space="preserve">
+    <value>Avec force ajouter ce fichier à votre liste sur AniDB</value>
+  </data>
+  <data name="TAB_MissingFiles" xml:space="preserve">
+    <value>MyList fichiers manquants</value>
+  </data>
+  <data name="TAB_Utilities" xml:space="preserve">
+    <value>Utilitaires</value>
+  </data>
+  <data name="TAB_SeriesWithoutFiles" xml:space="preserve">
+    <value>Série sans fichiers</value>
+  </data>
+  <data name="DeleteSeriesConfirm_Groups" xml:space="preserve">
+    <value>Supprimer des groupes de parents, s'ils sont vides</value>
+  </data>
+  <data name="Export" xml:space="preserve">
+    <value>Export</value>
+  </data>
+  <data name="TAB_MissingEpisodes" xml:space="preserve">
+    <value>Épisodes manquants</value>
+  </data>
+  <data name="MyGroupsOnly" xml:space="preserve">
+    <value>Seuls les groupes de libération que je collecte des</value>
+  </data>
+  <data name="RegularEpisodesOnly" xml:space="preserve">
+    <value>Épisodes réguliers seulement</value>
+  </data>
+  <data name="Dash_TraktFriends" xml:space="preserve">
+    <value>Activité d'amis (Trakt TV)</value>
+  </data>
+  <data name="Tooltip_IgnoreAnimeDownload" xml:space="preserve">
+    <value>Ignorer cet Anime pour télécharger les recommandations</value>
+  </data>
+  <data name="Tooltip_IgnoreAnimeWatch" xml:space="preserve">
+    <value>Ignorer cet Anime pour regarder les recommandations</value>
+  </data>
+  <data name="VisitWebsite" xml:space="preserve">
+    <value>Visitez le site Web</value>
+  </data>
+  <data name="AniDBSignup" xml:space="preserve">
+    <value>Inscription pour l'instant AniDB</value>
+  </data>
+  <data name="AvdumpHeader" xml:space="preserve">
+    <value>AVDump2 (facultatif)</value>
+  </data>
+  <data name="AvdumpInfoLink" xml:space="preserve">
+    <value>Plus d'infos sur AVDump2</value>
+  </data>
+  <data name="AvdumpKey" xml:space="preserve">
+    <value>Clé API</value>
+  </data>
+  <data name="AvdumpKeyEditLink" xml:space="preserve">
+    <value>Modifier votre clé API AVDump2 UDP ici</value>
+  </data>
+  <data name="Avdump" xml:space="preserve">
+    <value>Avdump2</value>
+  </data>
+  <data name="AvdumpRequiredFilesLink" xml:space="preserve">
+    <value>Assurez-vous de qu'avoir tous les fichiers requis dans le même dossier que le Bureau de JMM</value>
+  </data>
+  <data name="AvdumpSettingsError" xml:space="preserve">
+    <value>Vous n'avez pas spécifié votre clé API et/ou le Port Client</value>
+  </data>
+  <data name="AvdumpAddRelease" xml:space="preserve">
+    <value>Ajouter nouvelle version</value>
+  </data>
+  <data name="CopyED2KClipboard" xml:space="preserve">
+    <value>Copie ED2K Dump</value>
+  </data>
+  <data name="Tooltip_CopyED2KClipboard" xml:space="preserve">
+    <value>Copier le Dump ED2K dans le presse-papiers</value>
+  </data>
+  <data name="TAB_IgnoredAnime" xml:space="preserve">
+    <value>Anime ignoré</value>
+  </data>
+  <data name="Anime" xml:space="preserve">
+    <value>Anime</value>
+  </data>
+  <data name="RemoveDefaultSeries" xml:space="preserve">
+    <value>Enlever des souches par défaut</value>
+  </data>
+  <data name="SetDefaultSeries" xml:space="preserve">
+    <value>Ajouter la série par défaut</value>
+  </data>
+  <data name="DefSeries1" xml:space="preserve">
+    <value>Sélectionnez la série par défaut pour</value>
+  </data>
+  <data name="DefSeries2" xml:space="preserve">
+    <value>En sélectionnant une série par défaut signifie que toutes les images qui sont dsiplayed pour un groupe qui utilise </value>
+  </data>
+  <data name="DefSeries3" xml:space="preserve">
+    <value>série par défaut au lieu d'une série au hasard au sein du groupe</value>
+  </data>
+  <data name="ChangeLanguage" xml:space="preserve">
+    <value>Changer la langue</value>
+  </data>
+  <data name="EpisodeTitleSourceStyle" xml:space="preserve">
+    <value>Épisode titre Source</value>
+  </data>
+  <data name="SeriesNameSourceStyle" xml:space="preserve">
+    <value>Source de nom de série</value>
+  </data>
+  <data name="SeriesOverviewSourceStyle" xml:space="preserve">
+    <value>Source de vue d'ensemble de série</value>
+  </data>
+  <data name="Tooltip_EpisodeTitleSourceStyle" xml:space="preserve">
+    <value>Source privilégiée d'informations lors de l'affichage du titre d'un épisode</value>
+  </data>
+  <data name="Tooltip_SeriesNameSourceStyle" xml:space="preserve">
+    <value>Source privilégiée d'informations lors de l'affichage du nom de la série pour une adaptation en anime</value>
+  </data>
+  <data name="Tooltip_SeriesOverviewSourceStyle" xml:space="preserve">
+    <value>Source privilégiée d'informations lors de l'affichage de l'aperçu (description) pour une série d'animation</value>
+  </data>
+  <data name="User_EditSettings" xml:space="preserve">
+    <value>Modifier les paramètres du serveur</value>
+  </data>
+  <data name="Tooltip_RemoveMissingFiles" xml:space="preserve">
+    <value>Ceci supprimera toutes les entrées de fichiers vidéo de votre base de données, où le fichier ne peut pas être trouvé physiquement. Assurez-vous que tous vos partages réseau sont disponibles ou lecteurs USB branché avant de lancer cela.</value>
+  </data>
+  <data name="Tooltip_UpdateMediaInfo" xml:space="preserve">
+    <value>Le Media Info est les informations sur vos fichiers tels que le taux de bit, résolution codecs etc. qui sont lues et enregistrées la première fois, vous importez un fichier</value>
+  </data>
+  <data name="UpdateMediaInfo" xml:space="preserve">
+    <value>Mise à jour de tous les médias d'informations</value>
+  </data>
+  <data name="Video_Hi10P" xml:space="preserve">
+    <value>10 bits</value>
+  </data>
+  <data name="Tooltip_TraktAnimeOnly" xml:space="preserve">
+    <value>Spectacle seulement l'activité est liée à l'anime (c'est à dire exclure les autres séries tv)</value>
+  </data>
+  <data name="TraktAnimeOnly" xml:space="preserve">
+    <value>Anime uniquement</value>
+  </data>
+  <data name="ForceRefresh" xml:space="preserve">
+    <value>Forcer l'actualisation</value>
+  </data>
+  <data name="TraktFriendNotes" xml:space="preserve">
+    <value>Information est mise à jour le serveur toutes les 20 minutes</value>
+  </data>
+  <data name="Dash_RecentEpisodes" xml:space="preserve">
+    <value>Récemment regardés épisodes</value>
+  </data>
+  <data name="PromptRateSeries" xml:space="preserve">
+    <value>Invite à des séries de taux à la fin</value>
+  </data>
+  <data name="Tooltip_PromptRateSeries" xml:space="preserve">
+    <value>Chaque fois que vous regardez le dernier épisode d'une série, une invite s'affiche pour vous demander une note</value>
+  </data>
+  <data name="MALSearchPrompt" xml:space="preserve">
+    <value>Rechercher sur MyAnimelist ou entrez l'ID du MAL</value>
+  </data>
+  <data name="MALShow" xml:space="preserve">
+    <value>Aller à MyAnimeList</value>
+  </data>
+  <data name="Tooltip_WebCache_MALAssociations" xml:space="preserve">
+    <value>Utilisez le cache web pour rechercher des liens entre AniDB et MyAnimeList. Si ne pas sélectionné vous devrez rechercher manuellement tous les liens MAL.</value>
+  </data>
+  <data name="WebCache_MALAssociations" xml:space="preserve">
+    <value>Liens MyAnimeList</value>
+  </data>
+  <data name="Tooltip_MAL_UpdateFrequency" xml:space="preserve">
+    <value>À quelle fréquence les données sont actualisées, et combien de fois une recherche automatique est effectuée pour rechercher anime dans votre collection qui n'a pas un lien MAL</value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedMALInfo" xml:space="preserve">
+    <value>A MAL lien</value>
+  </data>
+  <data name="Tooltip_UseFanartOnSeries" xml:space="preserve">
+    <value>Fanart d'utilisateur au lieu d'affiches (le cas échéant) sur l'écran de la série</value>
+  </data>
+  <data name="UseFanartOnSeries" xml:space="preserve">
+    <value>Fanart d'utilisateur sur l'écran de la série</value>
+  </data>
+  <data name="MAL_NeverDecrease" xml:space="preserve">
+    <value>Jamais la diminution regardé comtes</value>
+  </data>
+  <data name="Tooltip_MAL_NeverDecrease" xml:space="preserve">
+    <value>Assurez-vous que regardé comptes sont toujours conservés. Cela nécessite le téléchargement de votre liste complète chaque fois que vous regardez un épisode, donc peut être beaucoup de temps</value>
+  </data>
+  <data name="GroupFilterConditionType_EpisodeCount" xml:space="preserve">
+    <value>Nombre d'épisode</value>
+  </data>
+  <data name="SyncMalDown" xml:space="preserve">
+    <value>Télécharger regardé des États de MAL</value>
+  </data>
+  <data name="SyncMalUp" xml:space="preserve">
+    <value>Télécharger les États regardés à MAL</value>
+  </data>
+  <data name="Tooltip_SyncMalDown" xml:space="preserve">
+    <value>Télécharger regardés États de MAL et mettre à jour votre collection locale et AniDB.</value>
+  </data>
+  <data name="Tooltip_SyncMalUp" xml:space="preserve">
+    <value>Mise à jour MAL utilisant les stats surveillés de votre collection locale</value>
+  </data>
+  <data name="Tooltip_WebCache_AniDB_File" xml:space="preserve">
+    <value>Il s'agit des données associées à chaque dossier individuel. Recommandé pour de grandes collections</value>
+  </data>
+  <data name="WebCache_AniDB_File" xml:space="preserve">
+    <value>Données du fichier AniDB</value>
+  </data>
+  <data name="PlaylistPlayOrderRandom" xml:space="preserve">
+    <value>Au hasard</value>
+  </data>
+  <data name="PlaylistPlayOrderSeq" xml:space="preserve">
+    <value>Séquentiel</value>
+  </data>
+  <data name="AniDBScheduleMyListStats" xml:space="preserve">
+    <value>Obtenez automatiquement MyList Stats de AniDB</value>
+  </data>
+  <data name="GroupFilter_Predefined" xml:space="preserve">
+    <value>Filtres prédéfinis</value>
+  </data>
+  <data name="BakaBTResetBody" xml:space="preserve">
+    <value>Réinitialiser le cookie si vous n'obtenez aucun résultat de BakaBT quand vous devriez être. Cela va forcer une connexion d'accès à BakaBT à nouveau.</value>
+  </data>
+  <data name="BakaBTResetTitle" xml:space="preserve">
+    <value>Réinitialiser le Cookie</value>
+  </data>
+  <data name="BakaBTSeriesBody" xml:space="preserve">
+    <value>Lorsque vous recherchez une série, BakaBT (et AnimeBytes) sera la source de torrent seulement utilisée pour la recherche initiale</value>
+  </data>
+  <data name="BakaBTSeriesTitle" xml:space="preserve">
+    <value>BakaBT (et AnimeBytes) seulement</value>
+  </data>
+  <data name="AnimeBytesResetBody" xml:space="preserve">
+    <value>Réinitialiser le cookie si vous n'obtenez aucun résultat de AnimeBytes quand vous devriez être. Cela va forcer une connexion d'accès à AnimeBytes à nouveau.</value>
+  </data>
+  <data name="AnimeBytesResetTitle" xml:space="preserve">
+    <value>Réinitialiser le cookie</value>
+  </data>
+  <data name="AnimeBytesSeriesBody" xml:space="preserve">
+    <value>Lorsque vous recherchez une série, AnimeBytes (et BakaBT) sera la source de torrent seulement utilisée pour la recherche initiale</value>
+  </data>
+  <data name="AnimeBytesSeriesTitle" xml:space="preserve">
+    <value>AnimeBytes (et BakaBT) seulement</value>
+  </data>
+  <data name="IsVariation" xml:space="preserve">
+    <value>Est la Variation</value>
+  </data>
+  <data name="Tooltip_IsVariation" xml:space="preserve">
+    <value>Utilisez cette option lorsque vous ne voulez pas un fichier s'affiche dans le contrôle de fichiers multiples. C'est peut-être le cas où vous avez plusieurs versions d'un OP/ED pour nettoyer/non propre, de réalisateur et d'autres types de variations</value>
+  </data>
+  <data name="AniDBDownloadCharacters" xml:space="preserve">
+    <value>Télécharger des Images de caractère</value>
+  </data>
+  <data name="AniDBDownloadCreators" xml:space="preserve">
+    <value>Télécharger des Images de créateur</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadCharacters" xml:space="preserve">
+    <value>Ces images sont présentées dans 3 MyAnime et Anime Buddy</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadCreators" xml:space="preserve">
+    <value>Ces images sont affichées en 3 MyAnime et Anime Buddy (doubleurs)</value>
+  </data>
+  <data name="AniDBMyListDeleteAction" xml:space="preserve">
+    <value>Supprimer Action</value>
+  </data>
+  <data name="Tooltip_AniDBMyListDeleteAction" xml:space="preserve">
+    <value>Mesures à prendre pour un fichier lorsque vous le supprimez de votre collection locale.
+Supprimer le fichier (AniDB) - supprime de votre AniDB MyList.
+Supprimez le fichier (DB Local) - suppression du fichier depuis votre base de données locale seulement.
+Mark Deleted - laisse le fichier sur votre liste, mais modifie l'état supprimé.
+Mark externe (CD/DVD) - laisse le fichier sur votre liste, mais modifie l'état de stockage externe.
+Marque inconnue -, laisse le fichier sur votre liste, mais remplace l'état inconnu.</value>
+  </data>
+  <data name="GroupFilterConditionType_CustomTag" xml:space="preserve">
+    <value>Balise personnalisée</value>
+  </data>
+  <data name="Tooltip_WebCache_UserInfo" xml:space="preserve">
+    <value>Envoie info utilisation anonyme au cache web comme Type de base de données, version Windows etc. Consultez l'aide du lien pour toutes les données qui est envoyée</value>
+  </data>
+  <data name="WebCache_UserInfo" xml:space="preserve">
+    <value>Envoyer l'Info d'utilisation anonymes</value>
+  </data>
+  <data name="NewSeries_Search" xml:space="preserve">
+    <value>Recherche par titre ou ID</value>
+  </data>
+  <data name="Tooltip_NewSeries_Search" xml:space="preserve">
+    <value>Inscrivez le nom de l'anime, ou si vous connaissez l'ID de AniDB juste que directement</value>
+  </data>
+  <data name="Link_CommunityRecommendation" xml:space="preserve">
+    <value>http://jmediamanager.org/faq/#What-are-Community-Recommendations</value>
+  </data>
+  <data name="WhatsThis" xml:space="preserve">
+    <value>Qu'est-ce que c est?</value>
+  </data>
+  <data name="Override" xml:space="preserve">
+    <value>Substituez</value>
+  </data>
+  <data name="Tooltip_NameOverride" xml:space="preserve">
+    <value>Vous pouvez manuellement taper le nom que vous souhaitez, ou utilisez les flèches vertes vers la droite pour sélectionner un nom dans AniDB.</value>
+  </data>
+  <data name="Tooltip_NameOverride2" xml:space="preserve">
+    <value>Sélectionnez un nom dans une liste de noms AniDB.</value>
+  </data>
+  <data name="AdminMessageTitle" xml:space="preserve">
+    <value>Message de l'admin</value>
+  </data>
+  <data name="CheckForUpdate" xml:space="preserve">
+    <value>Check For Updates</value>
+  </data>
+  <data name="Link_Blog" xml:space="preserve">
+    <value>http://jmediamanager.org/blog</value>
+  </data>
+  <data name="Link_AniDBBanned" xml:space="preserve">
+    <value>http://jmediamanager.org/FAQ/#Banned-from-anidb</value>
+  </data>
+  <data name="Link_AniDBSettings" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#anidb</value>
+  </data>
+  <data name="Link_FileRenaming" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Utilities/file-renaming/</value>
+  </data>
+  <data name="Link_GroupFilters" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/collection/#What-are-Filters</value>
+  </data>
+  <data name="Link_ImportFolders" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Server/Configuring-JMM-Server/#Import-Folders</value>
+  </data>
+  <data name="Link_MAL" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#Community-sites</value>
+  </data>
+  <data name="Link_MPC" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#MPC</value>
+  </data>
+  <data name="Link_PotPlayer" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#pot-Player</value>
+  </data>
+  <data name="Link_TMDb" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#Community-sites</value>
+  </data>
+  <data name="Link_Trakt" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#Community-sites</value>
+  </data>
+  <data name="Link_TvDB" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#Community-sites</value>
+  </data>
+  <data name="Link_uTorrent" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Downloads/#uTorrent</value>
+  </data>
+  <data name="Link_VLC" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#VLC</value>
+  </data>
+  <data name="Link_WebCache" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Settings/#Web-cache</value>
+  </data>
+  <data name="UpdateFrequency_OneMonth" xml:space="preserve">
+    <value>Une fois par mois</value>
+  </data>
+  <data name="UpdateFrequency_OneWeek" xml:space="preserve">
+    <value>Une fois par semaine</value>
+  </data>
+  <data name="SettingAlwaysAniDBPoster" xml:space="preserve">
+    <value>Utilisez toujours l'affiche AniDB</value>
+  </data>
+  <data name="Tooltip_SettingAlwaysAniDBPoster" xml:space="preserve">
+    <value>Ce paramètre pilotera trop d'autres paramètres de Poster afin que seulement l'affiche AniDB est utilisé. C'est généralement plus rapide que d'utiliser des affiches au hasard</value>
+  </data>
+  <data name="MoreInfo" xml:space="preserve">
+    <value>Plus d'informations</value>
+  </data>
+  <data name="Link_Changelog" xml:space="preserve">
+    <value>http://jmediamanager.org/changelog/</value>
+  </data>
+  <data name="Link_Download" xml:space="preserve">
+    <value>http://jmediamanager.org/downloads/</value>
+  </data>
+  <data name="Link_Site" xml:space="preserve">
+    <value>http://jmediamanager.org/</value>
+  </data>
+  <data name="ReenterPassword" xml:space="preserve">
+    <value>Ré-entrez le mot de passe</value>
+  </data>
+  <data name="ChangePassword" xml:space="preserve">
+    <value>Changer mot de passe</value>
+  </data>
+  <data name="ChangingPassword" xml:space="preserve">
+    <value>Changer le mot de passe : </value>
+  </data>
+  <data name="WhatDoesThisMean" xml:space="preserve">
+    <value>Que cela signifie-t-il ?</value>
+  </data>
+  <data name="DetailedExplanation" xml:space="preserve">
+    <value>Cliquez ici pour une explication détaillée des options</value>
+  </data>
+  <data name="CustomTag_Name" xml:space="preserve">
+    <value>Nom de la balise</value>
+  </data>
+  <data name="CustomTag_Description" xml:space="preserve">
+    <value>Description de la balise</value>
+  </data>
+  <data name="Add" xml:space="preserve">
+    <value>Ajouter</value>
+  </data>
+  <data name="MissingEpisodes_AnimeName" xml:space="preserve">
+    <value>Nom de l'anime</value>
+  </data>
+  <data name="MissingEpisodes_AnimeID" xml:space="preserve">
+    <value>ID de l'anime</value>
+  </data>
+  <data name="MissingEpisodes_EpisodeNumber" xml:space="preserve">
+    <value>Numéro de l'épisode</value>
+  </data>
+  <data name="MissingEpisodes_EpisodeID" xml:space="preserve">
+    <value>ID de l'épisode</value>
+  </data>
+  <data name="MissingEpisodes_GroupSummary" xml:space="preserve">
+    <value>Résumé de groupe</value>
+  </data>
+  <data name="MissingEpisodes_AnimeLink" xml:space="preserve">
+    <value>Lien vers Anime</value>
+  </data>
+  <data name="MissingEpisodes_EpisodeLink" xml:space="preserve">
+    <value>Lien vers l'épisode</value>
+  </data>
+  <data name="MissingEpisodes_FileSummary" xml:space="preserve">
+    <value>Résumé de fichier</value>
+  </data>
+  <data name="NewSeries_AlreadyAttached" xml:space="preserve">
+    <value>Une série est déjà attachée à cet anime</value>
+  </data>
+  <data name="NewSeries_Step1" xml:space="preserve">
+    <value>Étape 1 - Sélectionnez une adaptation en Anime</value>
+  </data>
+  <data name="NewSeries_SearchBy" xml:space="preserve">
+    <value>Recherche par titre ou ID</value>
+  </data>
+  <data name="NewSeries_Step2" xml:space="preserve">
+    <value>Sélectionnez un groupe Local</value>
+  </data>
+  <data name="NewSeries_BackToStep1" xml:space="preserve">
+    <value>Retour à l'étape 1</value>
+  </data>
+  <data name="TryAgain" xml:space="preserve">
+    <value>Réessayez!</value>
+  </data>
+  <data name="Random_Tags" xml:space="preserve">
+    <value>Tags</value>
+  </data>
+  <data name="Finish" xml:space="preserve">
+    <value>Finition</value>
+  </data>
+  <data name="Clear" xml:space="preserve">
+    <value>Claire</value>
+  </data>
+  <data name="Matches" xml:space="preserve">
+    <value>Allumettes</value>
+  </data>
+  <data name="Random_Watched" xml:space="preserve">
+    <value>Regardé</value>
+  </data>
+  <data name="Random_Unwatched" xml:space="preserve">
+    <value>Espionné</value>
+  </data>
+  <data name="Random_PartiallyWatched" xml:space="preserve">
+    <value>Regardé partiellement</value>
+  </data>
+  <data name="Random_CompleteOnly" xml:space="preserve">
+    <value>Remplissez seulement</value>
+  </data>
+  <data name="Random_View" xml:space="preserve">
+    <value>Découvre cette série</value>
+  </data>
+  <data name="RateSeries_Rate" xml:space="preserve">
+    <value>Séries de taux :</value>
+  </data>
+  <data name="RateSeries_TraktShout" xml:space="preserve">
+    <value>Exprimez-vous sur Trakt</value>
+  </data>
+  <data name="Search_Episodes" xml:space="preserve">
+    <value>Épisodes :</value>
+  </data>
+  <data name="Search_StartingAt" xml:space="preserve">
+    <value>À partir de</value>
+  </data>
+  <data name="Search_ID" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="Search_Title" xml:space="preserve">
+    <value>Titre</value>
+  </data>
+  <data name="Search_AniDBStart" xml:space="preserve">
+    <value>AniDB Start :</value>
+  </data>
+  <data name="Search_Trakt" xml:space="preserve">
+    <value>Trakt : </value>
+  </data>
+  <data name="Search_Approved" xml:space="preserve">
+    <value>Admin a approuvé</value>
+  </data>
+  <data name="Search_TvDB" xml:space="preserve">
+    <value>TvDB : </value>
+  </data>
+  <data name="Search_MAL" xml:space="preserve">
+    <value>MAL : </value>
+  </data>
+  <data name="SelectAniDBTitle_SelectName" xml:space="preserve">
+    <value>Sélectionnez un nom de remplacement</value>
+  </data>
+  <data name="SelectGroupSeries_Select" xml:space="preserve">
+    <value>Sélectionnez un </value>
+  </data>
+  <data name="Select_MyAnimeList" xml:space="preserve">
+    <value>MyAnimeList</value>
+  </data>
+  <data name="Select_StartingEpisode" xml:space="preserve">
+    <value>À partir de Episode #</value>
+  </data>
+  <data name="Select_EpisodeType" xml:space="preserve">
+    <value>Type d'épisode :</value>
+  </data>
+  <data name="Select_TraktTV" xml:space="preserve">
+    <value>Trakt TV</value>
+  </data>
+  <data name="Select_TvDBDetails" xml:space="preserve">
+    <value>Sélectionnez les détails TvDB</value>
+  </data>
+  <data name="Select_Season" xml:space="preserve">
+    <value>Saison</value>
+  </data>
+  <data name="Select_DefaultLanguage" xml:space="preserve">
+    <value>Sélectionnez la langue par défaut</value>
+  </data>
+  <data name="Update_Update" xml:space="preserve">
+    <value>JMM Desktop mise à jour disponible !</value>
+  </data>
+  <data name="Update_UpdatePage" xml:space="preserve">
+    <value>Page mise à jour</value>
+  </data>
+  <data name="Update_Changelog" xml:space="preserve">
+    <value>Changelog</value>
+  </data>
+  <data name="Update_AvailableVersion" xml:space="preserve">
+    <value>Disponible en Version</value>
+  </data>
+  <data name="Update_YourVersion" xml:space="preserve">
+    <value>Votre Version</value>
+  </data>
+  <data name="ViewComments_FromTrakt" xml:space="preserve">
+    <value>De Trakt</value>
+  </data>
+  <data name="ViewComments_Username" xml:space="preserve">
+    <value>Nom d'utilisateur</value>
+  </data>
+  <data name="ViewComments_CommentDate" xml:space="preserve">
+    <value>Date d'observation</value>
+  </data>
+  <data name="ViewComments_Comments" xml:space="preserve">
+    <value>Commentaires</value>
+  </data>
+  <data name="ViewComments_Website" xml:space="preserve">
+    <value>Avis sur site Internet</value>
+  </data>
+  <data name="JMMDesktop" xml:space="preserve">
+    <value>Bureau JMM</value>
+  </data>
+  <data name="MoreInformation" xml:space="preserve">
+    <value>Plus d'informations</value>
+  </data>
+  <data name="Metro_Continue" xml:space="preserve">
+    <value>Continuer à regarder</value>
+  </data>
+  <data name="Metro_New" xml:space="preserve">
+    <value>Nouveaux épisodes</value>
+  </data>
+  <data name="Metro_Random" xml:space="preserve">
+    <value>Série aléatoire</value>
+  </data>
+  <data name="Metro_Trakt" xml:space="preserve">
+    <value>Trakt activité</value>
+  </data>
+  <data name="MarkedFavorite" xml:space="preserve">
+    <value>Ce groupe est marqué comme favori</value>
+  </data>
+  <data name="Community_TraktValid" xml:space="preserve">
+    <value>Vérifier que mes liens sont toujours valides sur Trakt</value>
+  </data>
+  <data name="Community_TraktRemoveBad" xml:space="preserve">
+    <value>Supprimer automatiquement la mauvaise information de la base de données (fortement recommandé)</value>
+  </data>
+  <data name="Community_CommunityCheck" xml:space="preserve">
+    <value>Vérifier si mes liens ne diffèrent par les recommandations de la communauté</value>
+  </data>
+  <data name="Community_ProblemStop" xml:space="preserve">
+    <value>Arrêter après avoir constaté des problèmes autant</value>
+  </data>
+  <data name="Trakt" xml:space="preserve">
+    <value>Trakt</value>
+  </data>
+  <data name="Start" xml:space="preserve">
+    <value>Début</value>
+  </data>
+  <data name="Stop" xml:space="preserve">
+    <value>Arrêter</value>
+  </data>
+  <data name="Community_Filter" xml:space="preserve">
+    <value>Filtre :</value>
+  </data>
+  <data name="Community_Refresh" xml:space="preserve">
+    <value>Actualiser les données pour cette série</value>
+  </data>
+  <data name="Community_SeriesName" xml:space="preserve">
+    <value>Nom de série</value>
+  </data>
+  <data name="Community_Status" xml:space="preserve">
+    <value>Statut</value>
+  </data>
+  <data name="Community_ValidTraktLink" xml:space="preserve">
+    <value>Lien Trakt valide</value>
+  </data>
+  <data name="Community_HasTraktLink" xml:space="preserve">
+    <value>A lien Trakt</value>
+  </data>
+  <data name="Community_CommunityLink" xml:space="preserve">
+    <value>Lien communautaire</value>
+  </data>
+  <data name="Community_Match" xml:space="preserve">
+    <value>Liens Match ?</value>
+  </data>
+  <data name="Download_Bookmark" xml:space="preserve">
+    <value>Mettre en signet cet anime à télécharger plus tard</value>
+  </data>
+  <data name="Download_SeriesSearch" xml:space="preserve">
+    <value>Recherche de téléchargements pour cette série</value>
+  </data>
+  <data name="Download_Approval" xml:space="preserve">
+    <value>Approbation</value>
+  </data>
+  <data name="Download_YourVote" xml:space="preserve">
+    <value>Votre Vote</value>
+  </data>
+  <data name="Download_RecommendPrompt" xml:space="preserve">
+    <value>Cet utilitaire vous affiche une liste des anime recommandée qui ne sont pas dans votre collection basée sur vos propres cotes et la rétroaction des utilisateurs AniDB</value>
+  </data>
+  <data name="Torrent" xml:space="preserve">
+    <value>Torrent</value>
+  </data>
+  <data name="Torrents" xml:space="preserve">
+    <value>Torrents</value>
+  </data>
+  <data name="Download_Name" xml:space="preserve">
+    <value>Nom</value>
+  </data>
+  <data name="Download_Size" xml:space="preserve">
+    <value>Taille</value>
+  </data>
+  <data name="Download_Seeders" xml:space="preserve">
+    <value>Semoirs</value>
+  </data>
+  <data name="Download_Leechers" xml:space="preserve">
+    <value>Leechers</value>
+  </data>
+  <data name="Download_ExtraInfo" xml:space="preserve">
+    <value>Infos supplémentaires</value>
+  </data>
+  <data name="Download_WrongSeries" xml:space="preserve">
+    <value>Mauvaise série ?</value>
+  </data>
+  <data name="Tooltip_WrongSeries" xml:space="preserve">
+    <value>Il s'agit de JMMs tenter de deviner quelles séries vous regardez pour que vous puissiez comparer à votre collection locale. Si vous n'avez pas la série dans votre collection, il sera incorrecte.</value>
+  </data>
+  <data name="Download_ResetCookie" xml:space="preserve">
+    <value>Réinitialiser le Cookie</value>
+  </data>
+  <data name="Download_AnimeBytesOnly" xml:space="preserve">
+    <value>AnimeBytes uniquement pour les séries</value>
+  </data>
+  <data name="Download_BakaBTOnly" xml:space="preserve">
+    <value>BakaBT uniquement pour les séries</value>
+  </data>
+  <data name="Available" xml:space="preserve">
+    <value>Disponible</value>
+  </data>
+  <data name="Selected" xml:space="preserve">
+    <value>Sélectionné</value>
+  </data>
+  <data name="Download_Source" xml:space="preserve">
+    <value>Source</value>
+  </data>
+  <data name="Download_Server" xml:space="preserve">
+    <value>Serveur</value>
+  </data>
+  <data name="Download_RefreshInterval" xml:space="preserve">
+    <value>Intervalle (secondes) d'actualisation</value>
+  </data>
+  <data name="Download_AutoRefresh" xml:space="preserve">
+    <value>Auto Refresh</value>
+  </data>
+  <data name="Download_UseBlackHole" xml:space="preserve">
+    <value>Utilisez le trou noir Torrent</value>
+  </data>
+  <data name="Download_FolderLocation" xml:space="preserve">
+    <value>Emplacement du dossier</value>
+  </data>
+  <data name="Download_Hash" xml:space="preserve">
+    <value>Hachage</value>
+  </data>
+  <data name="Download_Queue" xml:space="preserve">
+    <value>#</value>
+  </data>
+  <data name="Download_Done" xml:space="preserve">
+    <value>Fait</value>
+  </data>
+  <data name="Download_Peers" xml:space="preserve">
+    <value>Pairs</value>
+  </data>
+  <data name="Download_DownSpeed" xml:space="preserve">
+    <value>Vitesse</value>
+  </data>
+  <data name="Download_UpSpeed" xml:space="preserve">
+    <value>Vitesse de téléchargement</value>
+  </data>
+  <data name="Download_Ratio" xml:space="preserve">
+    <value>Ratio</value>
+  </data>
+  <data name="Download_InvalidCred" xml:space="preserve">
+    <value>Vous n'avez pas spécifié les informations d'identification valides uTorrent</value>
+  </data>
+  <data name="Download_EnterCred" xml:space="preserve">
+    <value>Veuillez entrer vos informations d'identification sous l'onglet paramètre, puis retourner</value>
+  </data>
+  <data name="Download_Priority" xml:space="preserve">
+    <value>Priorité</value>
+  </data>
+  <data name="Download_Downloaded" xml:space="preserve">
+    <value>Téléchargé</value>
+  </data>
+  <data name="Settings_DeleteAction" xml:space="preserve">
+    <value>Supprimer Action</value>
+  </data>
+  <data name="Settings_AutoUpdateInfo" xml:space="preserve">
+    <value>Mise à jour automatique des fichiers avec des informations manquantes</value>
+  </data>
+  <data name="Settings_HideDownloadButton" xml:space="preserve">
+    <value>Cacher le bouton Download épisode lorsque vous avez déjà des fichiers</value>
+  </data>
+  <data name="Settings_RecreateGroups" xml:space="preserve">
+    <value>Recréer tous les groupes</value>
+  </data>
+  <data name="Settings_ScanOnStart" xml:space="preserve">
+    <value>Scan des dossiers de Drop sur Démarrer</value>
+  </data>
+  <data name="Settings_ImagePath" xml:space="preserve">
+    <value>Chemin de l'image</value>
+  </data>
+  <data name="Settings_SelectFolder" xml:space="preserve">
+    <value>Sélectionnez le dossier</value>
+  </data>
+  <data name="Settings_FilePort" xml:space="preserve">
+    <value>Port de fichier</value>
+  </data>
+  <data name="WebCache_TraktLinks" xml:space="preserve">
+    <value>Trakt liens</value>
+  </data>
+  <data name="VideoPlayer_MPC" xml:space="preserve">
+    <value>Media Player Classic</value>
+  </data>
+  <data name="VideoPlayer_MPCNote" xml:space="preserve">
+    <value>Pour l'intégration de MPC que vous devez activer les deux options (1) magasin paramètres au fichier .ini et (2) conserver historique de récemment regardé les fichiers. Voir la capture d'écran ci-dessous pour plus de détails. L'emplacement du MPC est généralement quelque chose comme C:\Program Files (x 86) \Combined Community Codec Pack\MPC</value>
+  </data>
+  <data name="VideoPlayer_MPCOptions" xml:space="preserve">
+    <value>Options de MPC</value>
+  </data>
+  <data name="VideoPlayer_VLC" xml:space="preserve">
+    <value>VLC</value>
+  </data>
+  <data name="VideoPlayer_VLCNote" xml:space="preserve">
+    <value>VLC 2.2 + enregistre les fichiers récents et les horodatages par défaut (et la désactivation est une option « Avancé »). Des versions plus anciennes ne supportent pas la fonctionnalité de 'Reprise de la dernière position'. L'emplacement du fichier .ini VLC est généralement quelque chose comme C:\Users\username\AppData\Roaming\vlc\vlc-qt-interface.ini</value>
+  </data>
+  <data name="VideoPlayer_VLCOptions" xml:space="preserve">
+    <value>Options de VLC</value>
+  </data>
+  <data name="VideoPlayer_PotPlayer" xml:space="preserve">
+    <value>PotPlayer</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerNote" xml:space="preserve">
+    <value>Pour intégration PotPlayer vous devez activer le suivant options préférences (1) &gt; générales &gt; magasin paramètres à .ini fichier de préférences (2) &gt; lecture &gt; jouer du dernier point. Voir la capture d'écran ci-dessous pour plus de détails. L'emplacement du fichier .ini PlotPlayer est généralement quelque chose comme C:\Users\username\AppData\Roaming\PotPlayer64\PotPlayer64.ini</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerOptions" xml:space="preserve">
+    <value>PotPlayer Options</value>
+  </data>
+  <data name="VideoPlayer_MPCINI" xml:space="preserve">
+    <value>Sélectionnez dossier INI MPC</value>
+  </data>
+  <data name="VideoPlayer_VLCINI" xml:space="preserve">
+    <value>Sélectionnez dossier VLC INI</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerINI" xml:space="preserve">
+    <value>Sélectionnez dossier PotPlayer INI</value>
+  </data>
+  <data name="VideoPlayer_MPCTest" xml:space="preserve">
+    <value>Fichier de test MPC</value>
+  </data>
+  <data name="VideoPlayer_VLCTest" xml:space="preserve">
+    <value>Fichier de test VLC</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerTest" xml:space="preserve">
+    <value>PotPlayer fichier test</value>
+  </data>
+  <data name="VideoPlayer_AutoMark" xml:space="preserve">
+    <value>Marquer automatiquement les fichiers comme regardé quand le pourcentage suivant est surveillé</value>
+  </data>
+  <data name="VideoPlayer_MPCFolder" xml:space="preserve">
+    <value>Dossier d'INI MPC</value>
+  </data>
+  <data name="VideoPlayer_VLCFolder" xml:space="preserve">
+    <value>Dossier d'INI de VLC</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerFolder" xml:space="preserve">
+    <value>PotPlayer INI dossier</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote1" xml:space="preserve">
+    <value>Préférences de sélection automatiques fichier - il s'agit de quand vous avez plus de fichier pour un épisode</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote2" xml:space="preserve">
+    <value>Pour une liste de lecture, il faut choisir un seul fichier, qui s'appuiera sur vous les préférences ci-dessous.</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote3" xml:space="preserve">
+    <value>Pour un seul épisode, vous pouvez activer la sélection de fichier automatique ou avez JMM vous invite à sélectionner un fichier chaque fois que vous avez plus d'un</value>
+  </data>
+  <data name="VideoPlayer_AutoFileFirstEpisode" xml:space="preserve">
+    <value>Sélection automatique des fichiers - premier épisode de la série</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNextEpisode" xml:space="preserve">
+    <value>Sélection automatique de fichier - épisodes ultérieurs en série</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote4" xml:space="preserve">
+    <value>Si vous sélectionnez « Communiqué de groupe de précédemment joué épisode » dans le cadre ci-dessus vous devez également effectuer les opérations suivantes</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote5" xml:space="preserve">
+    <value>Décochez la case « Set file comme regardé si l'épisode est regardé » sous paramètres - essentiel - paramètres d'importation</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote6" xml:space="preserve">
+    <value>Toujours la marque un fichier comme regardé et pas un épisode</value>
+  </data>
+  <data name="VideoPlayer_AutoFileEnable" xml:space="preserve">
+    <value>Permettre la sélection de fichier automatique sur épisodes unique</value>
+  </data>
+  <data name="TvDB_WideBannerMax" xml:space="preserve">
+    <value>Bannières de larges maximum</value>
+  </data>
+  <data name="TvDB_PostersMax" xml:space="preserve">
+    <value>Affiches maximales</value>
+  </data>
+  <data name="Trakt_Enable" xml:space="preserve">
+    <value>Activez Trakt</value>
+  </data>
+  <data name="Trakt_PIN" xml:space="preserve">
+    <value>Trakt PIN</value>
+  </data>
+  <data name="Trakt_GetPIN" xml:space="preserve">
+    <value>Obtenir le code Pin</value>
+  </data>
+  <data name="Trakt_Authorize" xml:space="preserve">
+    <value>Autoriser les JMM</value>
+  </data>
+  <data name="Trakt_CurrentToken" xml:space="preserve">
+    <value>Jeton en cours est valable jusqu'au :</value>
+  </data>
+  <data name="Trakt_AutoFanart" xml:space="preserve">
+    <value>Fanart de téléchargement automatique</value>
+  </data>
+  <data name="Trakt_AutoPosters" xml:space="preserve">
+    <value>Affiches de téléchargement automatique</value>
+  </data>
+  <data name="Trakt_AutoEpisodeImages" xml:space="preserve">
+    <value>Auto téléchargement épisode Images</value>
+  </data>
+  <data name="MovieDB_MaxPosters" xml:space="preserve">
+    <value>Affiches maximales</value>
+  </data>
+  <data name="AnimeGroup_Random" xml:space="preserve">
+    <value>Épisode au hasard</value>
+  </data>
+  <data name="AnimeGroup_AllSeries" xml:space="preserve">
+    <value>Toutes les séries</value>
+  </data>
+  <data name="AnimeGroup_DoubleClick" xml:space="preserve">
+    <value>Cliquez deux fois sur une série de l'afficher directement</value>
+  </data>
+  <data name="PinnedSeries_Simple" xml:space="preserve">
+    <value>Afficher une vue simplifiée</value>
+  </data>
+  <data name="Playlist_Add" xml:space="preserve">
+    <value>Ajouter à la Playlist</value>
+  </data>
+  <data name="Series_Overview" xml:space="preserve">
+    <value>Vue d'ensemble</value>
+  </data>
+  <data name="Series_MoreInfo" xml:space="preserve">
+    <value>Plus d'informations</value>
+  </data>
+  <data name="Series_CustomTags" xml:space="preserve">
+    <value>Balises personnalisées</value>
+  </data>
+  <data name="Series_ManageCustom" xml:space="preserve">
+    <value>Gérer les balises personnalisées</value>
+  </data>
+  <data name="Series_Tag" xml:space="preserve">
+    <value>Balise</value>
+  </data>
+  <data name="Series_Add" xml:space="preserve">
+    <value>Ajouter</value>
+  </data>
+  <data name="Series_Files" xml:space="preserve">
+    <value>Fichiers</value>
+  </data>
+  <data name="Series_Folder" xml:space="preserve">
+    <value>Dossier</value>
+  </data>
+  <data name="SeriesSimple_TraktLink" xml:space="preserve">
+    <value>Aller cet épisode sur Trakt.TV</value>
+  </data>
+  <data name="SeriesSimple_Comments" xml:space="preserve">
+    <value>Commentaires</value>
+  </data>
+  <data name="SeriesSimple_Play" xml:space="preserve">
+    <value>Jouer</value>
+  </data>
+  <data name="SeriesSimple_Watched" xml:space="preserve">
+    <value>Regardé :</value>
+  </data>
+  <data name="SeriesSimple_From" xml:space="preserve">
+    <value>De:</value>
+  </data>
+  <data name="SeriesSimple_AlreadyHave" xml:space="preserve">
+    <value>Vous avez déjà cet anime dans votre collection</value>
+  </data>
+  <data name="SeriesSimple_Details" xml:space="preserve">
+    <value>Détails :</value>
+  </data>
+  <data name="SeriesSimple_Voteup" xml:space="preserve">
+    <value>Votez pour</value>
+  </data>
+  <data name="SeriesSimple_VoteDown" xml:space="preserve">
+    <value>Voter contre</value>
+  </data>
+  <data name="SeriesSimple_FromTrakt" xml:space="preserve">
+    <value>De Trakt</value>
+  </data>
+  <data name="SeriesSimple_View" xml:space="preserve">
+    <value>Vue</value>
+  </data>
+  <data name="SeriesSimple_FromAniDB" xml:space="preserve">
+    <value>De AniDB</value>
+  </data>
+  <data name="SeriesSimple_Aired" xml:space="preserve">
+    <value>Diffusé</value>
+  </data>
+  <data name="SeriesSimple_Episodes" xml:space="preserve">
+    <value>Épisodes</value>
+  </data>
+  <data name="SeriesSimple_MyVote" xml:space="preserve">
+    <value>Mon Vote</value>
+  </data>
+  <data name="SeriesSimple_PlayNext" xml:space="preserve">
+    <value>Jouer le prochain épisode</value>
+  </data>
+  <data name="SeriesSimple_PlayUnWatched" xml:space="preserve">
+    <value>Jouer tout sans surveillance)</value>
+  </data>
+  <data name="SeriesSimple_YourSay" xml:space="preserve">
+    <value>Avoir votre mot à dire...</value>
+  </data>
+  <data name="SeriesSimple_Spoiler" xml:space="preserve">
+    <value>Becquet</value>
+  </data>
+  <data name="SeriesSimple_CommentTrakt" xml:space="preserve">
+    <value>Commentaire sur Trakt</value>
+  </data>
+  <data name="SeriesSimple_Characters" xml:space="preserve">
+    <value>Caractères</value>
+  </data>
+  <data name="SeriesSimple_AlsoLike" xml:space="preserve">
+    <value>Vous aimerez aussi</value>
+  </data>
+  <data name="SeriesSimple_PeopleSaying" xml:space="preserve">
+    <value>Ce que disent les gens</value>
+  </data>
+  <data name="SeriesSimple_Loading" xml:space="preserve">
+    <value>Chargement...</value>
+  </data>
+  <data name="AvDump_Remove" xml:space="preserve">
+    <value>Retirer de la liste</value>
+  </data>
+  <data name="AvDump_Clear" xml:space="preserve">
+    <value>Effacer la liste</value>
+  </data>
+  <data name="AvDump_Dump" xml:space="preserve">
+    <value>Fichiers de vidage</value>
+  </data>
+  <data name="Bookmarks_Downloading" xml:space="preserve">
+    <value>Téléchargement</value>
+  </data>
+  <data name="Bookmarks_NotDownloading" xml:space="preserve">
+    <value>Ne pas de téléchargement</value>
+  </data>
+  <data name="Dashboard_YourVote" xml:space="preserve">
+    <value>Votre Vote</value>
+  </data>
+  <data name="Dashboard_Bookmark" xml:space="preserve">
+    <value>Mettre en signet cet anime à télécharger plus tard</value>
+  </data>
+  <data name="Dashboard_Download" xml:space="preserve">
+    <value>Recherche de téléchargements pour cette série</value>
+  </data>
+  <data name="Dashboard_NoRecommend" xml:space="preserve">
+    <value>Aucune recommandation n'a pu être trouvée.</value>
+  </data>
+  <data name="Dashboard_DownloadVotes" xml:space="preserve">
+    <value>Téléchargez vos votes, ou voter sur une adaptation en anime pour commencer à obtenir des recommandations.</value>
+  </data>
+  <data name="Dashboard_SyncVotes" xml:space="preserve">
+    <value>Sync Votes</value>
+  </data>
+  <data name="Dashboard_Added" xml:space="preserve">
+    <value>Ajouté</value>
+  </data>
+  <data name="Dashboard_Metro" xml:space="preserve">
+    <value>Tableau de bord métro</value>
+  </data>
+  <data name="Dashboard_UpdateCalendar" xml:space="preserve">
+    <value>Mise à jour des données de calendrier</value>
+  </data>
+  <data name="Dashboard_Recent" xml:space="preserve">
+    <value>Ajouts récents</value>
+  </data>
+  <data name="Metro_Options" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="Metro_General" xml:space="preserve">
+    <value>Générales</value>
+  </data>
+  <data name="Metro_ImageType" xml:space="preserve">
+    <value>Type d'image</value>
+  </data>
+  <data name="Metro_Sections" xml:space="preserve">
+    <value>Sections</value>
+  </data>
+  <data name="Metro_Items" xml:space="preserve">
+    <value>Éléments</value>
+  </data>
+  <data name="Metro_Refresh" xml:space="preserve">
+    <value>Actualisation</value>
+  </data>
+  <data name="PlayVideo" xml:space="preserve">
+    <value>Lire la vidéo</value>
+  </data>
+  <data name="Episode_MoreInfo" xml:space="preserve">
+    <value>Plus d'infos...</value>
+  </data>
+  <data name="Episode_LessInfo" xml:space="preserve">
+    <value>Moins d'Info...</value>
+  </data>
+  <data name="Episode_Manual" xml:space="preserve">
+    <value>Lien manuel</value>
+  </data>
+  <data name="Episode_ForceAniDBUpdate" xml:space="preserve">
+    <value>Information mise à jour force de AniDB</value>
+  </data>
+  <data name="Episode_RecalculateHash" xml:space="preserve">
+    <value>Recalculer le hachage</value>
+  </data>
+  <data name="Episode_Hash" xml:space="preserve">
+    <value>Hachage</value>
+  </data>
+  <data name="Episode_CRC32" xml:space="preserve">
+    <value>CRC32</value>
+  </data>
+  <data name="Episode_SHA1" xml:space="preserve">
+    <value>SHA1</value>
+  </data>
+  <data name="Episode_MD5" xml:space="preserve">
+    <value>MD5</value>
+  </data>
+  <data name="Episode_DownloadSearch" xml:space="preserve">
+    <value>Rechercher téléchargements pour cet épisode</value>
+  </data>
+  <data name="Episode_PlaylistAdd" xml:space="preserve">
+    <value>Ajouter à la Playlist</value>
+  </data>
+  <data name="Episode_TvDBOverride" xml:space="preserve">
+    <value>Remplacer le lien TvDB pour cet épisode</value>
+  </data>
+  <data name="Episode_TvDBRemove" xml:space="preserve">
+    <value>Supprimer le lien TvDB pour cet épisode</value>
+  </data>
+  <data name="Episode_AniDBForceUpdate" xml:space="preserve">
+    <value>Information mise à jour force de AniDB</value>
+  </data>
+  <data name="Episode_Type" xml:space="preserve">
+    <value>Type de</value>
+  </data>
+  <data name="Episode_Availability" xml:space="preserve">
+    <value>Disponibilité</value>
+  </data>
+  <data name="Episode_WatchedState" xml:space="preserve">
+    <value>État surveillé</value>
+  </data>
+  <data name="Rename_Script" xml:space="preserve">
+    <value>Script</value>
+  </data>
+  <data name="Rename_New" xml:space="preserve">
+    <value>Nouveau</value>
+  </data>
+  <data name="Rename_Save" xml:space="preserve">
+    <value>Enregistrer</value>
+  </data>
+  <data name="Rename_Delete" xml:space="preserve">
+    <value>Supprimer</value>
+  </data>
+  <data name="Rename_Tag" xml:space="preserve">
+    <value>Balise</value>
+  </data>
+  <data name="Rename_Add" xml:space="preserve">
+    <value>Ajouter</value>
+  </data>
+  <data name="Rename_Test" xml:space="preserve">
+    <value>Test</value>
+  </data>
+  <data name="Rename_ScriptingHelp" xml:space="preserve">
+    <value>Aider avec les scripts</value>
+  </data>
+  <data name="Rename_ImportRun" xml:space="preserve">
+    <value>Exécutez ce script lorsque vous importez des fichiers dans la collection</value>
+  </data>
+  <data name="Rename_Filter" xml:space="preserve">
+    <value>Filtre :</value>
+  </data>
+  <data name="Rename_Clear" xml:space="preserve">
+    <value>Claire</value>
+  </data>
+  <data name="Rename_AddFiles" xml:space="preserve">
+    <value>Ajouter des fichiers</value>
+  </data>
+  <data name="Rename_Rename" xml:space="preserve">
+    <value>Renommer maintenant</value>
+  </data>
+  <data name="Rename_Preview" xml:space="preserve">
+    <value>Aperçu</value>
+  </data>
+  <data name="FileSearch_Rescan" xml:space="preserve">
+    <value>Rescan</value>
+  </data>
+  <data name="FileSearch_AniDBForceUpdate" xml:space="preserve">
+    <value>Information mise à jour force de AniDB</value>
+  </data>
+  <data name="GroupFilter_RandomSeries" xml:space="preserve">
+    <value>Série aléatoire</value>
+  </data>
+  <data name="GroupFilter_RandomEpisode" xml:space="preserve">
+    <value>Épisode au hasard</value>
+  </data>
+  <data name="IgnoredAnime_Delete" xml:space="preserve">
+    <value>Supprimer cette rubrique</value>
+  </data>
+  <data name="IgnoredAnime_Note" xml:space="preserve">
+    <value>Cet utilitaire va vous montrer tout l'anime que vous avez choisi d'ignorer les recommandations. Supprimer ces enregistrements signifie qu'ils peuvent réafficher dans les recommandations.</value>
+  </data>
+  <data name="ImportFolder_Watched" xml:space="preserve">
+    <value>Ce dossier est observé pour les nouveaux fichiers</value>
+  </data>
+  <data name="MissingEpisodes_SelectColumns" xml:space="preserve">
+    <value>Sélectionnez les colonnes à utiliser pour l'importation</value>
+  </data>
+  <data name="MissingEpisodes_AiringState" xml:space="preserve">
+    <value>État de diffusion :</value>
+  </data>
+  <data name="RefreshWait" xml:space="preserve">
+    <value>En appuyant sur le bouton actualiser peut durer plusieurs minutes, donc s'il vous plaît soyez patient</value>
+  </data>
+  <data name="MissingEpisodes_Note" xml:space="preserve">
+    <value>Cet utilitaire va vous montrer un aperçu de tous vos épisodes manquants.</value>
+  </data>
+  <data name="MissingMyList_Missing" xml:space="preserve">
+    <value>Afficher le fichier manquant</value>
+  </data>
+  <data name="MissingMyList_RemoveAll" xml:space="preserve">
+    <value>Supprimer toutes les entrées de AniDB</value>
+  </data>
+  <data name="MissingMyList_Note" xml:space="preserve">
+    <value>Cet utilitaire va télécharger votre liste de fichiers à partir AniDB et comparez-le aux fichiers localement. Vous aurez alors la possibilité de supprimer ces fichiers de AniDB si elles n'existent pas.</value>
+  </data>
+  <data name="Episode" xml:space="preserve">
+    <value>Épisode</value>
+  </data>
+  <data name="Playlist_Random" xml:space="preserve">
+    <value>Épisode au hasard</value>
+  </data>
+  <data name="Playlist_Default" xml:space="preserve">
+    <value>Ordre de lecture par défaut</value>
+  </data>
+  <data name="Playlist_Items" xml:space="preserve">
+    <value>Éléments de playlist</value>
+  </data>
+  <data name="PlayNext_Hidden" xml:space="preserve">
+    <value>Caché pour éviter les spoilers</value>
+  </data>
+  <data name="Rankings_Overall" xml:space="preserve">
+    <value>Selon la cote globale de l'utilisateur</value>
+  </data>
+  <data name="Rankings_GroupedByYear" xml:space="preserve">
+    <value>Groupés par année</value>
+  </data>
+  <data name="Rankings_CollectionState" xml:space="preserve">
+    <value>État de collection</value>
+  </data>
+  <data name="Rankings_Voted" xml:space="preserve">
+    <value>Voté</value>
+  </data>
+  <data name="Rankings_Completed" xml:space="preserve">
+    <value>Terminé</value>
+  </data>
+  <data name="Rankings_Anime" xml:space="preserve">
+    <value> Anime</value>
+  </data>
+  <data name="Rankings_AniDB" xml:space="preserve">
+    <value>AniDB Rating</value>
+  </data>
+  <data name="Rankings_User" xml:space="preserve">
+    <value>Votre cote</value>
+  </data>
+  <data name="Rankings_Year" xml:space="preserve">
+    <value>Année</value>
+  </data>
+  <data name="Rankings_View" xml:space="preserve">
+    <value>Série vue</value>
+  </data>
+  <data name="Rankings_MyVote" xml:space="preserve">
+    <value>Mon Vote</value>
+  </data>
+  <data name="Related_Bookmark" xml:space="preserve">
+    <value>Mettre en signet cet anime à télécharger plus tard</value>
+  </data>
+  <data name="Related_Search" xml:space="preserve">
+    <value>Recherche de téléchargements pour cette série</value>
+  </data>
+  <data name="SeriesWithoutFiles_Delete" xml:space="preserve">
+    <value>Supprimer cette série dans la base de données</value>
+  </data>
+  <data name="SeriesWithoutFiles_Note" xml:space="preserve">
+    <value>Cet utilitaire va vous montrer toutes les séries qui n'ont pas tous les fichiers. Suppression de la série supprimera également le groupe si aucune autre série de ce groupe n'ont des fichiers.</value>
+  </data>
+  <data name="TraktShouts_View" xml:space="preserve">
+    <value>Vue</value>
+  </data>
+  <data name="TraktShouts_FromAniDB" xml:space="preserve">
+    <value>De AniDB</value>
+  </data>
+  <data name="TraktShouts_Spoiler" xml:space="preserve">
+    <value>Becquet</value>
+  </data>
+  <data name="TraktShouts_Loading" xml:space="preserve">
+    <value>Chargement...</value>
+  </data>
+  <data name="TraktShouts_Comments" xml:space="preserve">
+    <value>Commentaires</value>
+  </data>
+  <data name="CommunityLinks_Start" xml:space="preserve">
+    <value>Départ :</value>
+  </data>
+  <data name="CommunityLinks_Edit" xml:space="preserve">
+    <value>Modifier les détails</value>
+  </data>
+  <data name="CommunityLinks_AniDBStart" xml:space="preserve">
+    <value>AniDB Start :</value>
+  </data>
+  <data name="CommunityLinks_TvDB" xml:space="preserve">
+    <value>TvDB : </value>
+  </data>
+  <data name="CommunityLinks_Trakt" xml:space="preserve">
+    <value>Trakt : </value>
+  </data>
+  <data name="CommunityLinks_TMDb" xml:space="preserve">
+    <value>Le film DB</value>
+  </data>
+  <data name="CommunityLinks_MAL" xml:space="preserve">
+    <value>MyAnimeList</value>
+  </data>
+  <data name="CommunityLinks_AutoLink" xml:space="preserve">
+    <value>Auto Link</value>
+  </data>
+  <data name="Tooltip_DeleteTitle" xml:space="preserve">
+    <value>Supprimer</value>
+  </data>
+  <data name="Tooltip_DeleteInfo" xml:space="preserve">
+    <value>Supprimez ce lien</value>
+  </data>
+  <data name="Tooltip_EditTitle" xml:space="preserve">
+    <value>Edit</value>
+  </data>
+  <data name="Tooltip_EditInfo" xml:space="preserve">
+    <value>Modifier les détails de ce lien</value>
+  </data>
+  <data name="Tooltip_UpdateTitle" xml:space="preserve">
+    <value>Mise à jour</value>
+  </data>
+  <data name="Tooltip_UpdateTvDB" xml:space="preserve">
+    <value>Télécharger des données actualisées de la TvDB et de mettre à jour la base de données locale</value>
+  </data>
+  <data name="Tooltip_ReportLinkTitle" xml:space="preserve">
+    <value>Erreur de liaison de rapport</value>
+  </data>
+  <data name="Tooltip_ReportLinkInfo" xml:space="preserve">
+    <value>Si c'est lié à la mauvaise série Cliquez ici pour informer les développeurs</value>
+  </data>
+  <data name="Tooltip_UpdateTrakt" xml:space="preserve">
+    <value>Télécharger les nouvelles données de Trakt et mettre à jour la base de données locale</value>
+  </data>
+  <data name="Tooltip_Sync" xml:space="preserve">
+    <value>Sync</value>
+  </data>
+  <data name="Tooltip_SyncTrakt" xml:space="preserve">
+    <value>Synchronisez vos données de collecte et de l'histoire avec Trakt</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTitle" xml:space="preserve">
+    <value>Auto qui relie les personnes à mobilité réduite</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTvDB" xml:space="preserve">
+    <value>Auto liaison de cet anime une série de TvDB est actuellement désactivé</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTitle" xml:space="preserve">
+    <value>Liaison automatique activé</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTvDB" xml:space="preserve">
+    <value>Auto liaison de cet anime une série de TvDB est actuellement activé. Si JMM Server trouve une correspondance étroite ou une recommandation communautaire qu'il va automatiquement créer un lien</value>
+  </data>
+  <data name="CommunityLinks_TraktTV" xml:space="preserve">
+    <value>Trakt TV</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTrakt" xml:space="preserve">
+    <value>Auto liaison de cet anime une série Trakt est actuellement désactivé</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTrakt" xml:space="preserve">
+    <value>Auto liaison de cet anime une série Trakt est actuellement activé. Si JMM Server trouve une correspondance étroite ou une recommandation communautaire qu'il va automatiquement créer un lien</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledMAL" xml:space="preserve">
+    <value>Auto liaison de cet anime une série de MAL est actuellement désactivé</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledMAL" xml:space="preserve">
+    <value>Auto liaison de cet anime une série de MAL est actuellement activé. Si JMM Server trouve une correspondance étroite ou une recommandation communautaire qu'il va automatiquement créer un lien</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTMDb" xml:space="preserve">
+    <value>Auto liaison de cet anime une série de MovieDB est actuellement désactivé</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTMDb" xml:space="preserve">
+    <value>Auto liaison de cet anime une série de MovieDB est actuellement activé. Si JMM Server trouve une correspondance étroite ou une recommandation communautaire qu'il va automatiquement créer un lien</value>
+  </data>
+  <data name="Tooltip_CommunityAdminTitle" xml:space="preserve">
+    <value>Admin de la communauté</value>
+  </data>
+  <data name="Tooltip_CommunityAdminInfo" xml:space="preserve">
+    <value>Allez dans l'onglet admin de communauté et d'éditer les liens recommandés pour cet anime</value>
+  </data>
+  <data name="Unrecognized_Rescan" xml:space="preserve">
+    <value>Rescan</value>
+  </data>
+  <data name="Unrecognized_ForceAniDB" xml:space="preserve">
+    <value>Information mise à jour force de AniDB</value>
+  </data>
+  <data name="Unrecognized_Hash" xml:space="preserve">
+    <value>Hachage</value>
+  </data>
+  <data name="Unrecognized_CRC32" xml:space="preserve">
+    <value>CRC32</value>
+  </data>
+  <data name="Unrecognized_Rehash" xml:space="preserve">
+    <value>Re-hachage tous</value>
+  </data>
+  <data name="Unrecognized_Logs" xml:space="preserve">
+    <value>Journaux</value>
+  </data>
+  <data name="Unrecognized_NA" xml:space="preserve">
+    <value>NA</value>
+  </data>
+  <data name="Unrecognized_RefreshSeries" xml:space="preserve">
+    <value>Actualiser la liste des séries</value>
+  </data>
+  <data name="Unrecognized_To" xml:space="preserve">
+    <value>À</value>
+  </data>
+  <data name="UpdateAniDB_UpdateLocal" xml:space="preserve">
+    <value>Mise à jour de données de fichier AniDB Local</value>
+  </data>
+  <data name="UpdateAniDB_Info1" xml:space="preserve">
+    <value>Les données relatives aux fichiers sont téléchargées depuis AniDB et puis stockées dans votre base de données locale lorsque vous tout d'abord importez un fichier. Dans certains cas ces données ne peuvent être terminées lorsque vous commencez par le télécharger. Ou des données supplémentaires peuvent être téléchargées mais plus récentes versions de JMM. Cet utilitaire vous permettra d'obtenir une nouvelle copie de cette information de AniDB</value>
+  </data>
+  <data name="UpdateAniDB_MissingInfo" xml:space="preserve">
+    <value>Mise à jour des fichiers avec des informations manquantes</value>
+  </data>
+  <data name="UpdateAniDB_Info2" xml:space="preserve">
+    <value>Données manquantes relève habituellement d'un codec et la résolution des informations manquantes. Vous pouvez voir résolution: 0 x 0 à côté de ces fichiers</value>
+  </data>
+  <data name="UpdateAniDB_Version" xml:space="preserve">
+    <value>Mise à jour des fichiers internes Version 2</value>
+  </data>
+  <data name="UpdateAniDB_Info3" xml:space="preserve">
+    <value>Internal Version 2 a ajouté les informations suivantes - version du fichier (v2, v3 etc.), est censuré, est déconseillée</value>
+  </data>
+  <data name="UpdateAniDB_Info4" xml:space="preserve">
+    <value>Envoyer les commandes trop AniDB, peut entraîner une interdiction temporaire. Utiliser à vos risques et périls</value>
+  </data>
+  <data name="UpdateAniDB_HowManyQueued" xml:space="preserve">
+    <value>Combien de commandes seront mises en attente ?</value>
+  </data>
+  <data name="UpdateAniDB_Queued" xml:space="preserve">
+    <value>Commandes de la file d'attente</value>
+  </data>
+  <data name="User_HideTags" xml:space="preserve">
+    <value>Masquer les Tags</value>
+  </data>
+  <data name="User_ChangePassword" xml:space="preserve">
+    <value>Changer mot de passe</value>
+  </data>
+  <data name="Sort_Error" xml:space="preserve">
+    <value>Erreur en essayant de trier la liste des </value>
+  </data>
+  <data name="Sort_Using" xml:space="preserve">
+    <value> à l'aide </value>
+  </data>
+  <data name="Sort_Property" xml:space="preserve">
+    <value>propriété </value>
+  </data>
+  <data name="Sort_Field" xml:space="preserve">
+    <value>domaine </value>
+  </data>
+  <data name="Sort_Exception" xml:space="preserve">
+    <value>Exception dans MultiSort lors du tri d'une liste de </value>
+  </data>
+  <data name="Sort_PassedEmpty" xml:space="preserve">
+    <value>MultiSort paramètre rgSortBy a été adopté un nom de champ vide en rgSortBy [</value>
+  </data>
+  <data name="Selected_DoesNotExist" xml:space="preserve">
+    <value>Le fichier spécifié ou le dossier n'existe pas : </value>
+  </data>
+  <data name="ValueCompare_PropertyName" xml:space="preserve">
+    <value>Nom de la propriété </value>
+  </data>
+  <data name="ValueCompare_NotFound" xml:space="preserve">
+    <value> pas trouvé en essayant de comparer des objets de type </value>
+  </data>
+  <data name="ValueCompare_FieldName" xml:space="preserve">
+    <value>Nom de domaine </value>
+  </data>
+  <data name="Video_VLCError1" xml:space="preserve">
+    <value>Impossible d'analyser des URI dans le fichier ini VLC</value>
+  </data>
+  <data name="Video_VLCError2" xml:space="preserve">
+    <value>Le nombre de fichiers récents et les horodatages dans le fichier ini VLC diffèrent</value>
+  </data>
+  <data name="Video_Complete" xml:space="preserve">
+    <value>Toutes les</value>
+  </data>
+  <data name="Video_Position" xml:space="preserve">
+    <value>Vidéo position pour</value>
+  </data>
+  <data name="Video_HasChanged" xml:space="preserve">
+    <value>a changé</value>
+  </data>
+  <data name="Video_Updating" xml:space="preserve">
+    <value>Mise à jour à suivre par le lecteur multimédia : </value>
+  </data>
+  <data name="AniDB_DataMissing" xml:space="preserve">
+    <value>Données manquantes</value>
+  </data>
+  <data name="AniDB_Votes" xml:space="preserve">
+    <value>Votes</value>
+  </data>
+  <data name="AniDB_GotVids" xml:space="preserve">
+    <value>Me suis vids pour anime de service :</value>
+  </data>
+  <data name="AniDB_In" xml:space="preserve">
+    <value>dans</value>
+  </data>
+  <data name="AniDB_ForFans" xml:space="preserve">
+    <value>Pour les Fans</value>
+  </data>
+  <data name="AniDB_Recommended" xml:space="preserve">
+    <value>Recommandé</value>
+  </data>
+  <data name="AniDB_MustSee" xml:space="preserve">
+    <value>Must See</value>
+  </data>
+  <data name="AniDB_Collecting" xml:space="preserve">
+    <value>Collecte :</value>
+  </data>
+  <data name="AniDB_Files" xml:space="preserve">
+    <value>Fichiers :</value>
+  </data>
+  <data name="AnimeEpisode_Previous" xml:space="preserve">
+    <value>Episode précédent</value>
+  </data>
+  <data name="AnimeEpisode_Next" xml:space="preserve">
+    <value>Prochain épisode</value>
+  </data>
+  <data name="AnimeEpisode_NoOverview" xml:space="preserve">
+    <value>Épisode aperçu non disponible</value>
+  </data>
+  <data name="Anime_Groups" xml:space="preserve">
+    <value>Groupes</value>
+  </data>
+  <data name="Anime_Series" xml:space="preserve">
+    <value>Série</value>
+  </data>
+  <data name="Anime_GroupName" xml:space="preserve">
+    <value>Nom du groupe doit être renseigné</value>
+  </data>
+  <data name="Anime_SortName" xml:space="preserve">
+    <value>Nom tri doivent être renseigné</value>
+  </data>
+  <data name="Anime_GotVids" xml:space="preserve">
+    <value>Me suis vids pour anime de service :</value>
+  </data>
+  <data name="Anime_GotEpisodes" xml:space="preserve">
+    <value>A obtenu des données de l'épisode du service :</value>
+  </data>
+  <data name="Anime_In" xml:space="preserve">
+    <value>dans</value>
+  </data>
+  <data name="Anime_Contracts" xml:space="preserve">
+    <value>A obtenu des contrats de l'épisode :</value>
+  </data>
+  <data name="Anime_Sorted" xml:space="preserve">
+    <value>Trier les contrats de l'épisode :</value>
+  </data>
+  <data name="AVDump_ToBe" xml:space="preserve">
+    <value>À traiter</value>
+  </data>
+  <data name="Group_Groups" xml:space="preserve">
+    <value>Groupes</value>
+  </data>
+  <data name="Group_FilterName" xml:space="preserve">
+    <value>Nom du filtre doit être renseigné</value>
+  </data>
+  <data name="Ignore_RecDown" xml:space="preserve">
+    <value>Recommandations - Télécharger</value>
+  </data>
+  <data name="Ignore_RecWatch" xml:space="preserve">
+    <value>Recommandations - Watch</value>
+  </data>
+  <data name="Ignore_AnimeID" xml:space="preserve">
+    <value>ID de l'anime :</value>
+  </data>
+  <data name="JMMServer_TraktAuth" xml:space="preserve">
+    <value>Trakt Auth</value>
+  </data>
+  <data name="JMMServer_Success" xml:space="preserve">
+    <value>Succès</value>
+  </data>
+  <data name="JMMServer_Error" xml:space="preserve">
+    <value>Erreur</value>
+  </data>
+  <data name="Missing_Episode" xml:space="preserve">
+    <value>Épisode</value>
+  </data>
+  <data name="Missing_File" xml:space="preserve">
+    <value>Fichier</value>
+  </data>
+  <data name="Playlist_Name" xml:space="preserve">
+    <value>Entrez le nom de la playlist : </value>
+  </data>
+  <data name="Playlist_NameBlank" xml:space="preserve">
+    <value>Veuillez entrer un nom de la playlist</value>
+  </data>
+  <data name="Recommendation_Missing" xml:space="preserve">
+    <value>Données manquantes</value>
+  </data>
+  <data name="Recommendation_NoOverview" xml:space="preserve">
+    <value>Aperçu non disponible</value>
+  </data>
+  <data name="uTorrent_NotConnected" xml:space="preserve">
+    <value>Pas connecté</value>
+  </data>
+  <data name="uTorrent_Connecting" xml:space="preserve">
+    <value>Connexion...</value>
+  </data>
+  <data name="Constants_Continue" xml:space="preserve">
+    <value>Continuer à regarder (SYSTEM)</value>
+  </data>
+  <data name="Constants_MainCharacter" xml:space="preserve">
+    <value>personnage principal</value>
+  </data>
+  <data name="Group_GroupCount" xml:space="preserve">
+    <value> Groupes</value>
+  </data>
+  <data name="Tab_Playlists" xml:space="preserve">
+    <value>Listes de lecture</value>
+  </data>
+  <data name="Playlist_NewPlaylist" xml:space="preserve">
+    <value>Nouvelle liste de lecture</value>
+  </data>
+  <data name="Tab_Bookmarks" xml:space="preserve">
+    <value>Marque-pages</value>
+  </data>
+  <data name="JMMServer_ImportFolders" xml:space="preserve">
+    <value>Importer les dossiers</value>
+  </data>
+  <data name="JMMServer_ServerStatus" xml:space="preserve">
+    <value>État du serveur</value>
+  </data>
+  <data name="Tooltip_ClearHash" xml:space="preserve">
+    <value>Effacer toutes les commandes en file d'attente de hachage</value>
+  </data>
+  <data name="JMMServer_Running" xml:space="preserve">
+    <value>En cours d'exécution</value>
+  </data>
+  <data name="JMMServer_Paused" xml:space="preserve">
+    <value>En pause</value>
+  </data>
+  <data name="Tooltip_ClearGeneral" xml:space="preserve">
+    <value>Effacer toutes les commandes générales en file d'attente</value>
+  </data>
+  <data name="Tooltip_ClearImages" xml:space="preserve">
+    <value>Effacer toutes les commandes de téléchargement en file d'attente de serveur image</value>
+  </data>
+  <data name="JMMServer_ServerImage" xml:space="preserve">
+    <value>File d'attente de serveur Images</value>
+  </data>
+  <data name="Tab_AniDBAVDump" xml:space="preserve">
+    <value>AniDB AV benne</value>
+  </data>
+  <data name="Tab_FileSearch" xml:space="preserve">
+    <value>Recherche de fichiers</value>
+  </data>
+  <data name="Tab_FileRename" xml:space="preserve">
+    <value>Renommage de fichiers</value>
+  </data>
+  <data name="Tab_UpdateAniDB" xml:space="preserve">
+    <value>Mise à jour de données AniDB</value>
+  </data>
+  <data name="Tab_CommunityData" xml:space="preserve">
+    <value>Données sur les communautés</value>
+  </data>
+  <data name="Tab_MyVotes" xml:space="preserve">
+    <value>Mes Votes</value>
+  </data>
+  <data name="VideoPlayer_MPCI" xml:space="preserve">
+    <value>Media Player Classic intégration</value>
+  </data>
+  <data name="VideoPlayer_AutoFile" xml:space="preserve">
+    <value>Sélection automatique des fichiers</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_MAL" xml:space="preserve">
+    <value>Ma liste d'Anime</value>
+  </data>
+  <data name="Tab_Downloads" xml:space="preserve">
+    <value>Téléchargements</value>
+  </data>
+  <data name="Downloads_uTorrentInfo" xml:space="preserve">
+    <value>Cet exemple utilise l'uTorrent WebUI API, vous devez activer d'abord dans votre client uTorrent</value>
+  </data>
+  <data name="Downloads_uTorrentWebUI" xml:space="preserve">
+    <value>uTorrent WebUI détails</value>
+  </data>
+  <data name="Downloads_TorrentBlackHole" xml:space="preserve">
+    <value>Paramètres du trou noir torrent</value>
+  </data>
+  <data name="Downloads_TorrentDefault" xml:space="preserve">
+    <value>Sources de Torrent par défaut pour la recherche</value>
+  </data>
+  <data name="Downloads_BakaBT" xml:space="preserve">
+    <value>Paramètres de BakaBT</value>
+  </data>
+  <data name="Downloads_AnimeBytes" xml:space="preserve">
+    <value>Paramètres de AnimeBytes</value>
+  </data>
+  <data name="Downloads_BakaBTInfo" xml:space="preserve">
+    <value>BakaBT est un site de torrent anime qui se spécialise dans les téléchargements de toute la série, mais il nécessite un compte tout d'abord</value>
+  </data>
+  <data name="Downloads_AnimeBytesInfo" xml:space="preserve">
+    <value>AnimeBytes est un site de torrent anime qui se spécialise dans les téléchargements de toute la série, mais il nécessite un compte tout d'abord</value>
+  </data>
+  <data name="Downloads_GoTo" xml:space="preserve">
+    <value>Accédez au site Web</value>
+  </data>
+  <data name="Tab_Search" xml:space="preserve">
+    <value>Recherche</value>
+  </data>
+  <data name="Tab_Community" xml:space="preserve">
+    <value>Communauté</value>
+  </data>
+  <data name="Main_Messages" xml:space="preserve">
+    <value>Messages</value>
+  </data>
+  <data name="Main_Paused" xml:space="preserve">
+    <value>Suspendu en raison de l'interdiction de AniDB (</value>
+  </data>
+  <data name="Main_User" xml:space="preserve">
+    <value>Utilisateur</value>
+  </data>
+  <data name="Main_Feed" xml:space="preserve">
+    <value>Se nourrir</value>
+  </data>
+  <data name="Main_About" xml:space="preserve">
+    <value>Sur</value>
+  </data>
+  <data name="Tab_uTorrent" xml:space="preserve">
+    <value>uTorrent</value>
+  </data>
+  <data name="Tab_BrowseTorrents" xml:space="preserve">
+    <value>Parcourir Torrents</value>
+  </data>
+  <data name="Tab_SearchTorrents" xml:space="preserve">
+    <value>Recherche de Torrents</value>
+  </data>
+  <data name="Tab_Recommendations" xml:space="preserve">
+    <value>Recommandations</value>
+  </data>
+  <data name="Tab_Settings" xml:space="preserve">
+    <value>Paramètres</value>
+  </data>
+  <data name="Tab_SeriesInfo" xml:space="preserve">
+    <value>Infos de la série</value>
+  </data>
+  <data name="Tab_Comments" xml:space="preserve">
+    <value>Commentaires des utilisateurs</value>
+  </data>
+  <data name="Tab_Files" xml:space="preserve">
+    <value>Fichiers</value>
+  </data>
+  <data name="Download_TorrentFolder" xml:space="preserve">
+    <value>Emplacement du dossier torrent</value>
+  </data>
+  <data name="Search_TitleOnly" xml:space="preserve">
+    <value>Titre uniquement</value>
+  </data>
+</root>

--- a/JMMClient/Properties/Resources.it.resx
+++ b/JMMClient/Properties/Resources.it.resx
@@ -1,0 +1,3179 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AirDate" xml:space="preserve">
+    <value>Data dell'aria</value>
+  </data>
+  <data name="AniDBRating" xml:space="preserve">
+    <value>AniDB Voto</value>
+  </data>
+  <data name="AniDBVoteCount" xml:space="preserve">
+    <value>Conteggio dei voti AniDB</value>
+  </data>
+  <data name="Episodes" xml:space="preserve">
+    <value>Episodi</value>
+  </data>
+  <data name="EpisodeType" xml:space="preserve">
+    <value>Tipo di episodio</value>
+  </data>
+  <data name="EpisodeType_Credits" xml:space="preserve">
+    <value>Crediti</value>
+  </data>
+  <data name="EpisodeType_Normal" xml:space="preserve">
+    <value>Episodi</value>
+  </data>
+  <data name="EpisodeType_Other" xml:space="preserve">
+    <value>Altri</value>
+  </data>
+  <data name="EpisodeType_Parody" xml:space="preserve">
+    <value>Parodia</value>
+  </data>
+  <data name="EpisodeType_Specials" xml:space="preserve">
+    <value>Offerte speciali</value>
+  </data>
+  <data name="EpisodeType_Trailer" xml:space="preserve">
+    <value>Rimorchi</value>
+  </data>
+  <data name="Favorite" xml:space="preserve">
+    <value>Preferito</value>
+  </data>
+  <data name="GroupFilter_All" xml:space="preserve">
+    <value>Tutti i</value>
+  </data>
+  <data name="GroupFilter_Favorites" xml:space="preserve">
+    <value>Favoriti</value>
+  </data>
+  <data name="IsWatched" xml:space="preserve">
+    <value>È guardato</value>
+  </data>
+  <data name="MyRating" xml:space="preserve">
+    <value>MyRating</value>
+  </data>
+  <data name="Refresh" xml:space="preserve">
+    <value>Aggiornamento</value>
+  </data>
+  <data name="RunTime" xml:space="preserve">
+    <value>Tempo di esecuzione</value>
+  </data>
+  <data name="SortName" xml:space="preserve">
+    <value>Nome dell'ordinamento</value>
+  </data>
+  <data name="Series" xml:space="preserve">
+    <value>Serie</value>
+  </data>
+  <data name="TAB_Config" xml:space="preserve">
+    <value>Config</value>
+  </data>
+  <data name="TAB_Episodes" xml:space="preserve">
+    <value>Episodi</value>
+  </data>
+  <data name="TAB_FileManager" xml:space="preserve">
+    <value>File Manager</value>
+  </data>
+  <data name="TAB_Images" xml:space="preserve">
+    <value>Immagini</value>
+  </data>
+  <data name="TAB_Relations" xml:space="preserve">
+    <value>Relazioni</value>
+  </data>
+  <data name="TAB_SeriesEpisodes" xml:space="preserve">
+    <value>Collezione</value>
+  </data>
+  <data name="TAB_Server" xml:space="preserve">
+    <value>Server</value>
+  </data>
+  <data name="TAB_TvDB" xml:space="preserve">
+    <value>TvDB</value>
+  </data>
+  <data name="ViewLabel" xml:space="preserve">
+    <value>Vista: </value>
+  </data>
+  <data name="Back" xml:space="preserve">
+    <value>Indietro</value>
+  </data>
+  <data name="Language" xml:space="preserve">
+    <value>Lingua</value>
+  </data>
+  <data name="Delete" xml:space="preserve">
+    <value>Elimina</value>
+  </data>
+  <data name="RunImport" xml:space="preserve">
+    <value>Eseguire Import</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Salva</value>
+  </data>
+  <data name="AnimeTitles" xml:space="preserve">
+    <value>Titoli</value>
+  </data>
+  <data name="AnimeTitlesMain" xml:space="preserve">
+    <value>Titolo principale</value>
+  </data>
+  <data name="AnimeTitlesOfficial" xml:space="preserve">
+    <value>Ufficiale</value>
+  </data>
+  <data name="AnimeTitlesShort" xml:space="preserve">
+    <value>Breve</value>
+  </data>
+  <data name="AnimeTitlesSynonym" xml:space="preserve">
+    <value>Sinonimo</value>
+  </data>
+  <data name="Categories" xml:space="preserve">
+    <value>Categorie</value>
+  </data>
+  <data name="Tags" xml:space="preserve">
+    <value>Tag (potrebbe contenere spoiler)</value>
+  </data>
+  <data name="CategoryWeighting" xml:space="preserve">
+    <value>Ponderazione</value>
+  </data>
+  <data name="TagApproval" xml:space="preserve">
+    <value>Approvazione</value>
+  </data>
+  <data name="Episodes_AvAll" xml:space="preserve">
+    <value>Tutti gli episodi</value>
+  </data>
+  <data name="Episodes_AvMissing" xml:space="preserve">
+    <value>Nessun file Aavailable</value>
+  </data>
+  <data name="Episodes_AvOnly" xml:space="preserve">
+    <value>Solo i file disponibili</value>
+  </data>
+  <data name="Episodes_Watched_All" xml:space="preserve">
+    <value>Tutti i</value>
+  </data>
+  <data name="Episodes_Watched_Unwatched" xml:space="preserve">
+    <value>Non custodito</value>
+  </data>
+  <data name="Episodes_Watched_Watched" xml:space="preserve">
+    <value>Ho guardato</value>
+  </data>
+  <data name="Play" xml:space="preserve">
+    <value>Gioca</value>
+  </data>
+  <data name="Tooltip_FileFound" xml:space="preserve">
+    <value>Questo file è disponibile</value>
+  </data>
+  <data name="Tooltip_FileNotFound" xml:space="preserve">
+    <value>Questo file non esiste</value>
+  </data>
+  <data name="Tooltip_FutureDated" xml:space="preserve">
+    <value>Questo episodio non ha mandato in onda ancora</value>
+  </data>
+  <data name="Tooltip_Unwatched" xml:space="preserve">
+    <value>Incustodito - fare clic per contrassegnare come visto</value>
+  </data>
+  <data name="Tooltip_Watched" xml:space="preserve">
+    <value>Ho guardato - fare clic per contrassegnare come non custodito</value>
+  </data>
+  <data name="Tooltip_ZeroFiles" xml:space="preserve">
+    <value>Non sono presenti file disponibili per questo episodio</value>
+  </data>
+  <data name="Unwatched" xml:space="preserve">
+    <value>Non custodito</value>
+  </data>
+  <data name="Watched" xml:space="preserve">
+    <value>Ho guardato</value>
+  </data>
+  <data name="Rating" xml:space="preserve">
+    <value>Voto</value>
+  </data>
+  <data name="Votes" xml:space="preserve">
+    <value>Voti</value>
+  </data>
+  <data name="AnimeType_Movie" xml:space="preserve">
+    <value>Film</value>
+  </data>
+  <data name="AnimeType_Other" xml:space="preserve">
+    <value>Altri</value>
+  </data>
+  <data name="AnimeType_OVA" xml:space="preserve">
+    <value>OVA</value>
+  </data>
+  <data name="AnimeType_TVSeries" xml:space="preserve">
+    <value>Serie TV</value>
+  </data>
+  <data name="AnimeType_TVSpecial" xml:space="preserve">
+    <value>Speciale TV</value>
+  </data>
+  <data name="AnimeType_Web" xml:space="preserve">
+    <value>Web</value>
+  </data>
+  <data name="Ongoing" xml:space="preserve">
+    <value>In corso</value>
+  </data>
+  <data name="To" xml:space="preserve">
+    <value>A</value>
+  </data>
+  <data name="LastWatched" xml:space="preserve">
+    <value>Visto l'ultima</value>
+  </data>
+  <data name="Today" xml:space="preserve">
+    <value>Oggi</value>
+  </data>
+  <data name="Yesterday" xml:space="preserve">
+    <value>Ieri</value>
+  </data>
+  <data name="GroupsAvailableFrom" xml:space="preserve">
+    <value>Disponibile da:</value>
+  </data>
+  <data name="Missing" xml:space="preserve">
+    <value>Manca</value>
+  </data>
+  <data name="Tooltip_MissingEps" xml:space="preserve">
+    <value>Episodi mancanti da tutti i gruppi di rilascio</value>
+  </data>
+  <data name="Tooltip_MissingEpsGroups" xml:space="preserve">
+    <value>Episodi mancanti da gruppi di rilascio che sto raccogliendo</value>
+  </data>
+  <data name="Tooltip_QueueImages" xml:space="preserve">
+    <value>Scarica immagini in coda in attesa di</value>
+  </data>
+  <data name="Specials" xml:space="preserve">
+    <value>Offerte speciali</value>
+  </data>
+  <data name="GroupFilter_Missing" xml:space="preserve">
+    <value>Episodi mancanti</value>
+  </data>
+  <data name="RemoveMissingFiles" xml:space="preserve">
+    <value>Rimuovere i file mancanti</value>
+  </data>
+  <data name="ServerActions" xml:space="preserve">
+    <value>Azioni del server</value>
+  </data>
+  <data name="NewGroup" xml:space="preserve">
+    <value>Nuovo gruppo</value>
+  </data>
+  <data name="AllFilters" xml:space="preserve">
+    <value>Tutti i filtri</value>
+  </data>
+  <data name="Filter" xml:space="preserve">
+    <value>Filtro</value>
+  </data>
+  <data name="Group" xml:space="preserve">
+    <value>Gruppo</value>
+  </data>
+  <data name="AddSubGroup" xml:space="preserve">
+    <value>Nuovo gruppo di Sub</value>
+  </data>
+  <data name="Edit" xml:space="preserve">
+    <value>Modifica</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Annulla</value>
+  </data>
+  <data name="SubGroup" xml:space="preserve">
+    <value>Gruppo di sub</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Impostazioni</value>
+  </data>
+  <data name="NewSeries" xml:space="preserve">
+    <value>Nuova serie</value>
+  </data>
+  <data name="MoveSeries" xml:space="preserve">
+    <value>Spostare le serie</value>
+  </data>
+  <data name="MoveToGroup" xml:space="preserve">
+    <value>Spostare il gruppo selezionato</value>
+  </data>
+  <data name="OK" xml:space="preserve">
+    <value>Ok</value>
+  </data>
+  <data name="QueueGeneral" xml:space="preserve">
+    <value>Coda di AniDB</value>
+  </data>
+  <data name="QueueHasher" xml:space="preserve">
+    <value>Hasher coda</value>
+  </data>
+  <data name="Tooltip_QueueGeneral" xml:space="preserve">
+    <value>AniDB comandi in coda</value>
+  </data>
+  <data name="Tooltip_QueueHasher" xml:space="preserve">
+    <value>File in attesa di essere eseguito l'hashing</value>
+  </data>
+  <data name="Pause" xml:space="preserve">
+    <value>Pausa</value>
+  </data>
+  <data name="Resume" xml:space="preserve">
+    <value>Curriculum</value>
+  </data>
+  <data name="Video_Bluray" xml:space="preserve">
+    <value>BluRay</value>
+  </data>
+  <data name="Video_DVD" xml:space="preserve">
+    <value>DVD</value>
+  </data>
+  <data name="Video_FullHD" xml:space="preserve">
+    <value>Full HD</value>
+  </data>
+  <data name="Video_HD" xml:space="preserve">
+    <value>HD</value>
+  </data>
+  <data name="NewFolder" xml:space="preserve">
+    <value>Nuova cartella</value>
+  </data>
+  <data name="DropDestination" xml:space="preserve">
+    <value>Destinazione di goccia</value>
+  </data>
+  <data name="DropSource" xml:space="preserve">
+    <value>Origine di trascinamento</value>
+  </data>
+  <data name="ImportFolderName" xml:space="preserve">
+    <value>Nome della cartella di importazione</value>
+  </data>
+  <data name="ImportFolderPath" xml:space="preserve">
+    <value>Percorso di cartella di importazione</value>
+  </data>
+  <data name="LocalMapping" xml:space="preserve">
+    <value>Mapping locale</value>
+  </data>
+  <data name="LocalPath" xml:space="preserve">
+    <value>Percorso locale</value>
+  </data>
+  <data name="ServerDetails" xml:space="preserve">
+    <value>Dettagli server</value>
+  </data>
+  <data name="MSG_ERR_DropSourceDestCheck" xml:space="preserve">
+    <value>Una cartella di importazione non può essere sia l'origine di trascinamento e la destinazione di goccia</value>
+  </data>
+  <data name="MSG_ERR_ImportFolderLocationCheck" xml:space="preserve">
+    <value>Il percorso della cartella di importazione non può essere vuoto. Immettere un percorso valido sul Server di OMM</value>
+  </data>
+  <data name="TAB_UnrecognisedFiles" xml:space="preserve">
+    <value>Non riconosciuto</value>
+  </data>
+  <data name="Confirm" xml:space="preserve">
+    <value>Confermare</value>
+  </data>
+  <data name="NothingSelected" xml:space="preserve">
+    <value>Non è selezionato alcun</value>
+  </data>
+  <data name="SelectSeriesEp" xml:space="preserve">
+    <value>Selezionare una serie e l'episodio</value>
+  </data>
+  <data name="AssociateFile" xml:space="preserve">
+    <value>Collegare un file con un episodio</value>
+  </data>
+  <data name="Ignore" xml:space="preserve">
+    <value>Ignorare</value>
+  </data>
+  <data name="OpenFolder" xml:space="preserve">
+    <value>Aprire la cartella</value>
+  </data>
+  <data name="MSG_ERR_FileNotFound" xml:space="preserve">
+    <value>Il file potrebbe non essere trovato</value>
+  </data>
+  <data name="FilesSelected" xml:space="preserve">
+    <value>File selezionati</value>
+  </data>
+  <data name="StartingEpisodeNumber" xml:space="preserve">
+    <value>Episodio numero iniziale</value>
+  </data>
+  <data name="Existing" xml:space="preserve">
+    <value>Esistenti</value>
+  </data>
+  <data name="SelectGroup" xml:space="preserve">
+    <value>Selezionare un gruppo</value>
+  </data>
+  <data name="SelectAnime" xml:space="preserve">
+    <value>Selezionare Anime da AniDB</value>
+  </data>
+  <data name="New" xml:space="preserve">
+    <value>Nuovo</value>
+  </data>
+  <data name="GroupName" xml:space="preserve">
+    <value>Nome del gruppo</value>
+  </data>
+  <data name="AniDBID" xml:space="preserve">
+    <value>AniDB ID</value>
+  </data>
+  <data name="MSG_ERR_AnimeIDRequired" xml:space="preserve">
+    <value>Si prega di inserire un ID valido AniDB Anime</value>
+  </data>
+  <data name="MSG_ERR_AnimeSelectionRequired" xml:space="preserve">
+    <value>Si prega di selezionare un anime esistente</value>
+  </data>
+  <data name="MSG_ERR_GroupNameRequired" xml:space="preserve">
+    <value>Si prega di inserire un nome di gruppo</value>
+  </data>
+  <data name="MSG_ERR_GroupSelectionRequired" xml:space="preserve">
+    <value>Si prega di selezionare un gruppo esistente</value>
+  </data>
+  <data name="MSG_ERR_InvalidEpGetAnime" xml:space="preserve">
+    <value>L'intervallo di numero di episodio immesso non è valido, si desidera aggiornare i dati da AniDB?</value>
+  </data>
+  <data name="MSG_ERR_InvalidEp" xml:space="preserve">
+    <value>La gamma di episodio immesso non è valida.</value>
+  </data>
+  <data name="DeleteLink" xml:space="preserve">
+    <value>Elimina collegamento</value>
+  </data>
+  <data name="Tooltip_DeleteLink" xml:space="preserve">
+    <value>Rimuovere il collegamento tra questo file e l'episodio.</value>
+  </data>
+  <data name="TAB_IgnoredFiles" xml:space="preserve">
+    <value>Ignorato</value>
+  </data>
+  <data name="Restore" xml:space="preserve">
+    <value>Ripristino</value>
+  </data>
+  <data name="TAB_ManuallyLinked" xml:space="preserve">
+    <value>Manualmente collegato</value>
+  </data>
+  <data name="AniDBLogin" xml:space="preserve">
+    <value>AniDB Login</value>
+  </data>
+  <data name="Client" xml:space="preserve">
+    <value>Client</value>
+  </data>
+  <data name="ImportFolders" xml:space="preserve">
+    <value>Importare le cartelle</value>
+  </data>
+  <data name="JMMServer" xml:space="preserve">
+    <value>JMM Server</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Port" xml:space="preserve">
+    <value>Porta</value>
+  </data>
+  <data name="Server" xml:space="preserve">
+    <value>Server</value>
+  </data>
+  <data name="ServerPath" xml:space="preserve">
+    <value>Percorso del server</value>
+  </data>
+  <data name="TAB_SettingsAniDB" xml:space="preserve">
+    <value>AniDB</value>
+  </data>
+  <data name="TAB_SettingsDisplay" xml:space="preserve">
+    <value>Visualizzazione</value>
+  </data>
+  <data name="TAB_SettingsEssential" xml:space="preserve">
+    <value>Essenziale</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB" xml:space="preserve">
+    <value>Siti della community</value>
+  </data>
+  <data name="Test" xml:space="preserve">
+    <value>Prova</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Nome utente</value>
+  </data>
+  <data name="TestAndSave" xml:space="preserve">
+    <value>Prova e Salva</value>
+  </data>
+  <data name="Success" xml:space="preserve">
+    <value>Successo!</value>
+  </data>
+  <data name="INFO_SettingsEssential" xml:space="preserve">
+    <value>Tutte le impostazioni in questa pagina devono essere popolate. Assicurarsi di testare e salvare il Server JMM e AniDB dettagli prima di procedere. Se questa è la prima volta che esegue l'applicazione immettere importazione almeno una cartella e premere il tasto Esegui importazione.</value>
+  </data>
+  <data name="Search" xml:space="preserve">
+    <value>Ricerca</value>
+  </data>
+  <data name="Tooltip_GroupSearch" xml:space="preserve">
+    <value>Gruppi di ricerca per nome (in qualsiasi lingua), categoria o tag</value>
+  </data>
+  <data name="AniDBDownloadChar" xml:space="preserve">
+    <value>Scaricare caratteri/creatori</value>
+  </data>
+  <data name="AniDBDownloadOptions" xml:space="preserve">
+    <value>Opzioni di Download AniDB</value>
+  </data>
+  <data name="AniDBDownloadRelated" xml:space="preserve">
+    <value>Scaricare Anime correlati</value>
+  </data>
+  <data name="AniDBDownloadReleaseGroups" xml:space="preserve">
+    <value>Scaricare i gruppi di rilascio</value>
+  </data>
+  <data name="AniDBDownloadReviews" xml:space="preserve">
+    <value>Scarica recensioni</value>
+  </data>
+  <data name="AniDBDownloadSimilar" xml:space="preserve">
+    <value>Scarica Anime simili</value>
+  </data>
+  <data name="AniDBMyListAddFiles" xml:space="preserve">
+    <value>Aggiungere file</value>
+  </data>
+  <data name="AniDBMylistOptions" xml:space="preserve">
+    <value>Opzioni di AniDB MyList</value>
+  </data>
+  <data name="AniDBMyListReadUnwatched" xml:space="preserve">
+    <value>Leggi incustodito</value>
+  </data>
+  <data name="AniDBMyListReadWatched" xml:space="preserve">
+    <value>Ho guardato lettura</value>
+  </data>
+  <data name="AniDBMyListSetUnwatched" xml:space="preserve">
+    <value>Impostare non custodito</value>
+  </data>
+  <data name="AniDBMyListSetWatched" xml:space="preserve">
+    <value>Set di visto</value>
+  </data>
+  <data name="AniDBMyListState" xml:space="preserve">
+    <value>Stato di conservazione</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadChar" xml:space="preserve">
+    <value>Scaricare informazioni e immagini sui personaggi e seiyuu che appaiono nell'anime</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadRelated" xml:space="preserve">
+    <value>Quando si scaricano informazioni su un anime, anche scaricare informazioni su tutte le anime correlati. Ciò è necessario per raggruppare correttamente correlati anime durante il processo di importazione.</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadReleaseGroups" xml:space="preserve">
+    <value>Scarica informazioni dettagliate circa il rilascio/sottotitolazioni gruppi per vostri anime</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadReviews" xml:space="preserve">
+    <value>Recensioni anime scaricati dagli utenti di AniDB</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadSimilar" xml:space="preserve">
+    <value>Quando si scaricano informazioni su un anime, anche scaricare informazioni su titoli consigliati e simili</value>
+  </data>
+  <data name="Tooltip_AniDBMyListAddFiles" xml:space="preserve">
+    <value>Se selezionato durante l'importazione di file, i file verranno aggiunti al tuo account di AniDB</value>
+  </data>
+  <data name="Tooltip_AniDBMyListReadUnwatched" xml:space="preserve">
+    <value>Se il file è impostato come ONU-ho guardato su AniDB, sarà anche impostare come ONU-ho guardato il tuo locale di raccolta</value>
+  </data>
+  <data name="Tooltip_AniDBMyListReadWatched" xml:space="preserve">
+    <value>Se il file è impostato come visto su AniDB, inoltre verrà impostato come visto sulla tua collezione locale</value>
+  </data>
+  <data name="Tooltip_AniDBMyListSetUnwatched" xml:space="preserve">
+    <value>Quando si contrassegna manualmente un video come visto, verrà aggiornato anche AniDB</value>
+  </data>
+  <data name="Tooltip_AniDBMyListSetWatched" xml:space="preserve">
+    <value>Quando finire di guardare un video o contrassegnare manualmente un video, come visto, verrà aggiornato anche AniDB</value>
+  </data>
+  <data name="Tooltip_AniDBMyListState" xml:space="preserve">
+    <value>I file di stato del deposito verranno impostati quando aggiunto alla tua lista</value>
+  </data>
+  <data name="SyncMyList" xml:space="preserve">
+    <value>Sincronizzazione AniDB MyList</value>
+  </data>
+  <data name="Rehash" xml:space="preserve">
+    <value>Rimaneggiamento</value>
+  </data>
+  <data name="MSG_INFO_AddedQueueCmds" xml:space="preserve">
+    <value>Comandi sono stati aggiunti alla coda</value>
+  </data>
+  <data name="MultiTypeRange" xml:space="preserve">
+    <value>Gamma di episodio</value>
+  </data>
+  <data name="MultiTypeSingle" xml:space="preserve">
+    <value>Episodio singolo</value>
+  </data>
+  <data name="AniDBScheduleCalendar" xml:space="preserve">
+    <value>Aggiornare automaticamente il calendario</value>
+  </data>
+  <data name="AniDBScheduleHTTP" xml:space="preserve">
+    <value>Aggiornare automaticamente le informazioni sulla trasmissione e Anime</value>
+  </data>
+  <data name="AniDBScheduleMyList" xml:space="preserve">
+    <value>Automaticamente informazioni di sincronizzazione MyList</value>
+  </data>
+  <data name="AniDBScheduleOptions" xml:space="preserve">
+    <value>Aggiornamenti pianificati</value>
+  </data>
+  <data name="Tooltip_AniDBScheduleCalendar" xml:space="preserve">
+    <value>Scarica informazioni su prossime anime.</value>
+  </data>
+  <data name="Tooltip_AniDBScheduleHTTP" xml:space="preserve">
+    <value>Aggiornare informazioni su anime e ottenere nuove informazioni sulla trasmissione. Verranno scaricati solo i dati modificati dopo l'ultimo aggiornamento.</value>
+  </data>
+  <data name="Tooltip_AniDBScheduleMyList" xml:space="preserve">
+    <value>Informazioni di sincronizzazione da AniDB secondo le opzioni specificate nella sezione MyList.</value>
+  </data>
+  <data name="TAB_SettingsWebCache" xml:space="preserve">
+    <value>Web Cache</value>
+  </data>
+  <data name="DetailedInformationLink" xml:space="preserve">
+    <value>Segui questo link per un'approfondita spiegazione</value>
+  </data>
+  <data name="Get" xml:space="preserve">
+    <value>Ottieni</value>
+  </data>
+  <data name="INFO_SettingsWebCache" xml:space="preserve">
+    <value>La cache web è un database online creato dagli sviluppatori di JMM e MyAnime. Il suo scopo è quello di colmare le lacune che altri database non soddisfare e anche rendere il processo di importazione più veloce attraverso la condivisione di informazioni con altri utenti di JMM.</value>
+  </data>
+  <data name="Send" xml:space="preserve">
+    <value>Invia</value>
+  </data>
+  <data name="Tooltip_WebCache_Anonymous" xml:space="preserve">
+    <value>Selezionando questa opzione il tuo nome utente AniDB non verrà inviato alla cache web. Tuttavia questo significa che non sarà possibile ottenere il beneficio di ricordare le proprie selezioni personali.</value>
+  </data>
+  <data name="Tooltip_WebCache_FileEpisodes" xml:space="preserve">
+    <value>Quando i file non vengono visualizzati in AniDB, la cache web può avere informazioni circa l'episodio relativo a tale file. Questo è particolarmente utile quando si manualmente collegare file e non voglio perdere tali informazioni.</value>
+  </data>
+  <data name="Tooltip_WebCache_FileHashes" xml:space="preserve">
+    <value>Provare a ottenere il file hash dalla cache del web prima di hashing localmente. Questo può risparmiare un sacco di tempo durante l'importazione.</value>
+  </data>
+  <data name="Tooltip_WebCache_TvDBAssociations" xml:space="preserve">
+    <value>Utilizzare la cache web per cercare la pagina di collegamenti tra AniDB e TvDB. Se non selezionata sarà necessario cercare manualmente tutti i collegamenti di TvDB.</value>
+  </data>
+  <data name="TvDB_FanartAutoDownload" xml:space="preserve">
+    <value>Auto Download Fanart</value>
+  </data>
+  <data name="TvDB_FanartCount" xml:space="preserve">
+    <value>Massimo Fanarts</value>
+  </data>
+  <data name="TvDB_PosterAutoDownload" xml:space="preserve">
+    <value>Auto Download poster</value>
+  </data>
+  <data name="TvDB_WideBannerAutoDownload" xml:space="preserve">
+    <value>Auto Download banner vasta</value>
+  </data>
+  <data name="WebCache_Anonymous" xml:space="preserve">
+    <value>Rimanere anonimi</value>
+  </data>
+  <data name="WebCache_FileEpisodes" xml:space="preserve">
+    <value>File per episodio Links</value>
+  </data>
+  <data name="WebCache_FileHashes" xml:space="preserve">
+    <value>Hash dei file</value>
+  </data>
+  <data name="WebCache_TvDBAssociations" xml:space="preserve">
+    <value>TvDB Links</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_MovieDB" xml:space="preserve">
+    <value>Il film DB</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_TvDB" xml:space="preserve">
+    <value>Il TvDB</value>
+  </data>
+  <data name="Tooltip_TvDB_FanartAutoDownload" xml:space="preserve">
+    <value>Scaricare automaticamente nuove fanart ogni volta che viene eseguita un'importazione.</value>
+  </data>
+  <data name="Tooltip_TvDB_FanartCount" xml:space="preserve">
+    <value>La quantità massima di fanart immagini da scaricare</value>
+  </data>
+  <data name="Tooltip_TvDB_PosterAutoDownload" xml:space="preserve">
+    <value>Scaricare automaticamente i nuovi poster ogni volta che viene eseguita un'importazione.</value>
+  </data>
+  <data name="Tooltip_TvDB_WideBannerAutoDownload" xml:space="preserve">
+    <value>Scaricare automaticamente i nuovi banner vasta ogni volta che viene eseguita un'importazione.</value>
+  </data>
+  <data name="ImportSettings_HashCRC32" xml:space="preserve">
+    <value>Calcolare il CRC32</value>
+  </data>
+  <data name="ImportSettings_HashMD5" xml:space="preserve">
+    <value>Calcolare il MD5</value>
+  </data>
+  <data name="ImportSettings_ImportOnStart" xml:space="preserve">
+    <value>Importare su start</value>
+  </data>
+  <data name="ImportSettings_SHA1" xml:space="preserve">
+    <value>Calcolare SHA1</value>
+  </data>
+  <data name="ImportSettings_VideoExtensions" xml:space="preserve">
+    <value>Estensioni dei video</value>
+  </data>
+  <data name="ImportSettings_WatchFiles" xml:space="preserve">
+    <value>Guarda per i nuovi file</value>
+  </data>
+  <data name="MovieDB_FanartAutoDownload" xml:space="preserve">
+    <value>Auto Download Fanart</value>
+  </data>
+  <data name="MovieDB_FanartCount" xml:space="preserve">
+    <value>Massimo Fanarts</value>
+  </data>
+  <data name="MovieDB_PosterAutoDownload" xml:space="preserve">
+    <value>Auto Download poster</value>
+  </data>
+  <data name="TAB_Settings_ImportSettings" xml:space="preserve">
+    <value>Impostazioni di importazione</value>
+  </data>
+  <data name="Tooltip_MovieDB_FanartAutoDownload" xml:space="preserve">
+    <value>Scaricare automaticamente nuove fanart ogni volta che viene eseguita un'importazione.</value>
+  </data>
+  <data name="Tooltip_MovieDB_FanartCount" xml:space="preserve">
+    <value>La quantità massima di fanart immagini da scaricare</value>
+  </data>
+  <data name="Tooltip_MovieDB_PosterAutoDownload" xml:space="preserve">
+    <value>Scaricare automaticamente i nuovi poster ogni volta che viene eseguita un'importazione.</value>
+  </data>
+  <data name="Down" xml:space="preserve">
+    <value>Verso il basso</value>
+  </data>
+  <data name="LanguageUseSynonyms" xml:space="preserve">
+    <value>Anche utilizzare sinonimi</value>
+  </data>
+  <data name="TAB_Settings_Language" xml:space="preserve">
+    <value>Preferenze di lingua</value>
+  </data>
+  <data name="Tooltip_LanguageUseSynonyms" xml:space="preserve">
+    <value>Inoltre è possibile utilizzare sinonimi da selezionato lingua preferita per la visualizzazione delle serie e dei gruppi. Inglese e Romaji sinonimi non verranno utilizzati</value>
+  </data>
+  <data name="Up" xml:space="preserve">
+    <value>Fino</value>
+  </data>
+  <data name="GroupFilterConditions" xml:space="preserve">
+    <value>Condizioni di filtro</value>
+  </data>
+  <data name="GroupFilterConditionType" xml:space="preserve">
+    <value>Tipo di condizione</value>
+  </data>
+  <data name="GroupFilterConditionType_AirDate" xml:space="preserve">
+    <value>AirDate</value>
+  </data>
+  <data name="GroupFilterConditionType_AllEpisodesWatched" xml:space="preserve">
+    <value>Ho guardati tutti gli episodi</value>
+  </data>
+  <data name="GroupFilterConditionType_AnimeGroup" xml:space="preserve">
+    <value>Gruppo</value>
+  </data>
+  <data name="GroupFilterConditionType_AnimeType" xml:space="preserve">
+    <value>Tipo di anime</value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedTvDBInfo" xml:space="preserve">
+    <value>Ha collegamento TvDB</value>
+  </data>
+  <data name="GroupFilterConditionType_Category" xml:space="preserve">
+    <value>Categoria</value>
+  </data>
+  <data name="GroupFilterConditionType_CompletedSeries" xml:space="preserve">
+    <value>Serie completa</value>
+  </data>
+  <data name="GroupFilterConditionType_Favourite" xml:space="preserve">
+    <value>Preferito</value>
+  </data>
+  <data name="GroupFilterConditionType_HasUnwatchedEpisodes" xml:space="preserve">
+    <value>Ha incustodito episodi</value>
+  </data>
+  <data name="GroupFilterConditionType_MissingEpisodes" xml:space="preserve">
+    <value>Episodi mancanti</value>
+  </data>
+  <data name="GroupFilterConditionType_ReleaseGroup" xml:space="preserve">
+    <value>Gruppo di rilascio</value>
+  </data>
+  <data name="GroupFilterConditionType_Studio" xml:space="preserve">
+    <value>Studio</value>
+  </data>
+  <data name="GroupFilterConditionType_Tag" xml:space="preserve">
+    <value>Prodotto Tag</value>
+  </data>
+  <data name="GroupFilterConditionType_UserVoted" xml:space="preserve">
+    <value>Utente ha votato (Perm)</value>
+  </data>
+  <data name="GroupFilterConditionType_VideoQuality" xml:space="preserve">
+    <value>Qualità video</value>
+  </data>
+  <data name="GroupFilterOperator" xml:space="preserve">
+    <value>Operatore</value>
+  </data>
+  <data name="GroupFilterOperator_Equals" xml:space="preserve">
+    <value>È uguale a</value>
+  </data>
+  <data name="GroupFilterOperator_Exclude" xml:space="preserve">
+    <value>Escludi</value>
+  </data>
+  <data name="GroupFilterOperator_GreaterThan" xml:space="preserve">
+    <value>Maggiore di o uguale a</value>
+  </data>
+  <data name="GroupFilterOperator_Include" xml:space="preserve">
+    <value>Includono</value>
+  </data>
+  <data name="GroupFilterOperator_LessThan" xml:space="preserve">
+    <value>Minore o uguale a</value>
+  </data>
+  <data name="GroupFilterOperator_NotEquals" xml:space="preserve">
+    <value>Non è uguale a</value>
+  </data>
+  <data name="GroupFilterSorting" xml:space="preserve">
+    <value>L'ordinamento</value>
+  </data>
+  <data name="ImageSize_GroupList" xml:space="preserve">
+    <value>Gruppo e lista per serie</value>
+  </data>
+  <data name="ImageSize_SeriesPoster" xml:space="preserve">
+    <value>Serie di Poster</value>
+  </data>
+  <data name="ImageSize_SubGroupList" xml:space="preserve">
+    <value>Sub gruppi elenco e serie</value>
+  </data>
+  <data name="INFO_SettingsDisplayStyle" xml:space="preserve">
+    <value>Sarà necessario aggiornare la tua lista di gruppo per vedere gli effetti delle modifiche</value>
+  </data>
+  <data name="MSG_ERR_SelectDate" xml:space="preserve">
+    <value>Prima di selezionare una data</value>
+  </data>
+  <data name="NewGroupFilter" xml:space="preserve">
+    <value>Nuovo filtro gruppo</value>
+  </data>
+  <data name="RenameGroups" xml:space="preserve">
+    <value>Rinominare tutti i gruppi</value>
+  </data>
+  <data name="Style_GroupList" xml:space="preserve">
+    <value>Elenco dei gruppi</value>
+  </data>
+  <data name="Style_GroupList_MediumDetail" xml:space="preserve">
+    <value>Dettaglio medio</value>
+  </data>
+  <data name="Style_GroupList_Simple" xml:space="preserve">
+    <value>Semplice</value>
+  </data>
+  <data name="TAB_SettingsImageSizes" xml:space="preserve">
+    <value>Dimensioni delle immagini</value>
+  </data>
+  <data name="TAB_SettingsStyle" xml:space="preserve">
+    <value>Stili</value>
+  </data>
+  <data name="Tooltip_ImageSize_GroupList" xml:space="preserve">
+    <value>Le immagini mostrate nella lista principale quando si visualizzano i gruppi e la serie</value>
+  </data>
+  <data name="Tooltip_ImageSize_SeriesPoster" xml:space="preserve">
+    <value>Le immagini mostrate nel riquadro destro per tutte le serie appartenenti a un gruppo</value>
+  </data>
+  <data name="Tooltip_ImageSize_SubGroupList" xml:space="preserve">
+    <value>Le immagini mostrate nella lista principale durante la visualizzazione di sottogruppi o serie</value>
+  </data>
+  <data name="Tooltip_Style_GroupList" xml:space="preserve">
+    <value>Lo stile dei gruppi quando visualizzata nella lista principale (anche gruppi di sub)</value>
+  </data>
+  <data name="FilterValue" xml:space="preserve">
+    <value>Valore di filtro</value>
+  </data>
+  <data name="MSG_ERR_EnterValue" xml:space="preserve">
+    <value>Si prega di inserire un valore</value>
+  </data>
+  <data name="PreviewFilter" xml:space="preserve">
+    <value>Anteprima dei risultati del filtro</value>
+  </data>
+  <data name="GroupFilter_ApplyToSeries" xml:space="preserve">
+    <value>Applicare il filtro a livello di serie anziché a livello di gruppo</value>
+  </data>
+  <data name="GroupFilter_BaseCondition" xml:space="preserve">
+    <value>Condizione di base</value>
+  </data>
+  <data name="GroupFilter_BaseCondition_ExcludeAll" xml:space="preserve">
+    <value>Escludere tutti</value>
+  </data>
+  <data name="GroupFilter_BaseCondition_IncludeAll" xml:space="preserve">
+    <value>Includere tutti i</value>
+  </data>
+  <data name="Tooltip_GroupFilter_BaseCondition" xml:space="preserve">
+    <value>Includere tutti i modo che tutti i gruppi sono inclusi per impostazione predefinita. Escludere tutti i modo che i gruppi non sono inclusi, questo è destinato a essere utilizzato quando si desidera specificare manualmente gruppi su base indvidual.</value>
+  </data>
+  <data name="GroupFilterOperator_In" xml:space="preserve">
+    <value>In</value>
+  </data>
+  <data name="GroupFilterOperator_NotIn" xml:space="preserve">
+    <value>Non In</value>
+  </data>
+  <data name="GroupFilter_Category_Help" xml:space="preserve">
+    <value>Fare doppio clic su catgeories per aggiungerli all'elenco selezionato</value>
+  </data>
+  <data name="GroupFilterConditionType_AniDBRating" xml:space="preserve">
+    <value>Voto - AniDB</value>
+  </data>
+  <data name="GroupFilterConditionType_UserRating" xml:space="preserve">
+    <value>Voto - utente</value>
+  </data>
+  <data name="MSG_ERR_RatingValue" xml:space="preserve">
+    <value>Voto deve essere un valore compreso tra 0 e 10. Punti decimali sono ammessi.</value>
+  </data>
+  <data name="ScanFolder" xml:space="preserve">
+    <value>Scansione ora questa cartella</value>
+  </data>
+  <data name="GroupFilterConditionType_EpisodeAddedDate" xml:space="preserve">
+    <value>Data di aggiunta di episodio</value>
+  </data>
+  <data name="GroupFilterConditionType_EpisodeWatchedDate" xml:space="preserve">
+    <value>Episodio visto data</value>
+  </data>
+  <data name="GroupFilterConditionType_SeriesDate" xml:space="preserve">
+    <value>Data di aggiunta di serie</value>
+  </data>
+  <data name="GroupFilterOperator_LastXDays" xml:space="preserve">
+    <value>Ultimo 'X' giorni</value>
+  </data>
+  <data name="SelectDate" xml:space="preserve">
+    <value>Seleziona le Date di</value>
+  </data>
+  <data name="MSG_ERR_DaysValue" xml:space="preserve">
+    <value>Si prega di inserire i numeri di giorni come valore integer (valore minimo è 1)</value>
+  </data>
+  <data name="SyncVotes" xml:space="preserve">
+    <value>Sincronizzazione AniDB voti</value>
+  </data>
+  <data name="UserVote" xml:space="preserve">
+    <value>Il mio voto</value>
+  </data>
+  <data name="VoteNow" xml:space="preserve">
+    <value>Vota ora</value>
+  </data>
+  <data name="VoteRevoke" xml:space="preserve">
+    <value>Revocare</value>
+  </data>
+  <data name="GroupFilterConditionType_FinishedAiring" xml:space="preserve">
+    <value>Finito in onda</value>
+  </data>
+  <data name="VoteTypeAnimePermanent" xml:space="preserve">
+    <value>Permanente</value>
+  </data>
+  <data name="VoteTypeAnimeTemporary" xml:space="preserve">
+    <value>Temporanea</value>
+  </data>
+  <data name="AniDBMyListLocalActions" xml:space="preserve">
+    <value>Azioni locali</value>
+  </data>
+  <data name="AniDBMyListSyncAndImport" xml:space="preserve">
+    <value>Opzioni di importazione e sincronizzazione MyList</value>
+  </data>
+  <data name="EpisodeMarkAllUnwatched" xml:space="preserve">
+    <value>Mark tutto incustodito</value>
+  </data>
+  <data name="EpisodeMarkAllWatched" xml:space="preserve">
+    <value>Mark va controllata</value>
+  </data>
+  <data name="EpisodeMarkAllWatchedPrevious" xml:space="preserve">
+    <value>Segna tutto precedente visto incluso EP #</value>
+  </data>
+  <data name="GroupFilter_VideoQuality_Help" xml:space="preserve">
+    <value>Fare doppio clic sulle voci per aggiungerli all'elenco</value>
+  </data>
+  <data name="GroupFilterConditionType_MissingEpisodesCollecting" xml:space="preserve">
+    <value>Episodi mancanti (raccolta)</value>
+  </data>
+  <data name="GroupFilterOperator_InAllEpisodes" xml:space="preserve">
+    <value>In (tutti gli episodi)</value>
+  </data>
+  <data name="GroupFilterOperator_NotInAllEpisodes" xml:space="preserve">
+    <value>Non In (tutti gli episodi)</value>
+  </data>
+  <data name="GroupFilterConditionType_AudioLanguage" xml:space="preserve">
+    <value>Lingua audio</value>
+  </data>
+  <data name="GroupFilterConditionType_SubtitleLanguage" xml:space="preserve">
+    <value>Lingua dei sottotitoli</value>
+  </data>
+  <data name="GroupFilterSortDirection_Asc" xml:space="preserve">
+    <value>ASC</value>
+  </data>
+  <data name="GroupFilterSortDirection_Desc" xml:space="preserve">
+    <value>DESC</value>
+  </data>
+  <data name="GroupFilterSorting_AniDBRating" xml:space="preserve">
+    <value>AniDB Voto</value>
+  </data>
+  <data name="GroupFilterSorting_EpisodeAddedDate" xml:space="preserve">
+    <value>Data di aggiunta di episodio</value>
+  </data>
+  <data name="GroupFilterSorting_EpisodeAirDate" xml:space="preserve">
+    <value>Episodio Air Data</value>
+  </data>
+  <data name="GroupFilterSorting_EpisodeWatchedDate" xml:space="preserve">
+    <value>Episodio visto data</value>
+  </data>
+  <data name="GroupFilterSorting_GroupName" xml:space="preserve">
+    <value>Nome del gruppo</value>
+  </data>
+  <data name="GroupFilterSorting_MissingEpisodeCount" xml:space="preserve">
+    <value>Conteggio di episodio mancante</value>
+  </data>
+  <data name="GroupFilterSorting_SeriesAddedDate" xml:space="preserve">
+    <value>Data di aggiunta di serie</value>
+  </data>
+  <data name="GroupFilterSorting_SeriesCount" xml:space="preserve">
+    <value>Numero di serie</value>
+  </data>
+  <data name="GroupFilterSorting_UnwatchedEpisodeCount" xml:space="preserve">
+    <value>Incustodito episodio totali</value>
+  </data>
+  <data name="GroupFilterSorting_UserRating" xml:space="preserve">
+    <value>Voto degli utenti</value>
+  </data>
+  <data name="GroupFilterSorting_Year" xml:space="preserve">
+    <value>Anno</value>
+  </data>
+  <data name="GroupFilterSorting_SortName" xml:space="preserve">
+    <value>Nome dell'ordinamento</value>
+  </data>
+  <data name="GroupFilterDirection" xml:space="preserve">
+    <value>Direzione</value>
+  </data>
+  <data name="GroupFilterSortType" xml:space="preserve">
+    <value>Tipo di ordinamento</value>
+  </data>
+  <data name="QuickSort" xml:space="preserve">
+    <value>Ordinamento rapido</value>
+  </data>
+  <data name="TAB_DuplicateFiles" xml:space="preserve">
+    <value>File duplicati</value>
+  </data>
+  <data name="INFO_DuplicateFiles" xml:space="preserve">
+    <value>I file duplicati sono dove avete due o più file che sono esattamente gli stessi, tranne per il fatto che sono in cartelle diverse o sono denominati in modo diverso. JMM consente solo un file con lo stesso hash nell'insieme.</value>
+  </data>
+  <data name="Tooltip_DeleteDuplicateFileAll" xml:space="preserve">
+    <value>Eliminare la voce del database e il file selezionato sul disco.</value>
+  </data>
+  <data name="Tooltip_DeleteDuplicateFileEntry" xml:space="preserve">
+    <value>Eliminare solo la voce di database. File sul disco non ne risentiranno.</value>
+  </data>
+  <data name="Files" xml:space="preserve">
+    <value>File</value>
+  </data>
+  <data name="ReevaluateDuplicateFiles" xml:space="preserve">
+    <value>Rivalutare tutte le voci</value>
+  </data>
+  <data name="Tooltip_ReevaluateDuplicateFiles" xml:space="preserve">
+    <value>Controllare tutti i file duplicati voci per vedere se i file esistono ancora. Se non eliminare la voce del database</value>
+  </data>
+  <data name="TAB_MultipleFiles" xml:space="preserve">
+    <value>Più file</value>
+  </data>
+  <data name="INFO_MultipleFiles" xml:space="preserve">
+    <value>Più file sono dove avete due o più file per l'episodio stesso. Questa utility vi permetterà di esaminare tutti questi avvenimenti e decidere quali si desidera mantenere</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Caricamento...</value>
+  </data>
+  <data name="TotalFileCount" xml:space="preserve">
+    <value>Conteggio totale dei File</value>
+  </data>
+  <data name="ImportSettings_UseEpisodeStatus" xml:space="preserve">
+    <value>Impostare il file come ho guardato se è guardato episodio</value>
+  </data>
+  <data name="Tooltip_TvDB_Schedule_Updates" xml:space="preserve">
+    <value>Aggiornare le informazioni serie ed episodio ogni 12 ore e anche scaricare qualsiasi nuova fanart, poster e banner vasta</value>
+  </data>
+  <data name="TvDB_Schedule_Updates" xml:space="preserve">
+    <value>Info aggiornamento ogni 12 ore</value>
+  </data>
+  <data name="RescanAll" xml:space="preserve">
+    <value>Rianalizzare tutti</value>
+  </data>
+  <data name="DeleteAll" xml:space="preserve">
+    <value>Eliminare tutti i</value>
+  </data>
+  <data name="CrossRefSummary" xml:space="preserve">
+    <value>TvDB e altri link di AniDB Non</value>
+  </data>
+  <data name="FileSummary" xml:space="preserve">
+    <value>Riepilogo file</value>
+  </data>
+  <data name="TheTvDB" xml:space="preserve">
+    <value>Il TvDB</value>
+  </data>
+  <data name="SeasonNumber" xml:space="preserve">
+    <value>Stagione #</value>
+  </data>
+  <data name="CommunityRecommendation" xml:space="preserve">
+    <value>Raccomandazione comunitaria</value>
+  </data>
+  <data name="TvDBSearchPrompt" xml:space="preserve">
+    <value>Cerca nella TvDB o immettere TvDB serie ID</value>
+  </data>
+  <data name="TvDBShow" xml:space="preserve">
+    <value>Vai a TvDB</value>
+  </data>
+  <data name="UseThis" xml:space="preserve">
+    <value>Utilizzare questo</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Chiudere</value>
+  </data>
+  <data name="SwitchSeason" xml:space="preserve">
+    <value>Stagione di interruttore</value>
+  </data>
+  <data name="AniDB" xml:space="preserve">
+    <value>AniDB</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>Aggiornamento</value>
+  </data>
+  <data name="UpdateAniDBInfo" xml:space="preserve">
+    <value>Aggiornamento AniDB Info</value>
+  </data>
+  <data name="UpdateInfo" xml:space="preserve">
+    <value>Aggiornamento Info</value>
+  </data>
+  <data name="ImageSize_EpisodeImage" xml:space="preserve">
+    <value>Immagine di episodio</value>
+  </data>
+  <data name="Tooltip_ImageSize_EpisodeImage" xml:space="preserve">
+    <value>Le immagini mostrano in dettaglio l'episodio</value>
+  </data>
+  <data name="EpisodeDetailStyle" xml:space="preserve">
+    <value>Episodio particolare stile</value>
+  </data>
+  <data name="EpisodeDetailStyle_Option1" xml:space="preserve">
+    <value>Immagini/Panoramica in sintesi</value>
+  </data>
+  <data name="EpisodeDetailStyle_Option2" xml:space="preserve">
+    <value>Immagini/Panoramica quando espansa solo</value>
+  </data>
+  <data name="EpisodeDetailStyle_Option3" xml:space="preserve">
+    <value>Immagini/Panoramica per disabili</value>
+  </data>
+  <data name="HideEpisodeImageWhenUnwatched" xml:space="preserve">
+    <value>Nascondi immagine episodio quando incustodito</value>
+  </data>
+  <data name="HideEpisodeOverviewWhenUnwatched" xml:space="preserve">
+    <value>Nascondere la descrizione di episodio quando incustodito</value>
+  </data>
+  <data name="Tooltip_HideEpisodeImageWhenUnwatched" xml:space="preserve">
+    <value>L'immagine di episodio sarà nascosto fino a quando l'episodio è visto</value>
+  </data>
+  <data name="Tooltip_HideEpisodeOverviewWhenUnwatched" xml:space="preserve">
+    <value>La descrizione di episodio (descrizione) sarà nascosto fino a quando l'episodio è visto</value>
+  </data>
+  <data name="Fanart" xml:space="preserve">
+    <value>Fanart</value>
+  </data>
+  <data name="Images" xml:space="preserve">
+    <value>Immagini</value>
+  </data>
+  <data name="Image_Disabled" xml:space="preserve">
+    <value>Immagine è attualmente disattivato</value>
+  </data>
+  <data name="Image_Dynamic" xml:space="preserve">
+    <value>Impostare questa immagine come l'unica immagine che verrà visualizzata</value>
+  </data>
+  <data name="Image_Enabled" xml:space="preserve">
+    <value>Immagine è attualmente abilitato</value>
+  </data>
+  <data name="Image_Static" xml:space="preserve">
+    <value>Questa immagine è l'unica immagine che verrà visualizzata</value>
+  </data>
+  <data name="Image_View" xml:space="preserve">
+    <value>Visualizza immagine</value>
+  </data>
+  <data name="Posters" xml:space="preserve">
+    <value>Poster</value>
+  </data>
+  <data name="WideBanners" xml:space="preserve">
+    <value>Larghezza banner</value>
+  </data>
+  <data name="TheMovieDB" xml:space="preserve">
+    <value>Il film DB</value>
+  </data>
+  <data name="MovieDBShow" xml:space="preserve">
+    <value>Vai a MovieDB</value>
+  </data>
+  <data name="MovieDBSearchPrompt" xml:space="preserve">
+    <value>Cerca nella MovieDB o immettere ID MovieDB</value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedTvDBOrMovieDBInfo" xml:space="preserve">
+    <value>Ha TvDB o Link MovieDB</value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedMovieDBInfo" xml:space="preserve">
+    <value>Ha Link MovieDB</value>
+  </data>
+  <data name="Image_Default" xml:space="preserve">
+    <value>Solo questa immagine sarà utilizzata</value>
+  </data>
+  <data name="Image_NotDefault" xml:space="preserve">
+    <value>Questa immagine non è l'impostazione predefinita</value>
+  </data>
+  <data name="PlayNextEpisode" xml:space="preserve">
+    <value>Giocare il prossimo episodio</value>
+  </data>
+  <data name="AllEpisodesWatched" xml:space="preserve">
+    <value>Tutti gli episodi sono già stati visti</value>
+  </data>
+  <data name="FinishEditing" xml:space="preserve">
+    <value>Terminare la modifica</value>
+  </data>
+  <data name="TAB_Dashboard" xml:space="preserve">
+    <value>Cruscotto</value>
+  </data>
+  <data name="Dash_WatchNextEp_Recent" xml:space="preserve">
+    <value>Continuare a guardare... (Recentemente visto)</value>
+  </data>
+  <data name="DeleteSeries" xml:space="preserve">
+    <value>Eliminare la serie</value>
+  </data>
+  <data name="DeleteSeriesConfirm" xml:space="preserve">
+    <value>Sei sicuro di che voler eliminare questo gruppo di serie?</value>
+  </data>
+  <data name="DeleteSeriesConfirm_Files" xml:space="preserve">
+    <value>Anche eliminare tutti i file fisici?</value>
+  </data>
+  <data name="Dash_SeriesMissingEps" xml:space="preserve">
+    <value>Mancano episodi (di recente visto)</value>
+  </data>
+  <data name="LatestEp_Anime" xml:space="preserve">
+    <value>Ultimo episodio</value>
+  </data>
+  <data name="LatestEp_Yours" xml:space="preserve">
+    <value>Il tuo ultimo episodio</value>
+  </data>
+  <data name="MissingEpisodeCount" xml:space="preserve">
+    <value>Episodi mancanti</value>
+  </data>
+  <data name="Dash_MiniCalendar" xml:space="preserve">
+    <value>Mini calendario</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Account di accesso</value>
+  </data>
+  <data name="ImageSize" xml:space="preserve">
+    <value>Dimensione dell'immagine</value>
+  </data>
+  <data name="INFO_SettingsUserAdmin" xml:space="preserve">
+    <value>Aggiungere o modificare gli utenti qui. Gli utenti sono memorizzati nel database e condivisi tra client diversi. Deve sempre avere almeno un utente admin.</value>
+  </data>
+  <data name="TAB_SettingsUsers" xml:space="preserve">
+    <value>Utenti</value>
+  </data>
+  <data name="User_HideCategories" xml:space="preserve">
+    <value>Nascondi categorie</value>
+  </data>
+  <data name="User_IsAdmin" xml:space="preserve">
+    <value>Amministratore</value>
+  </data>
+  <data name="User_Password" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="User_Username" xml:space="preserve">
+    <value>Nome utente</value>
+  </data>
+  <data name="Items" xml:space="preserve">
+    <value>Elementi</value>
+  </data>
+  <data name="Days" xml:space="preserve">
+    <value>Giorni</value>
+  </data>
+  <data name="DashWatchNextStyle_Detailed" xml:space="preserve">
+    <value>Dettagliate</value>
+  </data>
+  <data name="DashWatchNextStyle_Simple" xml:space="preserve">
+    <value>Semplice</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_Trakt" xml:space="preserve">
+    <value>Trakt TV</value>
+  </data>
+  <data name="Trakt_Password" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Trakt_Username" xml:space="preserve">
+    <value>Nome utente</value>
+  </data>
+  <data name="UpdateFrequency" xml:space="preserve">
+    <value>Aggiornamento automatico dei dati</value>
+  </data>
+  <data name="UpdateFrequency_12Hours" xml:space="preserve">
+    <value>Ogni 12 ore</value>
+  </data>
+  <data name="UpdateFrequency_6Hours" xml:space="preserve">
+    <value>Ogni 6 ore</value>
+  </data>
+  <data name="UpdateFrequency_Daily" xml:space="preserve">
+    <value>Ogni 24 ore</value>
+  </data>
+  <data name="UpdateFrequency_Never" xml:space="preserve">
+    <value>Mai</value>
+  </data>
+  <data name="TraktSyncFrequency" xml:space="preserve">
+    <value>Sincronizza automaticamente la raccolta</value>
+  </data>
+  <data name="TraktSearchPrompt" xml:space="preserve">
+    <value>Cerca in Trakt o immettere ID Trakt (slug)</value>
+  </data>
+  <data name="TraktShow" xml:space="preserve">
+    <value>Vai a Trakt</value>
+  </data>
+  <data name="TAB_Pinned" xml:space="preserve">
+    <value>Appuntato</value>
+  </data>
+  <data name="Tooltip_ViewSeries" xml:space="preserve">
+    <value>Aprire questa serie di Anime in una nuova finestra</value>
+  </data>
+  <data name="GroupFilterConditionType_UserVotedAny" xml:space="preserve">
+    <value>Utente ha votato (qualsiasi)</value>
+  </data>
+  <data name="Tooltip_User_IsAniDB" xml:space="preserve">
+    <value>Qualsiasi utente contrassegnato come un utente di AniDB sarà conservati in sincronia con gli altri utenti di AniDB. Se l'utente non è che un utente di AniDB guardato gli episodi non si rifletteranno sul sito AniDB.</value>
+  </data>
+  <data name="User_IsAniDB" xml:space="preserve">
+    <value>AniDB utente</value>
+  </data>
+  <data name="User_IsTrakt" xml:space="preserve">
+    <value>Trakt utente</value>
+  </data>
+  <data name="ERROR_SeriesExists" xml:space="preserve">
+    <value>Per questo anime esiste già una serie</value>
+  </data>
+  <data name="Tooltip_CreateSeries" xml:space="preserve">
+    <value>Creare serie per questo anime</value>
+  </data>
+  <data name="SimilarAnime" xml:space="preserve">
+    <value>Anime simili</value>
+  </data>
+  <data name="RelatedAndSimilar" xml:space="preserve">
+    <value>Correlati e simili</value>
+  </data>
+  <data name="GetMissingData" xml:space="preserve">
+    <value>Ottenere dati mancanti ora</value>
+  </data>
+  <data name="NoSimilarAnime" xml:space="preserve">
+    <value>Nessun anime simili potrebbe essere trovato</value>
+  </data>
+  <data name="NoRelatedAnime" xml:space="preserve">
+    <value>È non stato possibile trovare nessun anime correlati</value>
+  </data>
+  <data name="RelatedAnime" xml:space="preserve">
+    <value>Correlati Anime</value>
+  </data>
+  <data name="Dash_RecWatch" xml:space="preserve">
+    <value>Consigli per orologio</value>
+  </data>
+  <data name="Dash_RecDownload" xml:space="preserve">
+    <value>Consigli per il Download</value>
+  </data>
+  <data name="ImportSettings_AutoGroupSeries" xml:space="preserve">
+    <value>Posizionare automaticamente serie correlati nello stesso gruppo di</value>
+  </data>
+  <data name="GroupFilterConditionType_HasWatchedEpisodes" xml:space="preserve">
+    <value>Ha visto episodi</value>
+  </data>
+  <data name="MyList" xml:space="preserve">
+    <value>MyList</value>
+  </data>
+  <data name="Tooltip_MyList" xml:space="preserve">
+    <value>Con forza aggiungere questo file all'elenco su AniDB</value>
+  </data>
+  <data name="TAB_MissingFiles" xml:space="preserve">
+    <value>MyList file mancanti</value>
+  </data>
+  <data name="TAB_Utilities" xml:space="preserve">
+    <value>Programmi di utilità</value>
+  </data>
+  <data name="TAB_SeriesWithoutFiles" xml:space="preserve">
+    <value>Serie senza file</value>
+  </data>
+  <data name="DeleteSeriesConfirm_Groups" xml:space="preserve">
+    <value>Se sono vuote, eliminare eventuali gruppi di genitori</value>
+  </data>
+  <data name="Export" xml:space="preserve">
+    <value>Esportazione</value>
+  </data>
+  <data name="TAB_MissingEpisodes" xml:space="preserve">
+    <value>Episodi mancanti</value>
+  </data>
+  <data name="MyGroupsOnly" xml:space="preserve">
+    <value>Solo i gruppi di rilascio che sto raccogliendo</value>
+  </data>
+  <data name="RegularEpisodesOnly" xml:space="preserve">
+    <value>Solo episodi regolari</value>
+  </data>
+  <data name="Dash_TraktFriends" xml:space="preserve">
+    <value>Attività di amici (Trakt TV)</value>
+  </data>
+  <data name="Tooltip_IgnoreAnimeDownload" xml:space="preserve">
+    <value>Ignorare questo Anime per scaricare consigli</value>
+  </data>
+  <data name="Tooltip_IgnoreAnimeWatch" xml:space="preserve">
+    <value>Ignorare questo Anime per orologio consigli</value>
+  </data>
+  <data name="VisitWebsite" xml:space="preserve">
+    <value>Visita il sito</value>
+  </data>
+  <data name="AniDBSignup" xml:space="preserve">
+    <value>Iscrizione per ora AniDB</value>
+  </data>
+  <data name="AvdumpHeader" xml:space="preserve">
+    <value>AVDump2 (opzionale)</value>
+  </data>
+  <data name="AvdumpInfoLink" xml:space="preserve">
+    <value>Più informazioni su AVDump2</value>
+  </data>
+  <data name="AvdumpKey" xml:space="preserve">
+    <value>Chiave API</value>
+  </data>
+  <data name="AvdumpKeyEditLink" xml:space="preserve">
+    <value>Modificare la chiave di API UDP AVDump2 qui</value>
+  </data>
+  <data name="Avdump" xml:space="preserve">
+    <value>Avdump2</value>
+  </data>
+  <data name="AvdumpRequiredFilesLink" xml:space="preserve">
+    <value>Assicurarsi di che avere tutti i file necessari nella stessa cartella come Desktop JMM</value>
+  </data>
+  <data name="AvdumpSettingsError" xml:space="preserve">
+    <value>Non è stata specificata la chiave API e/o la porta del Client</value>
+  </data>
+  <data name="AvdumpAddRelease" xml:space="preserve">
+    <value>Aggiungi nuova Release</value>
+  </data>
+  <data name="CopyED2KClipboard" xml:space="preserve">
+    <value>Copia ED2K Dump</value>
+  </data>
+  <data name="Tooltip_CopyED2KClipboard" xml:space="preserve">
+    <value>Copiare negli Appunti il Dump di ED2K</value>
+  </data>
+  <data name="TAB_IgnoredAnime" xml:space="preserve">
+    <value>Ignorato Anime</value>
+  </data>
+  <data name="Anime" xml:space="preserve">
+    <value>Anime</value>
+  </data>
+  <data name="RemoveDefaultSeries" xml:space="preserve">
+    <value>Rimuovere la serie di Default</value>
+  </data>
+  <data name="SetDefaultSeries" xml:space="preserve">
+    <value>Aggiungere serie predefinita</value>
+  </data>
+  <data name="DefSeries1" xml:space="preserve">
+    <value>Selezionare la serie di default per</value>
+  </data>
+  <data name="DefSeries2" xml:space="preserve">
+    <value>Selezionando una serie di default significa che tutte le immagini che sono dsiplayed per un gruppo che utilizzerà </value>
+  </data>
+  <data name="DefSeries3" xml:space="preserve">
+    <value>serie di default invece di una serie casuale all'interno del gruppo</value>
+  </data>
+  <data name="ChangeLanguage" xml:space="preserve">
+    <value>Cambia lingua</value>
+  </data>
+  <data name="EpisodeTitleSourceStyle" xml:space="preserve">
+    <value>Episodio Titolo fonte</value>
+  </data>
+  <data name="SeriesNameSourceStyle" xml:space="preserve">
+    <value>Origine del nome serie</value>
+  </data>
+  <data name="SeriesOverviewSourceStyle" xml:space="preserve">
+    <value>Serie panoramica fonte</value>
+  </data>
+  <data name="Tooltip_EpisodeTitleSourceStyle" xml:space="preserve">
+    <value>Fonte preferita di informazioni quando si Visualizza il titolo di un episodio</value>
+  </data>
+  <data name="Tooltip_SeriesNameSourceStyle" xml:space="preserve">
+    <value>Fonte preferita di informazioni quando si Visualizza il nome della serie per un anime</value>
+  </data>
+  <data name="Tooltip_SeriesOverviewSourceStyle" xml:space="preserve">
+    <value>Fonte preferita di informazioni durante la visualizzazione panoramica (descrizione) per una serie di anime</value>
+  </data>
+  <data name="User_EditSettings" xml:space="preserve">
+    <value>Modificare le impostazioni del Server</value>
+  </data>
+  <data name="Tooltip_RemoveMissingFiles" xml:space="preserve">
+    <value>Questo rimuoverà tutte le voci di file video dal vostro database, dove non è possibile trovare fisicamente il file. Assicurarsi che tutte le condivisioni di rete sono disponibili o unità USB collegato prima di eseguire questa.</value>
+  </data>
+  <data name="Tooltip_UpdateMediaInfo" xml:space="preserve">
+    <value>La Media Info è l'informazione sui tuoi file come bitrate, risoluzione codec ecc che viene letto e archiviato la prima volta che si importa un file</value>
+  </data>
+  <data name="UpdateMediaInfo" xml:space="preserve">
+    <value>Aggiornare tutti i Media Info</value>
+  </data>
+  <data name="Video_Hi10P" xml:space="preserve">
+    <value>10 bit</value>
+  </data>
+  <data name="Tooltip_TraktAnimeOnly" xml:space="preserve">
+    <value>Solo Visualizza attività è correlata alle anime (cioè escludere altre serie tv)</value>
+  </data>
+  <data name="TraktAnimeOnly" xml:space="preserve">
+    <value>Solo nell'anime</value>
+  </data>
+  <data name="ForceRefresh" xml:space="preserve">
+    <value>Forza Refresh</value>
+  </data>
+  <data name="TraktFriendNotes" xml:space="preserve">
+    <value>Informazioni viene aggiornati sul server ogni 20 minuti</value>
+  </data>
+  <data name="Dash_RecentEpisodes" xml:space="preserve">
+    <value>Recentemente ho guardato gli episodi</value>
+  </data>
+  <data name="PromptRateSeries" xml:space="preserve">
+    <value>Prompt per la serie di tasso al termine</value>
+  </data>
+  <data name="Tooltip_PromptRateSeries" xml:space="preserve">
+    <value>Ogni volta che si guarda l'ultimo episodio di una serie, verrà visualizzato un messaggio per chiedere per un voto</value>
+  </data>
+  <data name="MALSearchPrompt" xml:space="preserve">
+    <value>Cerca su MyAnimelist o immettere ID MAL</value>
+  </data>
+  <data name="MALShow" xml:space="preserve">
+    <value>Vai a MyAnimeList</value>
+  </data>
+  <data name="Tooltip_WebCache_MALAssociations" xml:space="preserve">
+    <value>Utilizzare la cache web per cercare la pagina di collegamenti tra AniDB e MyAnimeList. Se non selezionata sarà necessario cercare manualmente tutti i collegamenti di MAL.</value>
+  </data>
+  <data name="WebCache_MALAssociations" xml:space="preserve">
+    <value>MyAnimeList link</value>
+  </data>
+  <data name="Tooltip_MAL_UpdateFrequency" xml:space="preserve">
+    <value>Quanto spesso i dati vengono aggiornati, e quanto spesso viene eseguita una ricerca automatica per cercare anime nella vostra collezione, che non hanno un link MAL</value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedMALInfo" xml:space="preserve">
+    <value>Ha MAL Link</value>
+  </data>
+  <data name="Tooltip_UseFanartOnSeries" xml:space="preserve">
+    <value>Fanart di utente invece di poster (dove disponibile) sul Display di serie</value>
+  </data>
+  <data name="UseFanartOnSeries" xml:space="preserve">
+    <value>Fanart di utente sul Display di serie</value>
+  </data>
+  <data name="MAL_NeverDecrease" xml:space="preserve">
+    <value>Diminuzione non guardava mai la conta</value>
+  </data>
+  <data name="Tooltip_MAL_NeverDecrease" xml:space="preserve">
+    <value>Assicurarsi che guardava i conteggi vengono sempre mantenuti. Questo richiede il download di tutta la tua lista ogni volta che si guarda un episodio, così potrebbe richiedere molto tempo</value>
+  </data>
+  <data name="GroupFilterConditionType_EpisodeCount" xml:space="preserve">
+    <value>Conteggio di episodio</value>
+  </data>
+  <data name="SyncMalDown" xml:space="preserve">
+    <value>Scarica stati guardati dal MAL</value>
+  </data>
+  <data name="SyncMalUp" xml:space="preserve">
+    <value>Caricare gli stati guardati a MAL</value>
+  </data>
+  <data name="Tooltip_SyncMalDown" xml:space="preserve">
+    <value>Scarica stati guardati dal MAL e aggiornare la tua collezione locale e AniDB.</value>
+  </data>
+  <data name="Tooltip_SyncMalUp" xml:space="preserve">
+    <value>Aggiornamento MAL utilizzando le statistiche vista dalla tua collezione locale</value>
+  </data>
+  <data name="Tooltip_WebCache_AniDB_File" xml:space="preserve">
+    <value>Si tratta di dati associati a ogni singolo file. Consigliato per grandi collezioni</value>
+  </data>
+  <data name="WebCache_AniDB_File" xml:space="preserve">
+    <value>AniDB File dati</value>
+  </data>
+  <data name="PlaylistPlayOrderRandom" xml:space="preserve">
+    <value>Casuale</value>
+  </data>
+  <data name="PlaylistPlayOrderSeq" xml:space="preserve">
+    <value>Sequenziale</value>
+  </data>
+  <data name="AniDBScheduleMyListStats" xml:space="preserve">
+    <value>Ottenere automaticamente MyList statistiche dal AniDB</value>
+  </data>
+  <data name="GroupFilter_Predefined" xml:space="preserve">
+    <value>Filtri predefiniti</value>
+  </data>
+  <data name="BakaBTResetBody" xml:space="preserve">
+    <value>Reimpostare il cookie se non si ottiene alcun risultato da BakaBT quando si dovrebbe essere. Questo impone un login per BakaBT nuovamente.</value>
+  </data>
+  <data name="BakaBTResetTitle" xml:space="preserve">
+    <value>Reimpostare i Cookie</value>
+  </data>
+  <data name="BakaBTSeriesBody" xml:space="preserve">
+    <value>Durante la ricerca di una serie, BakaBT (e AnimeBytes) sarà la fonte di solo torrent usata nella ricerca iniziale</value>
+  </data>
+  <data name="BakaBTSeriesTitle" xml:space="preserve">
+    <value>BakaBT (e AnimeBytes) solo</value>
+  </data>
+  <data name="AnimeBytesResetBody" xml:space="preserve">
+    <value>Reimpostare il cookie se non si ottiene alcun risultato da AnimeBytes quando si dovrebbe essere. Questo impone un login per AnimeBytes nuovamente.</value>
+  </data>
+  <data name="AnimeBytesResetTitle" xml:space="preserve">
+    <value>Cookie di reset</value>
+  </data>
+  <data name="AnimeBytesSeriesBody" xml:space="preserve">
+    <value>Durante la ricerca di una serie, AnimeBytes (e BakaBT) sarà la fonte di solo torrent usata nella ricerca iniziale</value>
+  </data>
+  <data name="AnimeBytesSeriesTitle" xml:space="preserve">
+    <value>AnimeBytes (e BakaBT) solo</value>
+  </data>
+  <data name="IsVariation" xml:space="preserve">
+    <value>È la variazione</value>
+  </data>
+  <data name="Tooltip_IsVariation" xml:space="preserve">
+    <value>Utilizzare questa opzione quando non si desidera un file di presentarsi nel controllo multiplo di file. Questo può essere il caso dove si dispone di più versioni di un OP/ED per pulire/no pulito, regista e altri tipi di variazioni</value>
+  </data>
+  <data name="AniDBDownloadCharacters" xml:space="preserve">
+    <value>Scarica immagini di carattere</value>
+  </data>
+  <data name="AniDBDownloadCreators" xml:space="preserve">
+    <value>Scarica immagini di creatore</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadCharacters" xml:space="preserve">
+    <value>Queste immagini sono mostrate in MyAnime 3 e Anime Buddy</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadCreators" xml:space="preserve">
+    <value>Queste immagini sono mostrate in MyAnime 3 e Anime Buddy (Doppiatori)</value>
+  </data>
+  <data name="AniDBMyListDeleteAction" xml:space="preserve">
+    <value>Elimina l'azione</value>
+  </data>
+  <data name="Tooltip_AniDBMyListDeleteAction" xml:space="preserve">
+    <value>Azione da intraprendere per un file quando si elimina da voi raccolta locale.
+Eliminare il File (AniDB) - rimuove file dal tuo AniDB MyList.
+Eliminare il File (DB locale) - Rimuovi file dal tuo DB locale solo.
+Mark Deleted - lascia il file sulla vostra lista, ma cambia lo stato eliminato.
+Mark esterno (CD/DVD) - lascia il file sulla vostra lista, ma cambia lo stato di archiviazione esterna.
+Mark Unknown - lascia il file nel tuo elenco, ma cambia lo stato sconosciuto.</value>
+  </data>
+  <data name="GroupFilterConditionType_CustomTag" xml:space="preserve">
+    <value>Tag personalizzato</value>
+  </data>
+  <data name="Tooltip_WebCache_UserInfo" xml:space="preserve">
+    <value>Invia informazioni anonime sull'utilizzo della cache web come tipo di Database, versione di Windows ecc. Vedere la Guida di collegamento per tutti i dati che viene inviato</value>
+  </data>
+  <data name="WebCache_UserInfo" xml:space="preserve">
+    <value>Inviare informazioni anonime sull'utilizzo</value>
+  </data>
+  <data name="NewSeries_Search" xml:space="preserve">
+    <value>Ricerca per titolo o ID</value>
+  </data>
+  <data name="Tooltip_NewSeries_Search" xml:space="preserve">
+    <value>Immettere parte del nome dell'anime, o se si conosce l'ID di AniDB solo che accedere direttamente</value>
+  </data>
+  <data name="Link_CommunityRecommendation" xml:space="preserve">
+    <value>http://jmediamanager.org/FAQ/#What-are-community-recommendations</value>
+  </data>
+  <data name="WhatsThis" xml:space="preserve">
+    <value>Che cos'è?</value>
+  </data>
+  <data name="Override" xml:space="preserve">
+    <value>Eseguire l'override</value>
+  </data>
+  <data name="Tooltip_NameOverride" xml:space="preserve">
+    <value>Si può digitare il nome preferito o usare le frecce verdi a destra per selezionare un nome da AniDB manualmente.</value>
+  </data>
+  <data name="Tooltip_NameOverride2" xml:space="preserve">
+    <value>Selezionare un nome da un elenco di nomi di AniDB.</value>
+  </data>
+  <data name="AdminMessageTitle" xml:space="preserve">
+    <value>Messaggio di admin</value>
+  </data>
+  <data name="CheckForUpdate" xml:space="preserve">
+    <value>Controlla aggiornamenti</value>
+  </data>
+  <data name="Link_Blog" xml:space="preserve">
+    <value>http://jmediamanager.org/Blog</value>
+  </data>
+  <data name="Link_AniDBBanned" xml:space="preserve">
+    <value>http://jmediamanager.org/FAQ/#Banned-from-AniDB</value>
+  </data>
+  <data name="Link_AniDBSettings" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-desktop/Settings/#AniDB</value>
+  </data>
+  <data name="Link_FileRenaming" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-Desktop/Utilities/file-renaming/</value>
+  </data>
+  <data name="Link_GroupFilters" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-desktop/Collection/#What-are-filters</value>
+  </data>
+  <data name="Link_ImportFolders" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-server/Configuring-JMM-Server/#Import-Folders</value>
+  </data>
+  <data name="Link_MAL" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-desktop/Settings/#community-sites</value>
+  </data>
+  <data name="Link_MPC" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-desktop/Settings/#MPC</value>
+  </data>
+  <data name="Link_PotPlayer" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-desktop/Settings/#pot-Player</value>
+  </data>
+  <data name="Link_TMDb" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-desktop/Settings/#community-sites</value>
+  </data>
+  <data name="Link_Trakt" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-desktop/Settings/#community-sites</value>
+  </data>
+  <data name="Link_TvDB" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-desktop/Settings/#community-sites</value>
+  </data>
+  <data name="Link_uTorrent" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-desktop/downloads/#uTorrent</value>
+  </data>
+  <data name="Link_VLC" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-desktop/Settings/#VLC</value>
+  </data>
+  <data name="Link_WebCache" xml:space="preserve">
+    <value>http://jmediamanager.org/JMM-desktop/Settings/#Web-cache</value>
+  </data>
+  <data name="UpdateFrequency_OneMonth" xml:space="preserve">
+    <value>Una volta al mese</value>
+  </data>
+  <data name="UpdateFrequency_OneWeek" xml:space="preserve">
+    <value>Una volta a settimana</value>
+  </data>
+  <data name="SettingAlwaysAniDBPoster" xml:space="preserve">
+    <value>Utilizzare sempre il Poster di AniDB</value>
+  </data>
+  <data name="Tooltip_SettingAlwaysAniDBPoster" xml:space="preserve">
+    <value>Questa impostazione sarà scavalcare eventuali altre impostazioni di Poster affinché solo il Poster di AniDB viene utilizzato. Questo è generalmente più veloce rispetto all'utilizzo casuale poster</value>
+  </data>
+  <data name="MoreInfo" xml:space="preserve">
+    <value>Più informazioni</value>
+  </data>
+  <data name="Link_Changelog" xml:space="preserve">
+    <value>http://jmediamanager.org/changelog/</value>
+  </data>
+  <data name="Link_Download" xml:space="preserve">
+    <value>http://jmediamanager.org/downloads/</value>
+  </data>
+  <data name="Link_Site" xml:space="preserve">
+    <value>http://jmediamanager.org/</value>
+  </data>
+  <data name="ReenterPassword" xml:space="preserve">
+    <value>Immettere nuovamente la Password</value>
+  </data>
+  <data name="ChangePassword" xml:space="preserve">
+    <value>Cambia Password</value>
+  </data>
+  <data name="ChangingPassword" xml:space="preserve">
+    <value>Modifica della Password per: </value>
+  </data>
+  <data name="WhatDoesThisMean" xml:space="preserve">
+    <value>Cosa significa?</value>
+  </data>
+  <data name="DetailedExplanation" xml:space="preserve">
+    <value>Clicca per una spiegazione dettagliata delle opzioni</value>
+  </data>
+  <data name="CustomTag_Name" xml:space="preserve">
+    <value>Nome del tag</value>
+  </data>
+  <data name="CustomTag_Description" xml:space="preserve">
+    <value>Descrizione tag</value>
+  </data>
+  <data name="Add" xml:space="preserve">
+    <value>Aggiungere</value>
+  </data>
+  <data name="MissingEpisodes_AnimeName" xml:space="preserve">
+    <value>Nome anime</value>
+  </data>
+  <data name="MissingEpisodes_AnimeID" xml:space="preserve">
+    <value>ID di anime</value>
+  </data>
+  <data name="MissingEpisodes_EpisodeNumber" xml:space="preserve">
+    <value>Numero episodio</value>
+  </data>
+  <data name="MissingEpisodes_EpisodeID" xml:space="preserve">
+    <value>Episodio ID</value>
+  </data>
+  <data name="MissingEpisodes_GroupSummary" xml:space="preserve">
+    <value>Gruppo sintesi</value>
+  </data>
+  <data name="MissingEpisodes_AnimeLink" xml:space="preserve">
+    <value>Link per Anime</value>
+  </data>
+  <data name="MissingEpisodes_EpisodeLink" xml:space="preserve">
+    <value>Link per episodio</value>
+  </data>
+  <data name="MissingEpisodes_FileSummary" xml:space="preserve">
+    <value>Riepilogo file</value>
+  </data>
+  <data name="NewSeries_AlreadyAttached" xml:space="preserve">
+    <value>Una serie è già associata a questo anime</value>
+  </data>
+  <data name="NewSeries_Step1" xml:space="preserve">
+    <value>Fase 1 - selezionare un Anime</value>
+  </data>
+  <data name="NewSeries_SearchBy" xml:space="preserve">
+    <value>Ricerca per titolo o ID</value>
+  </data>
+  <data name="NewSeries_Step2" xml:space="preserve">
+    <value>Selezionare un gruppo locale</value>
+  </data>
+  <data name="NewSeries_BackToStep1" xml:space="preserve">
+    <value>Torna al passo 1</value>
+  </data>
+  <data name="TryAgain" xml:space="preserve">
+    <value>Riprova!</value>
+  </data>
+  <data name="Random_Tags" xml:space="preserve">
+    <value>Tag</value>
+  </data>
+  <data name="Finish" xml:space="preserve">
+    <value>Finitura</value>
+  </data>
+  <data name="Clear" xml:space="preserve">
+    <value>Chiaro</value>
+  </data>
+  <data name="Matches" xml:space="preserve">
+    <value>Partite</value>
+  </data>
+  <data name="Random_Watched" xml:space="preserve">
+    <value>Ho guardato</value>
+  </data>
+  <data name="Random_Unwatched" xml:space="preserve">
+    <value>Non custodito</value>
+  </data>
+  <data name="Random_PartiallyWatched" xml:space="preserve">
+    <value>Parzialmente visto</value>
+  </data>
+  <data name="Random_CompleteOnly" xml:space="preserve">
+    <value>Completare solo</value>
+  </data>
+  <data name="Random_View" xml:space="preserve">
+    <value>Mostra questa serie</value>
+  </data>
+  <data name="RateSeries_Rate" xml:space="preserve">
+    <value>Serie di tasso:</value>
+  </data>
+  <data name="RateSeries_TraktShout" xml:space="preserve">
+    <value>Dite la vostra su Trakt</value>
+  </data>
+  <data name="Search_Episodes" xml:space="preserve">
+    <value>Episodi:</value>
+  </data>
+  <data name="Search_StartingAt" xml:space="preserve">
+    <value>A partire da</value>
+  </data>
+  <data name="Search_ID" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="Search_Title" xml:space="preserve">
+    <value>Titolo</value>
+  </data>
+  <data name="Search_AniDBStart" xml:space="preserve">
+    <value>AniDB Start:</value>
+  </data>
+  <data name="Search_Trakt" xml:space="preserve">
+    <value>Trakt: </value>
+  </data>
+  <data name="Search_Approved" xml:space="preserve">
+    <value>Admin ha approvato</value>
+  </data>
+  <data name="Search_TvDB" xml:space="preserve">
+    <value>TvDB: </value>
+  </data>
+  <data name="Search_MAL" xml:space="preserve">
+    <value>MAL COBB: </value>
+  </data>
+  <data name="SelectAniDBTitle_SelectName" xml:space="preserve">
+    <value>Selezionare un nome di override</value>
+  </data>
+  <data name="SelectGroupSeries_Select" xml:space="preserve">
+    <value>Selezionare un </value>
+  </data>
+  <data name="Select_MyAnimeList" xml:space="preserve">
+    <value>MyAnimeList</value>
+  </data>
+  <data name="Select_StartingEpisode" xml:space="preserve">
+    <value>A partire di episodio n.</value>
+  </data>
+  <data name="Select_EpisodeType" xml:space="preserve">
+    <value>Tipo di episodio:</value>
+  </data>
+  <data name="Select_TraktTV" xml:space="preserve">
+    <value>Trakt TV</value>
+  </data>
+  <data name="Select_TvDBDetails" xml:space="preserve">
+    <value>Selezionare Dettagli TvDB</value>
+  </data>
+  <data name="Select_Season" xml:space="preserve">
+    <value>Stagione</value>
+  </data>
+  <data name="Select_DefaultLanguage" xml:space="preserve">
+    <value>Selezionare la lingua predefinita</value>
+  </data>
+  <data name="Update_Update" xml:space="preserve">
+    <value>JMM Desktop aggiornamento disponibile!</value>
+  </data>
+  <data name="Update_UpdatePage" xml:space="preserve">
+    <value>Aggiornamento pagina</value>
+  </data>
+  <data name="Update_Changelog" xml:space="preserve">
+    <value>Changelog</value>
+  </data>
+  <data name="Update_AvailableVersion" xml:space="preserve">
+    <value>Versione disponibile</value>
+  </data>
+  <data name="Update_YourVersion" xml:space="preserve">
+    <value>La versione</value>
+  </data>
+  <data name="ViewComments_FromTrakt" xml:space="preserve">
+    <value>Da Trakt</value>
+  </data>
+  <data name="ViewComments_Username" xml:space="preserve">
+    <value>Nome utente</value>
+  </data>
+  <data name="ViewComments_CommentDate" xml:space="preserve">
+    <value>Commento Data</value>
+  </data>
+  <data name="ViewComments_Comments" xml:space="preserve">
+    <value>Commenti</value>
+  </data>
+  <data name="ViewComments_Website" xml:space="preserve">
+    <value>Vista sul sito Web</value>
+  </data>
+  <data name="JMMDesktop" xml:space="preserve">
+    <value>JMM Desktop</value>
+  </data>
+  <data name="MoreInformation" xml:space="preserve">
+    <value>Ulteriori informazioni</value>
+  </data>
+  <data name="Metro_Continue" xml:space="preserve">
+    <value>Continuare a guardare</value>
+  </data>
+  <data name="Metro_New" xml:space="preserve">
+    <value>Nuovi episodi</value>
+  </data>
+  <data name="Metro_Random" xml:space="preserve">
+    <value>Serie casuale</value>
+  </data>
+  <data name="Metro_Trakt" xml:space="preserve">
+    <value>Trakt attività</value>
+  </data>
+  <data name="MarkedFavorite" xml:space="preserve">
+    <value>Questo gruppo è contrassegnato come preferito</value>
+  </data>
+  <data name="Community_TraktValid" xml:space="preserve">
+    <value>Controllare che i miei link sono ancora validi su Trakt</value>
+  </data>
+  <data name="Community_TraktRemoveBad" xml:space="preserve">
+    <value>Rimuovere automaticamente cattiva informazione dal database (altamente consigliato)</value>
+  </data>
+  <data name="Community_CommunityCheck" xml:space="preserve">
+    <value>Controllare se i miei link sono diversi dalle raccomandazioni comunitarie</value>
+  </data>
+  <data name="Community_ProblemStop" xml:space="preserve">
+    <value>Fermarsi dopo aver trovato questo molti problemi</value>
+  </data>
+  <data name="Trakt" xml:space="preserve">
+    <value>Trakt</value>
+  </data>
+  <data name="Start" xml:space="preserve">
+    <value>Inizio</value>
+  </data>
+  <data name="Stop" xml:space="preserve">
+    <value>Fermata</value>
+  </data>
+  <data name="Community_Filter" xml:space="preserve">
+    <value>Filtro:</value>
+  </data>
+  <data name="Community_Refresh" xml:space="preserve">
+    <value>Aggiornare i dati per questa serie</value>
+  </data>
+  <data name="Community_SeriesName" xml:space="preserve">
+    <value>Nome serie</value>
+  </data>
+  <data name="Community_Status" xml:space="preserve">
+    <value>Stato</value>
+  </data>
+  <data name="Community_ValidTraktLink" xml:space="preserve">
+    <value>Link valido Trakt</value>
+  </data>
+  <data name="Community_HasTraktLink" xml:space="preserve">
+    <value>Ha Trakt Link</value>
+  </data>
+  <data name="Community_CommunityLink" xml:space="preserve">
+    <value>Link comunità</value>
+  </data>
+  <data name="Community_Match" xml:space="preserve">
+    <value>Link partita?</value>
+  </data>
+  <data name="Download_Bookmark" xml:space="preserve">
+    <value>Segnalibro questo anime di scaricare più tardi</value>
+  </data>
+  <data name="Download_SeriesSearch" xml:space="preserve">
+    <value>Ricerca per download per questa serie</value>
+  </data>
+  <data name="Download_Approval" xml:space="preserve">
+    <value>Approvazione</value>
+  </data>
+  <data name="Download_YourVote" xml:space="preserve">
+    <value>Il tuo voto</value>
+  </data>
+  <data name="Download_RecommendPrompt" xml:space="preserve">
+    <value>Questa utility ti mostra un elenco degli anime consigliati che non sono nella vostra collezione basata sul proprio valutazioni e feedback degli utenti AniDB</value>
+  </data>
+  <data name="Torrent" xml:space="preserve">
+    <value>Torrent</value>
+  </data>
+  <data name="Torrents" xml:space="preserve">
+    <value>Torrenti</value>
+  </data>
+  <data name="Download_Name" xml:space="preserve">
+    <value>Nome</value>
+  </data>
+  <data name="Download_Size" xml:space="preserve">
+    <value>Dimensioni</value>
+  </data>
+  <data name="Download_Seeders" xml:space="preserve">
+    <value>Seminatrici</value>
+  </data>
+  <data name="Download_Leechers" xml:space="preserve">
+    <value>Leechers</value>
+  </data>
+  <data name="Download_ExtraInfo" xml:space="preserve">
+    <value>Informazioni extra</value>
+  </data>
+  <data name="Download_WrongSeries" xml:space="preserve">
+    <value>Serie di sbagliato?</value>
+  </data>
+  <data name="Tooltip_WrongSeries" xml:space="preserve">
+    <value>Si tratta di JMMs tentativo di indovinare le serie a cui si sta guardando, quindi può paragonare alla tua collezione locale. Se non si dispone della serie nella vostra collezione sarà errato.</value>
+  </data>
+  <data name="Download_ResetCookie" xml:space="preserve">
+    <value>Reimpostare i Cookie</value>
+  </data>
+  <data name="Download_AnimeBytesOnly" xml:space="preserve">
+    <value>AnimeBytes solo per la serie</value>
+  </data>
+  <data name="Download_BakaBTOnly" xml:space="preserve">
+    <value>BakaBT solo per la serie</value>
+  </data>
+  <data name="Available" xml:space="preserve">
+    <value>Disponibile</value>
+  </data>
+  <data name="Selected" xml:space="preserve">
+    <value>Selezionato</value>
+  </data>
+  <data name="Download_Source" xml:space="preserve">
+    <value>Fonte</value>
+  </data>
+  <data name="Download_Server" xml:space="preserve">
+    <value>Server</value>
+  </data>
+  <data name="Download_RefreshInterval" xml:space="preserve">
+    <value>Intervallo (secondi) di aggiornamento</value>
+  </data>
+  <data name="Download_AutoRefresh" xml:space="preserve">
+    <value>Aggiornamento automatico</value>
+  </data>
+  <data name="Download_UseBlackHole" xml:space="preserve">
+    <value>Buco nero di uso Torrent</value>
+  </data>
+  <data name="Download_FolderLocation" xml:space="preserve">
+    <value>Percorso della cartella</value>
+  </data>
+  <data name="Download_Hash" xml:space="preserve">
+    <value>Hash</value>
+  </data>
+  <data name="Download_Queue" xml:space="preserve">
+    <value>n.</value>
+  </data>
+  <data name="Download_Done" xml:space="preserve">
+    <value>Fatto</value>
+  </data>
+  <data name="Download_Peers" xml:space="preserve">
+    <value>Coetanei</value>
+  </data>
+  <data name="Download_DownSpeed" xml:space="preserve">
+    <value>Velocità di discesa</value>
+  </data>
+  <data name="Download_UpSpeed" xml:space="preserve">
+    <value>Velocità di upload</value>
+  </data>
+  <data name="Download_Ratio" xml:space="preserve">
+    <value>Rapporto</value>
+  </data>
+  <data name="Download_InvalidCred" xml:space="preserve">
+    <value>Non è stato specificato le credenziali valide uTorrent</value>
+  </data>
+  <data name="Download_EnterCred" xml:space="preserve">
+    <value>Si prega di inserire le proprie credenziali nella scheda Impostazioni e quindi restituire</value>
+  </data>
+  <data name="Download_Priority" xml:space="preserve">
+    <value>Priorità</value>
+  </data>
+  <data name="Download_Downloaded" xml:space="preserve">
+    <value>Scaricato</value>
+  </data>
+  <data name="Settings_DeleteAction" xml:space="preserve">
+    <value>Elimina l'azione</value>
+  </data>
+  <data name="Settings_AutoUpdateInfo" xml:space="preserve">
+    <value>Aggiornare automaticamente i file con informazioni mancanti</value>
+  </data>
+  <data name="Settings_HideDownloadButton" xml:space="preserve">
+    <value>Nascondere il pulsante Download episodio quando si dispone già di file</value>
+  </data>
+  <data name="Settings_RecreateGroups" xml:space="preserve">
+    <value>Ricreare tutti i gruppi</value>
+  </data>
+  <data name="Settings_ScanOnStart" xml:space="preserve">
+    <value>Scansione di cartelle di ricezione su Start</value>
+  </data>
+  <data name="Settings_ImagePath" xml:space="preserve">
+    <value>Percorso immagine</value>
+  </data>
+  <data name="Settings_SelectFolder" xml:space="preserve">
+    <value>Selezionare la cartella</value>
+  </data>
+  <data name="Settings_FilePort" xml:space="preserve">
+    <value>Porta file</value>
+  </data>
+  <data name="WebCache_TraktLinks" xml:space="preserve">
+    <value>Trakt Links</value>
+  </data>
+  <data name="VideoPlayer_MPC" xml:space="preserve">
+    <value>Media Player Classic</value>
+  </data>
+  <data name="VideoPlayer_MPCNote" xml:space="preserve">
+    <value>Per l'integrazione di MPC che è necessario attivare due opzioni impostazioni (1) archivio di file ini e (2) mantenere la storia di recente ho guardato i file. Vedere la schermata riportata di seguito per ulteriori dettagli. La posizione di MPC è di solito qualcosa di simile a C:\Program Files (x86) \Combined Community Codec Pack\MPC</value>
+  </data>
+  <data name="VideoPlayer_MPCOptions" xml:space="preserve">
+    <value>Opzioni di MPC</value>
+  </data>
+  <data name="VideoPlayer_VLC" xml:space="preserve">
+    <value>VLC</value>
+  </data>
+  <data name="VideoPlayer_VLCNote" xml:space="preserve">
+    <value>VLC 2.2 + registra file recenti e timestamp per impostazione predefinita (e la disattivazione è un'opzione 'Avanzate'). Le versioni precedenti non supportano la funzionalità di 'Riprendere dall'ultima posizione'. La posizione del file ini VLC è di solito qualcosa di simile C:\Users\username\AppData\Roaming\vlc\vlc-qt-interface.ini</value>
+  </data>
+  <data name="VideoPlayer_VLCOptions" xml:space="preserve">
+    <value>Opzioni di VLC</value>
+  </data>
+  <data name="VideoPlayer_PotPlayer" xml:space="preserve">
+    <value>PotPlayer</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerNote" xml:space="preserve">
+    <value>Per integrazione PotPlayer è necessario attivare le seguenti opzioni (1) Preferenze &gt; Generale &gt; impostazioni Store a ini file (2) preferenze &gt; riproduzione &gt; giocare dal punto più recente. Vedere la schermata riportata di seguito per ulteriori dettagli. La posizione del file ini PlotPlayer è di solito qualcosa di simile C:\Users\username\AppData\Roaming\PotPlayer64\PotPlayer64.ini</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerOptions" xml:space="preserve">
+    <value>PotPlayer opzioni</value>
+  </data>
+  <data name="VideoPlayer_MPCINI" xml:space="preserve">
+    <value>Selezionare la cartella di MPC INI</value>
+  </data>
+  <data name="VideoPlayer_VLCINI" xml:space="preserve">
+    <value>Selezionare la cartella VLC INI</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerINI" xml:space="preserve">
+    <value>Selezionare cartella PotPlayer INI</value>
+  </data>
+  <data name="VideoPlayer_MPCTest" xml:space="preserve">
+    <value>Test File MPC</value>
+  </data>
+  <data name="VideoPlayer_VLCTest" xml:space="preserve">
+    <value>File di prova VLC</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerTest" xml:space="preserve">
+    <value>File di test PotPlayer</value>
+  </data>
+  <data name="VideoPlayer_AutoMark" xml:space="preserve">
+    <value>Contrassegnare automaticamente i file come visto quando sono guardata le seguenti percentuali</value>
+  </data>
+  <data name="VideoPlayer_MPCFolder" xml:space="preserve">
+    <value>MPC INI cartella</value>
+  </data>
+  <data name="VideoPlayer_VLCFolder" xml:space="preserve">
+    <value>Cartella di VLC INI</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerFolder" xml:space="preserve">
+    <value>PotPlayer INI cartella</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote1" xml:space="preserve">
+    <value>Preferenze di selezione automatiche File - questo si riferisce a quando si dispone di più file per un episodio</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote2" xml:space="preserve">
+    <value>Per un elenco di riproduzione è necessario scegliere un file, che si baserà su di voi preferenze qui sotto.</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote3" xml:space="preserve">
+    <value>Per un singolo episodio è possibile attivare la selezione automatica del file o hanno JMM chiederà di selezionare un file ogni volta che ne hai più di uno</value>
+  </data>
+  <data name="VideoPlayer_AutoFileFirstEpisode" xml:space="preserve">
+    <value>Selezione automatica di File - primo episodio della serie</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNextEpisode" xml:space="preserve">
+    <value>Selezione automatica di File - episodi successivi della serie</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote4" xml:space="preserve">
+    <value>Se si seleziona 'Release Gruppo da precedentemente giocato episodio' nell'impostazione precedente è inoltre necessario effettuare le seguenti operazioni</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote5" xml:space="preserve">
+    <value>Deselezionare 'Set file come ho guardato se è guardato episodio' sotto impostazioni - essenziale - impostazioni di importazione</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote6" xml:space="preserve">
+    <value>Sempre contrassegnare un File come ho guardato e non un episodio</value>
+  </data>
+  <data name="VideoPlayer_AutoFileEnable" xml:space="preserve">
+    <value>Abilitare la selezione di file di auto su singoli episodi</value>
+  </data>
+  <data name="TvDB_WideBannerMax" xml:space="preserve">
+    <value>Massima larghezza banner</value>
+  </data>
+  <data name="TvDB_PostersMax" xml:space="preserve">
+    <value>Massimo manifesti</value>
+  </data>
+  <data name="Trakt_Enable" xml:space="preserve">
+    <value>Abilitare Trakt</value>
+  </data>
+  <data name="Trakt_PIN" xml:space="preserve">
+    <value>Trakt PIN</value>
+  </data>
+  <data name="Trakt_GetPIN" xml:space="preserve">
+    <value>Ottenere il Pin</value>
+  </data>
+  <data name="Trakt_Authorize" xml:space="preserve">
+    <value>Autorizzazione JMM</value>
+  </data>
+  <data name="Trakt_CurrentToken" xml:space="preserve">
+    <value>Token corrente è valido fino al:</value>
+  </data>
+  <data name="Trakt_AutoFanart" xml:space="preserve">
+    <value>Auto Download Fanart</value>
+  </data>
+  <data name="Trakt_AutoPosters" xml:space="preserve">
+    <value>Auto Download poster</value>
+  </data>
+  <data name="Trakt_AutoEpisodeImages" xml:space="preserve">
+    <value>Auto Download episodio immagini</value>
+  </data>
+  <data name="MovieDB_MaxPosters" xml:space="preserve">
+    <value>Massimo manifesti</value>
+  </data>
+  <data name="AnimeGroup_Random" xml:space="preserve">
+    <value>Episodio casuale</value>
+  </data>
+  <data name="AnimeGroup_AllSeries" xml:space="preserve">
+    <value>Tutte le serie</value>
+  </data>
+  <data name="AnimeGroup_DoubleClick" xml:space="preserve">
+    <value>Fare doppio clic su una serie di vederlo direttamente</value>
+  </data>
+  <data name="PinnedSeries_Simple" xml:space="preserve">
+    <value>Visualizza vista semplificata</value>
+  </data>
+  <data name="Playlist_Add" xml:space="preserve">
+    <value>Aggiungere alla Playlist</value>
+  </data>
+  <data name="Series_Overview" xml:space="preserve">
+    <value>Panoramica</value>
+  </data>
+  <data name="Series_MoreInfo" xml:space="preserve">
+    <value>Ulteriori informazioni</value>
+  </data>
+  <data name="Series_CustomTags" xml:space="preserve">
+    <value>Tag personalizzati</value>
+  </data>
+  <data name="Series_ManageCustom" xml:space="preserve">
+    <value>Il gestore di tag personalizzati</value>
+  </data>
+  <data name="Series_Tag" xml:space="preserve">
+    <value>Prodotto Tag</value>
+  </data>
+  <data name="Series_Add" xml:space="preserve">
+    <value>Aggiungere</value>
+  </data>
+  <data name="Series_Files" xml:space="preserve">
+    <value>File</value>
+  </data>
+  <data name="Series_Folder" xml:space="preserve">
+    <value>Cartella</value>
+  </data>
+  <data name="SeriesSimple_TraktLink" xml:space="preserve">
+    <value>Andare questo episodio su Trakt.TV</value>
+  </data>
+  <data name="SeriesSimple_Comments" xml:space="preserve">
+    <value>Commenti</value>
+  </data>
+  <data name="SeriesSimple_Play" xml:space="preserve">
+    <value>Gioca</value>
+  </data>
+  <data name="SeriesSimple_Watched" xml:space="preserve">
+    <value>Visto:</value>
+  </data>
+  <data name="SeriesSimple_From" xml:space="preserve">
+    <value>Da:</value>
+  </data>
+  <data name="SeriesSimple_AlreadyHave" xml:space="preserve">
+    <value>Hai già questo anime nella vostra collezione</value>
+  </data>
+  <data name="SeriesSimple_Details" xml:space="preserve">
+    <value>Dettagli:</value>
+  </data>
+  <data name="SeriesSimple_Voteup" xml:space="preserve">
+    <value>Voto alto</value>
+  </data>
+  <data name="SeriesSimple_VoteDown" xml:space="preserve">
+    <value>Voto</value>
+  </data>
+  <data name="SeriesSimple_FromTrakt" xml:space="preserve">
+    <value>Da Trakt</value>
+  </data>
+  <data name="SeriesSimple_View" xml:space="preserve">
+    <value>Vista</value>
+  </data>
+  <data name="SeriesSimple_FromAniDB" xml:space="preserve">
+    <value>Da AniDB</value>
+  </data>
+  <data name="SeriesSimple_Aired" xml:space="preserve">
+    <value>In onda</value>
+  </data>
+  <data name="SeriesSimple_Episodes" xml:space="preserve">
+    <value>Episodi</value>
+  </data>
+  <data name="SeriesSimple_MyVote" xml:space="preserve">
+    <value>Il mio voto</value>
+  </data>
+  <data name="SeriesSimple_PlayNext" xml:space="preserve">
+    <value>Giocare il prossimo episodio</value>
+  </data>
+  <data name="SeriesSimple_PlayUnWatched" xml:space="preserve">
+    <value>Gioca tutto incustodito (</value>
+  </data>
+  <data name="SeriesSimple_YourSay" xml:space="preserve">
+    <value>Dite la vostra...</value>
+  </data>
+  <data name="SeriesSimple_Spoiler" xml:space="preserve">
+    <value>Spoiler</value>
+  </data>
+  <data name="SeriesSimple_CommentTrakt" xml:space="preserve">
+    <value>Commento su Trakt</value>
+  </data>
+  <data name="SeriesSimple_Characters" xml:space="preserve">
+    <value>Caratteri</value>
+  </data>
+  <data name="SeriesSimple_AlsoLike" xml:space="preserve">
+    <value>Potrebbe piacerti anche</value>
+  </data>
+  <data name="SeriesSimple_PeopleSaying" xml:space="preserve">
+    <value>Cosa dice la gente</value>
+  </data>
+  <data name="SeriesSimple_Loading" xml:space="preserve">
+    <value>Caricamento...</value>
+  </data>
+  <data name="AvDump_Remove" xml:space="preserve">
+    <value>Rimuovere dall'elenco</value>
+  </data>
+  <data name="AvDump_Clear" xml:space="preserve">
+    <value>Cancella elenco</value>
+  </data>
+  <data name="AvDump_Dump" xml:space="preserve">
+    <value>I file di dump</value>
+  </data>
+  <data name="Bookmarks_Downloading" xml:space="preserve">
+    <value>Download in corso</value>
+  </data>
+  <data name="Bookmarks_NotDownloading" xml:space="preserve">
+    <value>Non scaricare</value>
+  </data>
+  <data name="Dashboard_YourVote" xml:space="preserve">
+    <value>Il tuo voto</value>
+  </data>
+  <data name="Dashboard_Bookmark" xml:space="preserve">
+    <value>Segnalibro questo anime di scaricare più tardi</value>
+  </data>
+  <data name="Dashboard_Download" xml:space="preserve">
+    <value>Ricerca per download per questa serie</value>
+  </data>
+  <data name="Dashboard_NoRecommend" xml:space="preserve">
+    <value>Non Impossibile trovare nessuna raccomandazione.</value>
+  </data>
+  <data name="Dashboard_DownloadVotes" xml:space="preserve">
+    <value>Scarica ora il tuo voto, o votare su un anime per iniziare a ricevere consigli.</value>
+  </data>
+  <data name="Dashboard_SyncVotes" xml:space="preserve">
+    <value>Voti di sincronizzazione</value>
+  </data>
+  <data name="Dashboard_Added" xml:space="preserve">
+    <value>Aggiunto</value>
+  </data>
+  <data name="Dashboard_Metro" xml:space="preserve">
+    <value>Cruscotto della metropolitana</value>
+  </data>
+  <data name="Dashboard_UpdateCalendar" xml:space="preserve">
+    <value>Aggiornare i dati del calendario</value>
+  </data>
+  <data name="Dashboard_Recent" xml:space="preserve">
+    <value>Aggiunte recenti</value>
+  </data>
+  <data name="Metro_Options" xml:space="preserve">
+    <value>Opzioni</value>
+  </data>
+  <data name="Metro_General" xml:space="preserve">
+    <value>Generale</value>
+  </data>
+  <data name="Metro_ImageType" xml:space="preserve">
+    <value>Tipo di immagine</value>
+  </data>
+  <data name="Metro_Sections" xml:space="preserve">
+    <value>Sezioni</value>
+  </data>
+  <data name="Metro_Items" xml:space="preserve">
+    <value>Elementi</value>
+  </data>
+  <data name="Metro_Refresh" xml:space="preserve">
+    <value>Aggiornamento</value>
+  </data>
+  <data name="PlayVideo" xml:space="preserve">
+    <value>Riprodurre Video</value>
+  </data>
+  <data name="Episode_MoreInfo" xml:space="preserve">
+    <value>Più informazioni...</value>
+  </data>
+  <data name="Episode_LessInfo" xml:space="preserve">
+    <value>Meno Info...</value>
+  </data>
+  <data name="Episode_Manual" xml:space="preserve">
+    <value>Collegamento manuale</value>
+  </data>
+  <data name="Episode_ForceAniDBUpdate" xml:space="preserve">
+    <value>Informazioni sull'aggiornamento di forza da AniDB</value>
+  </data>
+  <data name="Episode_RecalculateHash" xml:space="preserve">
+    <value>Ri-calcolare Hash</value>
+  </data>
+  <data name="Episode_Hash" xml:space="preserve">
+    <value>Hash</value>
+  </data>
+  <data name="Episode_CRC32" xml:space="preserve">
+    <value>CRC32</value>
+  </data>
+  <data name="Episode_SHA1" xml:space="preserve">
+    <value>SHA1</value>
+  </data>
+  <data name="Episode_MD5" xml:space="preserve">
+    <value>MD5</value>
+  </data>
+  <data name="Episode_DownloadSearch" xml:space="preserve">
+    <value>Cerca download per questo episodio</value>
+  </data>
+  <data name="Episode_PlaylistAdd" xml:space="preserve">
+    <value>Aggiungere alla Playlist</value>
+  </data>
+  <data name="Episode_TvDBOverride" xml:space="preserve">
+    <value>Ignorare il collegamento TvDB per questo episodio</value>
+  </data>
+  <data name="Episode_TvDBRemove" xml:space="preserve">
+    <value>Rimuovere il collegamento TvDB per questo episodio</value>
+  </data>
+  <data name="Episode_AniDBForceUpdate" xml:space="preserve">
+    <value>Informazioni sull'aggiornamento di forza da AniDB</value>
+  </data>
+  <data name="Episode_Type" xml:space="preserve">
+    <value>Tipo</value>
+  </data>
+  <data name="Episode_Availability" xml:space="preserve">
+    <value>Disponibilità</value>
+  </data>
+  <data name="Episode_WatchedState" xml:space="preserve">
+    <value>Stato visto</value>
+  </data>
+  <data name="Rename_Script" xml:space="preserve">
+    <value>Script</value>
+  </data>
+  <data name="Rename_New" xml:space="preserve">
+    <value>Nuovo</value>
+  </data>
+  <data name="Rename_Save" xml:space="preserve">
+    <value>Salva</value>
+  </data>
+  <data name="Rename_Delete" xml:space="preserve">
+    <value>Elimina</value>
+  </data>
+  <data name="Rename_Tag" xml:space="preserve">
+    <value>Prodotto Tag</value>
+  </data>
+  <data name="Rename_Add" xml:space="preserve">
+    <value>Aggiungere</value>
+  </data>
+  <data name="Rename_Test" xml:space="preserve">
+    <value>Prova</value>
+  </data>
+  <data name="Rename_ScriptingHelp" xml:space="preserve">
+    <value>Aiuto con lo script</value>
+  </data>
+  <data name="Rename_ImportRun" xml:space="preserve">
+    <value>Eseguire questo script quando si importano file in collezione</value>
+  </data>
+  <data name="Rename_Filter" xml:space="preserve">
+    <value>Filtro:</value>
+  </data>
+  <data name="Rename_Clear" xml:space="preserve">
+    <value>Chiaro</value>
+  </data>
+  <data name="Rename_AddFiles" xml:space="preserve">
+    <value>Aggiungere file</value>
+  </data>
+  <data name="Rename_Rename" xml:space="preserve">
+    <value>Rinominare ora</value>
+  </data>
+  <data name="Rename_Preview" xml:space="preserve">
+    <value>Anteprima</value>
+  </data>
+  <data name="FileSearch_Rescan" xml:space="preserve">
+    <value>Ripetizione dell'analisi</value>
+  </data>
+  <data name="FileSearch_AniDBForceUpdate" xml:space="preserve">
+    <value>Informazioni sull'aggiornamento di forza da AniDB</value>
+  </data>
+  <data name="GroupFilter_RandomSeries" xml:space="preserve">
+    <value>Serie casuale</value>
+  </data>
+  <data name="GroupFilter_RandomEpisode" xml:space="preserve">
+    <value>Episodio casuale</value>
+  </data>
+  <data name="IgnoredAnime_Delete" xml:space="preserve">
+    <value>Eliminare questa voce</value>
+  </data>
+  <data name="IgnoredAnime_Note" xml:space="preserve">
+    <value>Questa utility vi mostrerà tutte le anime che si è scelto di ignorare le raccomandazioni. L'eliminazione di questi record significa che essi possono mostrare nuovamente nelle raccomandazioni.</value>
+  </data>
+  <data name="ImportFolder_Watched" xml:space="preserve">
+    <value>Questa cartella viene guardata per i nuovi file</value>
+  </data>
+  <data name="MissingEpisodes_SelectColumns" xml:space="preserve">
+    <value>Selezionare le colonne da utilizzare nell'importazione</value>
+  </data>
+  <data name="MissingEpisodes_AiringState" xml:space="preserve">
+    <value>Stato di messa in onda:</value>
+  </data>
+  <data name="RefreshWait" xml:space="preserve">
+    <value>Premendo il pulsante di aggiornamento può richiedere alcuni minuti, quindi per favore sii paziente</value>
+  </data>
+  <data name="MissingEpisodes_Note" xml:space="preserve">
+    <value>Questa utility vi mostrerà un riepilogo di tutti i tuoi episodi mancanti.</value>
+  </data>
+  <data name="MissingMyList_Missing" xml:space="preserve">
+    <value>Mostra File mancante</value>
+  </data>
+  <data name="MissingMyList_RemoveAll" xml:space="preserve">
+    <value>Rimuovere tutte le voci da AniDB</value>
+  </data>
+  <data name="MissingMyList_Note" xml:space="preserve">
+    <value>Questa utility si Scarica la tua lista di file da AniDB e confrontarlo con i file localmente. Si avrà quindi la possibilità di rimuovere tali file da AniDB se non sono presenti.</value>
+  </data>
+  <data name="Episode" xml:space="preserve">
+    <value>Episodio</value>
+  </data>
+  <data name="Playlist_Random" xml:space="preserve">
+    <value>Episodio casuale</value>
+  </data>
+  <data name="Playlist_Default" xml:space="preserve">
+    <value>Ordine di riproduzione predefinita</value>
+  </data>
+  <data name="Playlist_Items" xml:space="preserve">
+    <value>Elementi di playlist</value>
+  </data>
+  <data name="PlayNext_Hidden" xml:space="preserve">
+    <value>Nascosta per evitare spoiler</value>
+  </data>
+  <data name="Rankings_Overall" xml:space="preserve">
+    <value>Per valutazione complessiva dell'utente</value>
+  </data>
+  <data name="Rankings_GroupedByYear" xml:space="preserve">
+    <value>Raggruppati per anno</value>
+  </data>
+  <data name="Rankings_CollectionState" xml:space="preserve">
+    <value>Stato di raccolta</value>
+  </data>
+  <data name="Rankings_Voted" xml:space="preserve">
+    <value>Votato</value>
+  </data>
+  <data name="Rankings_Completed" xml:space="preserve">
+    <value>Completato</value>
+  </data>
+  <data name="Rankings_Anime" xml:space="preserve">
+    <value> Anime</value>
+  </data>
+  <data name="Rankings_AniDB" xml:space="preserve">
+    <value>AniDB Voto</value>
+  </data>
+  <data name="Rankings_User" xml:space="preserve">
+    <value>Il tuo voto</value>
+  </data>
+  <data name="Rankings_Year" xml:space="preserve">
+    <value>Anno</value>
+  </data>
+  <data name="Rankings_View" xml:space="preserve">
+    <value>Visualizza serie</value>
+  </data>
+  <data name="Rankings_MyVote" xml:space="preserve">
+    <value>Il mio voto</value>
+  </data>
+  <data name="Related_Bookmark" xml:space="preserve">
+    <value>Segnalibro questo anime di scaricare più tardi</value>
+  </data>
+  <data name="Related_Search" xml:space="preserve">
+    <value>Ricerca per download per questa serie</value>
+  </data>
+  <data name="SeriesWithoutFiles_Delete" xml:space="preserve">
+    <value>Eliminare questa serie dal database</value>
+  </data>
+  <data name="SeriesWithoutFiles_Note" xml:space="preserve">
+    <value>Questa utility vi mostrerà tutte le serie che non hanno alcun file. L'eliminazione della serie eliminerà il gruppo anche se nessuna altra serie in quel gruppo hanno i file.</value>
+  </data>
+  <data name="TraktShouts_View" xml:space="preserve">
+    <value>Vista</value>
+  </data>
+  <data name="TraktShouts_FromAniDB" xml:space="preserve">
+    <value>Da AniDB</value>
+  </data>
+  <data name="TraktShouts_Spoiler" xml:space="preserve">
+    <value>Spoiler</value>
+  </data>
+  <data name="TraktShouts_Loading" xml:space="preserve">
+    <value>Caricamento...</value>
+  </data>
+  <data name="TraktShouts_Comments" xml:space="preserve">
+    <value>Commenti</value>
+  </data>
+  <data name="CommunityLinks_Start" xml:space="preserve">
+    <value>Inizio:</value>
+  </data>
+  <data name="CommunityLinks_Edit" xml:space="preserve">
+    <value>Modificare i dettagli</value>
+  </data>
+  <data name="CommunityLinks_AniDBStart" xml:space="preserve">
+    <value>AniDB Start:</value>
+  </data>
+  <data name="CommunityLinks_TvDB" xml:space="preserve">
+    <value>TvDB: </value>
+  </data>
+  <data name="CommunityLinks_Trakt" xml:space="preserve">
+    <value>Trakt: </value>
+  </data>
+  <data name="CommunityLinks_TMDb" xml:space="preserve">
+    <value>Il film DB</value>
+  </data>
+  <data name="CommunityLinks_MAL" xml:space="preserve">
+    <value>MyAnimeList</value>
+  </data>
+  <data name="CommunityLinks_AutoLink" xml:space="preserve">
+    <value>Auto Link</value>
+  </data>
+  <data name="Tooltip_DeleteTitle" xml:space="preserve">
+    <value>Elimina</value>
+  </data>
+  <data name="Tooltip_DeleteInfo" xml:space="preserve">
+    <value>Elimina questo Link</value>
+  </data>
+  <data name="Tooltip_EditTitle" xml:space="preserve">
+    <value>Modifica</value>
+  </data>
+  <data name="Tooltip_EditInfo" xml:space="preserve">
+    <value>Modificare i dettagli di questo Link</value>
+  </data>
+  <data name="Tooltip_UpdateTitle" xml:space="preserve">
+    <value>Aggiornamento</value>
+  </data>
+  <data name="Tooltip_UpdateTvDB" xml:space="preserve">
+    <value>Scarica i dati freschi da The TvDB e aggiornare il database locale</value>
+  </data>
+  <data name="Tooltip_ReportLinkTitle" xml:space="preserve">
+    <value>Segnala errore collegamento</value>
+  </data>
+  <data name="Tooltip_ReportLinkInfo" xml:space="preserve">
+    <value>Se questo è legato alla serie sbagliata Clicca qui per sapere gli sviluppatori</value>
+  </data>
+  <data name="Tooltip_UpdateTrakt" xml:space="preserve">
+    <value>Scarica i dati freschi dal Trakt e aggiornare il database locale</value>
+  </data>
+  <data name="Tooltip_Sync" xml:space="preserve">
+    <value>Sincronizzazione</value>
+  </data>
+  <data name="Tooltip_SyncTrakt" xml:space="preserve">
+    <value>Sincronizzare i dati di raccolta e storia con Trakt</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTitle" xml:space="preserve">
+    <value>Auto per disabili che collega</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTvDB" xml:space="preserve">
+    <value>Auto che collega da questo anime ad una serie di TvDB è attualmente disattivato</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTitle" xml:space="preserve">
+    <value>Auto collegamento abilitato</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTvDB" xml:space="preserve">
+    <value>Auto che collega da questo anime ad una serie di TvDB è attualmente abilitato. Se JMM Server rileva una raccomandazione stretta corrispondenza o comunità creerà automaticamente un link</value>
+  </data>
+  <data name="CommunityLinks_TraktTV" xml:space="preserve">
+    <value>Trakt TV</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTrakt" xml:space="preserve">
+    <value>Auto che collega da questo anime ad una serie di Trakt è attualmente disattivato</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTrakt" xml:space="preserve">
+    <value>Auto che collega da questo anime ad una serie di Trakt è attualmente abilitato. Se JMM Server rileva una raccomandazione stretta corrispondenza o comunità creerà automaticamente un link</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledMAL" xml:space="preserve">
+    <value>Auto che collega da questo anime ad una serie MAL è attualmente disattivato</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledMAL" xml:space="preserve">
+    <value>Auto che collega da questo anime ad una serie MAL è attualmente abilitato. Se JMM Server rileva una raccomandazione stretta corrispondenza o comunità creerà automaticamente un link</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTMDb" xml:space="preserve">
+    <value>Auto che collega da questo anime ad una serie di MovieDB è attualmente disattivato</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTMDb" xml:space="preserve">
+    <value>Auto che collega da questo anime ad una serie di MovieDB è attualmente abilitato. Se JMM Server rileva una raccomandazione stretta corrispondenza o comunità creerà automaticamente un link</value>
+  </data>
+  <data name="Tooltip_CommunityAdminTitle" xml:space="preserve">
+    <value>Admin di comunità</value>
+  </data>
+  <data name="Tooltip_CommunityAdminInfo" xml:space="preserve">
+    <value>Vai alla scheda di admin di comunità e modificare i collegamenti consigliati per questo anime</value>
+  </data>
+  <data name="Unrecognized_Rescan" xml:space="preserve">
+    <value>Ripetizione dell'analisi</value>
+  </data>
+  <data name="Unrecognized_ForceAniDB" xml:space="preserve">
+    <value>Informazioni sull'aggiornamento di forza da AniDB</value>
+  </data>
+  <data name="Unrecognized_Hash" xml:space="preserve">
+    <value>Hash</value>
+  </data>
+  <data name="Unrecognized_CRC32" xml:space="preserve">
+    <value>CRC32</value>
+  </data>
+  <data name="Unrecognized_Rehash" xml:space="preserve">
+    <value>Re-hash tutti</value>
+  </data>
+  <data name="Unrecognized_Logs" xml:space="preserve">
+    <value>Registri</value>
+  </data>
+  <data name="Unrecognized_NA" xml:space="preserve">
+    <value>NA</value>
+  </data>
+  <data name="Unrecognized_RefreshSeries" xml:space="preserve">
+    <value>Aggiorna elenco di serie</value>
+  </data>
+  <data name="Unrecognized_To" xml:space="preserve">
+    <value>A</value>
+  </data>
+  <data name="UpdateAniDB_UpdateLocal" xml:space="preserve">
+    <value>Aggiornare i dati di File locale AniDB</value>
+  </data>
+  <data name="UpdateAniDB_Info1" xml:space="preserve">
+    <value>Dati relativi ai file sono scaricati da AniDB e quindi memorizzati nel database locale quando è importare un file. In alcuni casi questi dati potrebbero non essere completi quando è scaricarlo. O dati aggiuntivi possono essere scaricate ma più recenti versioni di JMM. Questa utility vi permetterà di ottenere una nuova copia di tali informazioni da AniDB</value>
+  </data>
+  <data name="UpdateAniDB_MissingInfo" xml:space="preserve">
+    <value>File di aggiornamento con informazioni mancanti</value>
+  </data>
+  <data name="UpdateAniDB_Info2" xml:space="preserve">
+    <value>Dati mancanti si riferiscono di solito a codec e risoluzione informazioni mancanti. Si può vedere Risoluzione: 0x0 accanto a questi file</value>
+  </data>
+  <data name="UpdateAniDB_Version" xml:space="preserve">
+    <value>File di aggiornamento all'interno versione 2</value>
+  </data>
+  <data name="UpdateAniDB_Info3" xml:space="preserve">
+    <value>Versione interna 2 aggiunto le seguenti informazioni - versione del File (v2, v3 ecc), è censurato, è deprecato</value>
+  </data>
+  <data name="UpdateAniDB_Info4" xml:space="preserve">
+    <value>Invio di troppi comandi per AniDB, può causare un ban temporaneo. Utilizzare a proprio rischio</value>
+  </data>
+  <data name="UpdateAniDB_HowManyQueued" xml:space="preserve">
+    <value>Come molti comandi verranno accodati?</value>
+  </data>
+  <data name="UpdateAniDB_Queued" xml:space="preserve">
+    <value>Comandi di coda</value>
+  </data>
+  <data name="User_HideTags" xml:space="preserve">
+    <value>Nascondere le etichette</value>
+  </data>
+  <data name="User_ChangePassword" xml:space="preserve">
+    <value>Cambia Password</value>
+  </data>
+  <data name="Sort_Error" xml:space="preserve">
+    <value>Errore tentativo di ordinare l'elenco dei </value>
+  </data>
+  <data name="Sort_Using" xml:space="preserve">
+    <value> utilizzando </value>
+  </data>
+  <data name="Sort_Property" xml:space="preserve">
+    <value>Proprietà. </value>
+  </data>
+  <data name="Sort_Field" xml:space="preserve">
+    <value>campo </value>
+  </data>
+  <data name="Sort_Exception" xml:space="preserve">
+    <value>Eccezione in MultiSort durante l'ordinamento di un elenco di </value>
+  </data>
+  <data name="Sort_PassedEmpty" xml:space="preserve">
+    <value>MultiSort parametro rgSortBy è stato passato un nome di campo vuoto in rgSortBy [</value>
+  </data>
+  <data name="Selected_DoesNotExist" xml:space="preserve">
+    <value>Il file specificato o la cartella non esiste: </value>
+  </data>
+  <data name="ValueCompare_PropertyName" xml:space="preserve">
+    <value>Nome struttura </value>
+  </data>
+  <data name="ValueCompare_NotFound" xml:space="preserve">
+    <value> non trovato durante il tentativo di confrontare oggetti di tipo </value>
+  </data>
+  <data name="ValueCompare_FieldName" xml:space="preserve">
+    <value>Nome del campo </value>
+  </data>
+  <data name="Video_VLCError1" xml:space="preserve">
+    <value>Impossibile analizzare URI nel file ini VLC</value>
+  </data>
+  <data name="Video_VLCError2" xml:space="preserve">
+    <value>Il conteggio dei file recenti e i timestamp nel file ini VLC differiscono</value>
+  </data>
+  <data name="Video_Complete" xml:space="preserve">
+    <value>Completare</value>
+  </data>
+  <data name="Video_Position" xml:space="preserve">
+    <value>Posizione video per</value>
+  </data>
+  <data name="Video_HasChanged" xml:space="preserve">
+    <value>è stato modificato in</value>
+  </data>
+  <data name="Video_Updating" xml:space="preserve">
+    <value>Aggiornamento al visto da media player: </value>
+  </data>
+  <data name="AniDB_DataMissing" xml:space="preserve">
+    <value>Dati mancanti</value>
+  </data>
+  <data name="AniDB_Votes" xml:space="preserve">
+    <value>Voti</value>
+  </data>
+  <data name="AniDB_GotVids" xml:space="preserve">
+    <value>Ottenuto il vids per anime dal servizio:</value>
+  </data>
+  <data name="AniDB_In" xml:space="preserve">
+    <value>in</value>
+  </data>
+  <data name="AniDB_ForFans" xml:space="preserve">
+    <value>Per gli appassionati</value>
+  </data>
+  <data name="AniDB_Recommended" xml:space="preserve">
+    <value>Consigliato</value>
+  </data>
+  <data name="AniDB_MustSee" xml:space="preserve">
+    <value>Assolutamente da vedere</value>
+  </data>
+  <data name="AniDB_Collecting" xml:space="preserve">
+    <value>Raccolta:</value>
+  </data>
+  <data name="AniDB_Files" xml:space="preserve">
+    <value>File:</value>
+  </data>
+  <data name="AnimeEpisode_Previous" xml:space="preserve">
+    <value>Precedente episodio</value>
+  </data>
+  <data name="AnimeEpisode_Next" xml:space="preserve">
+    <value>Prossimo episodio</value>
+  </data>
+  <data name="AnimeEpisode_NoOverview" xml:space="preserve">
+    <value>Descrizione di episodio non disponibile</value>
+  </data>
+  <data name="Anime_Groups" xml:space="preserve">
+    <value>Gruppi</value>
+  </data>
+  <data name="Anime_Series" xml:space="preserve">
+    <value>Serie</value>
+  </data>
+  <data name="Anime_GroupName" xml:space="preserve">
+    <value>Nome del gruppo deve essere compilato</value>
+  </data>
+  <data name="Anime_SortName" xml:space="preserve">
+    <value>Nome dell'ordinamento deve essere compilato</value>
+  </data>
+  <data name="Anime_GotVids" xml:space="preserve">
+    <value>Ottenuto il vids per anime dal servizio:</value>
+  </data>
+  <data name="Anime_GotEpisodes" xml:space="preserve">
+    <value>Ottenuto dati episodio dal servizio:</value>
+  </data>
+  <data name="Anime_In" xml:space="preserve">
+    <value>in</value>
+  </data>
+  <data name="Anime_Contracts" xml:space="preserve">
+    <value>Ha ottenuto contratti di episodio:</value>
+  </data>
+  <data name="Anime_Sorted" xml:space="preserve">
+    <value>Ordinato secondo episodio contratti:</value>
+  </data>
+  <data name="AVDump_ToBe" xml:space="preserve">
+    <value>Da elaborare</value>
+  </data>
+  <data name="Group_Groups" xml:space="preserve">
+    <value>Gruppi</value>
+  </data>
+  <data name="Group_FilterName" xml:space="preserve">
+    <value>Nome del filtro deve essere compilato</value>
+  </data>
+  <data name="Ignore_RecDown" xml:space="preserve">
+    <value>Consigli - Download</value>
+  </data>
+  <data name="Ignore_RecWatch" xml:space="preserve">
+    <value>Consigli - orologio</value>
+  </data>
+  <data name="Ignore_AnimeID" xml:space="preserve">
+    <value>ID di anime:</value>
+  </data>
+  <data name="JMMServer_TraktAuth" xml:space="preserve">
+    <value>Trakt Auth</value>
+  </data>
+  <data name="JMMServer_Success" xml:space="preserve">
+    <value>Successo</value>
+  </data>
+  <data name="JMMServer_Error" xml:space="preserve">
+    <value>Errore</value>
+  </data>
+  <data name="Missing_Episode" xml:space="preserve">
+    <value>Episodio</value>
+  </data>
+  <data name="Missing_File" xml:space="preserve">
+    <value>File</value>
+  </data>
+  <data name="Playlist_Name" xml:space="preserve">
+    <value>Immettere il nome della playlist: </value>
+  </data>
+  <data name="Playlist_NameBlank" xml:space="preserve">
+    <value>Inserisci il nome di una playlist</value>
+  </data>
+  <data name="Recommendation_Missing" xml:space="preserve">
+    <value>Dati mancanti</value>
+  </data>
+  <data name="Recommendation_NoOverview" xml:space="preserve">
+    <value>Descrizione non disponibile</value>
+  </data>
+  <data name="uTorrent_NotConnected" xml:space="preserve">
+    <value>Non collegato</value>
+  </data>
+  <data name="uTorrent_Connecting" xml:space="preserve">
+    <value>Collegamento...</value>
+  </data>
+  <data name="Constants_Continue" xml:space="preserve">
+    <value>Continuare a guardare (SYSTEM)</value>
+  </data>
+  <data name="Constants_MainCharacter" xml:space="preserve">
+    <value>personaggio principale in</value>
+  </data>
+  <data name="Group_GroupCount" xml:space="preserve">
+    <value> Gruppi</value>
+  </data>
+  <data name="Tab_Playlists" xml:space="preserve">
+    <value>Playlist</value>
+  </data>
+  <data name="Playlist_NewPlaylist" xml:space="preserve">
+    <value>Nuova Playlist</value>
+  </data>
+  <data name="Tab_Bookmarks" xml:space="preserve">
+    <value>Segnalibri</value>
+  </data>
+  <data name="JMMServer_ImportFolders" xml:space="preserve">
+    <value>Importare le cartelle</value>
+  </data>
+  <data name="JMMServer_ServerStatus" xml:space="preserve">
+    <value>Stato del server</value>
+  </data>
+  <data name="Tooltip_ClearHash" xml:space="preserve">
+    <value>Deselezionare tutti i comandi di hash in coda</value>
+  </data>
+  <data name="JMMServer_Running" xml:space="preserve">
+    <value>In esecuzione</value>
+  </data>
+  <data name="JMMServer_Paused" xml:space="preserve">
+    <value>In pausa</value>
+  </data>
+  <data name="Tooltip_ClearGeneral" xml:space="preserve">
+    <value>Deselezionare tutti i comandi generali in coda</value>
+  </data>
+  <data name="Tooltip_ClearImages" xml:space="preserve">
+    <value>Deselezionare tutti i comandi di Scarica immagine server in coda</value>
+  </data>
+  <data name="JMMServer_ServerImage" xml:space="preserve">
+    <value>Coda di server immagini</value>
+  </data>
+  <data name="Tab_AniDBAVDump" xml:space="preserve">
+    <value>AniDB AV Dump</value>
+  </data>
+  <data name="Tab_FileSearch" xml:space="preserve">
+    <value>Ricerca di file</value>
+  </data>
+  <data name="Tab_FileRename" xml:space="preserve">
+    <value>Ridenominazione di file</value>
+  </data>
+  <data name="Tab_UpdateAniDB" xml:space="preserve">
+    <value>Aggiornare dati di AniDB</value>
+  </data>
+  <data name="Tab_CommunityData" xml:space="preserve">
+    <value>Dati della community</value>
+  </data>
+  <data name="Tab_MyVotes" xml:space="preserve">
+    <value>I miei voti</value>
+  </data>
+  <data name="VideoPlayer_MPCI" xml:space="preserve">
+    <value>Integrazione di Media Player Classic</value>
+  </data>
+  <data name="VideoPlayer_AutoFile" xml:space="preserve">
+    <value>Selezione automatica dei File</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_MAL" xml:space="preserve">
+    <value>Mia lista di Anime</value>
+  </data>
+  <data name="Tab_Downloads" xml:space="preserve">
+    <value>Download</value>
+  </data>
+  <data name="Downloads_uTorrentInfo" xml:space="preserve">
+    <value>Questo utilizza uTorrent WebUI API, che è necessario abilitare nel tuo client uTorrent prima</value>
+  </data>
+  <data name="Downloads_uTorrentWebUI" xml:space="preserve">
+    <value>uTorrent WebUI dettagli</value>
+  </data>
+  <data name="Downloads_TorrentBlackHole" xml:space="preserve">
+    <value>Impostazioni di buco nero torrent</value>
+  </data>
+  <data name="Downloads_TorrentDefault" xml:space="preserve">
+    <value>Fonti Torrent predefinito per la ricerca</value>
+  </data>
+  <data name="Downloads_BakaBT" xml:space="preserve">
+    <value>BakaBT impostazioni</value>
+  </data>
+  <data name="Downloads_AnimeBytes" xml:space="preserve">
+    <value>AnimeBytes impostazioni</value>
+  </data>
+  <data name="Downloads_BakaBTInfo" xml:space="preserve">
+    <value>BakaBT è un sito di torrent anime che si specializza in serie full download, ma richiede un account prima</value>
+  </data>
+  <data name="Downloads_AnimeBytesInfo" xml:space="preserve">
+    <value>AnimeBytes è un sito di torrent anime che si specializza in serie full download, ma richiede un account prima</value>
+  </data>
+  <data name="Downloads_GoTo" xml:space="preserve">
+    <value>Vai al sito</value>
+  </data>
+  <data name="Tab_Search" xml:space="preserve">
+    <value>Ricerca</value>
+  </data>
+  <data name="Tab_Community" xml:space="preserve">
+    <value>Comunità</value>
+  </data>
+  <data name="Main_Messages" xml:space="preserve">
+    <value>Messaggi</value>
+  </data>
+  <data name="Main_Paused" xml:space="preserve">
+    <value>In pausa a causa di BAN da AniDB (</value>
+  </data>
+  <data name="Main_User" xml:space="preserve">
+    <value>Utente</value>
+  </data>
+  <data name="Main_Feed" xml:space="preserve">
+    <value>Alimentazione</value>
+  </data>
+  <data name="Main_About" xml:space="preserve">
+    <value>Circa</value>
+  </data>
+  <data name="Tab_uTorrent" xml:space="preserve">
+    <value>uTorrent</value>
+  </data>
+  <data name="Tab_BrowseTorrents" xml:space="preserve">
+    <value>Sfoglia Torrents</value>
+  </data>
+  <data name="Tab_SearchTorrents" xml:space="preserve">
+    <value>Cerca torrenti</value>
+  </data>
+  <data name="Tab_Recommendations" xml:space="preserve">
+    <value>Consigli</value>
+  </data>
+  <data name="Tab_Settings" xml:space="preserve">
+    <value>Impostazioni</value>
+  </data>
+  <data name="Tab_SeriesInfo" xml:space="preserve">
+    <value>Info serie</value>
+  </data>
+  <data name="Tab_Comments" xml:space="preserve">
+    <value>Commenti degli utenti</value>
+  </data>
+  <data name="Tab_Files" xml:space="preserve">
+    <value>File</value>
+  </data>
+  <data name="Download_TorrentFolder" xml:space="preserve">
+    <value>Percorso della cartella torrent</value>
+  </data>
+  <data name="Search_TitleOnly" xml:space="preserve">
+    <value>Solo titolo</value>
+  </data>
+</root>

--- a/JMMClient/Properties/Resources.resx
+++ b/JMMClient/Properties/Resources.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -789,7 +789,7 @@
     <value>Video Extensions</value>
   </data>
   <data name="ImportSettings_WatchFiles" xml:space="preserve">
-    <value>Watch for new files</value>
+    <value>Watch For New Files</value>
   </data>
   <data name="MovieDB_FanartAutoDownload" xml:space="preserve">
     <value>Auto Download Fanart</value>
@@ -1671,22 +1671,22 @@
     <value>Reset Cookie</value>
   </data>
   <data name="BakaBTSeriesBody" xml:space="preserve">
-    <value>When searching for a series, BakaBT (and AnimeByt.es) will be the only torrent source used in the initial search</value>
+    <value>When searching for a series, BakaBT (and AnimeBytes) will be the only torrent source used in the initial search</value>
   </data>
   <data name="BakaBTSeriesTitle" xml:space="preserve">
-    <value>BakaBT (and AnimeByt.es) Only</value>
+    <value>BakaBT (and AnimeBytes) Only</value>
   </data>
   <data name="AnimeBytesResetBody" xml:space="preserve">
-    <value>Reset the cookie if you are not getting any results from AnimeByt.es when you should be. This will force a login to AnimeByt.es again.</value>
+    <value>Reset the cookie if you are not getting any results from AnimeBytes when you should be. This will force a login to AnimeBytes again.</value>
   </data>
   <data name="AnimeBytesResetTitle" xml:space="preserve">
     <value>Reset cookie</value>
   </data>
   <data name="AnimeBytesSeriesBody" xml:space="preserve">
-    <value>When searching for a series, AnimeByt.es (and BakaBT) will be the only torrent source used in the initial search</value>
+    <value>When searching for a series, AnimeBytes (and BakaBT) will be the only torrent source used in the initial search</value>
   </data>
   <data name="AnimeBytesSeriesTitle" xml:space="preserve">
-    <value>AnimeByt.es (and BakaBT) Only</value>
+    <value>AnimeBytes (and BakaBT) Only</value>
   </data>
   <data name="IsVariation" xml:space="preserve">
     <value>Is Variation</value>
@@ -1821,5 +1821,1361 @@ Mark Unknown - Leaves the file on your list, but changes the state to unkown.</v
   </data>
   <data name="Link_Site" xml:space="preserve">
     <value>http://jmediamanager.org/</value>
+  </data>
+  <data name="ReenterPassword" xml:space="preserve">
+    <value>Re-enter Password</value>
+  </data>
+  <data name="ChangePassword" xml:space="preserve">
+    <value>Change Password</value>
+  </data>
+  <data name="ChangingPassword" xml:space="preserve">
+    <value>Changing Password For: </value>
+  </data>
+  <data name="WhatDoesThisMean" xml:space="preserve">
+    <value>What Does This Mean?</value>
+  </data>
+  <data name="DetailedExplanation" xml:space="preserve">
+    <value>Click for detailed explanation of options</value>
+  </data>
+  <data name="CustomTag_Name" xml:space="preserve">
+    <value>Tag Name</value>
+  </data>
+  <data name="CustomTag_Description" xml:space="preserve">
+    <value>Tag Description</value>
+  </data>
+  <data name="Add" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="MissingEpisodes_AnimeName" xml:space="preserve">
+    <value>Anime Name</value>
+  </data>
+  <data name="MissingEpisodes_AnimeID" xml:space="preserve">
+    <value>Anime ID</value>
+  </data>
+  <data name="MissingEpisodes_EpisodeNumber" xml:space="preserve">
+    <value>Episode Number</value>
+  </data>
+  <data name="MissingEpisodes_EpisodeID" xml:space="preserve">
+    <value>Episode ID</value>
+  </data>
+  <data name="MissingEpisodes_GroupSummary" xml:space="preserve">
+    <value>Group Summary</value>
+  </data>
+  <data name="MissingEpisodes_AnimeLink" xml:space="preserve">
+    <value>Link to Anime</value>
+  </data>
+  <data name="MissingEpisodes_EpisodeLink" xml:space="preserve">
+    <value>Link to Episode</value>
+  </data>
+  <data name="MissingEpisodes_FileSummary" xml:space="preserve">
+    <value>File Summary</value>
+  </data>
+  <data name="NewSeries_AlreadyAttached" xml:space="preserve">
+    <value>A series is already attached to this anime</value>
+  </data>
+  <data name="NewSeries_Step1" xml:space="preserve">
+    <value>Step 1 - Select an Anime</value>
+  </data>
+  <data name="NewSeries_SearchBy" xml:space="preserve">
+    <value>Search by Title or ID</value>
+  </data>
+  <data name="NewSeries_Step2" xml:space="preserve">
+    <value>Select a Local Group</value>
+  </data>
+  <data name="NewSeries_BackToStep1" xml:space="preserve">
+    <value>Back to Step 1</value>
+  </data>
+  <data name="TryAgain" xml:space="preserve">
+    <value>Try Again!</value>
+  </data>
+  <data name="Random_Tags" xml:space="preserve">
+    <value>Tags</value>
+  </data>
+  <data name="Finish" xml:space="preserve">
+    <value>Finish</value>
+  </data>
+  <data name="Clear" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="Matches" xml:space="preserve">
+    <value>Matches</value>
+  </data>
+  <data name="Random_Watched" xml:space="preserve">
+    <value>Watched</value>
+  </data>
+  <data name="Random_Unwatched" xml:space="preserve">
+    <value>Unwatched</value>
+  </data>
+  <data name="Random_PartiallyWatched" xml:space="preserve">
+    <value>Partially Watched</value>
+  </data>
+  <data name="Random_CompleteOnly" xml:space="preserve">
+    <value>Complete ONLY</value>
+  </data>
+  <data name="Random_View" xml:space="preserve">
+    <value>View this Series</value>
+  </data>
+  <data name="RateSeries_Rate" xml:space="preserve">
+    <value>Rate Series:</value>
+  </data>
+  <data name="RateSeries_TraktShout" xml:space="preserve">
+    <value>Have your say on Trakt</value>
+  </data>
+  <data name="Search_Episodes" xml:space="preserve">
+    <value>Episodes:</value>
+  </data>
+  <data name="Search_StartingAt" xml:space="preserve">
+    <value>Starting At</value>
+  </data>
+  <data name="Search_ID" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="Search_Title" xml:space="preserve">
+    <value>Title</value>
+  </data>
+  <data name="Search_AniDBStart" xml:space="preserve">
+    <value>AniDB Start:</value>
+  </data>
+  <data name="Search_Trakt" xml:space="preserve">
+    <value>Trakt: </value>
+  </data>
+  <data name="Search_Approved" xml:space="preserve">
+    <value>Admin Approved</value>
+  </data>
+  <data name="Search_TvDB" xml:space="preserve">
+    <value>TvDB: </value>
+  </data>
+  <data name="Search_MAL" xml:space="preserve">
+    <value>MAL: </value>
+  </data>
+  <data name="SelectAniDBTitle_SelectName" xml:space="preserve">
+    <value>Select an override name</value>
+  </data>
+  <data name="SelectGroupSeries_Select" xml:space="preserve">
+    <value>Select a </value>
+  </data>
+  <data name="Select_MyAnimeList" xml:space="preserve">
+    <value>MyAnimeList</value>
+  </data>
+  <data name="Select_StartingEpisode" xml:space="preserve">
+    <value>Starting Episode #</value>
+  </data>
+  <data name="Select_EpisodeType" xml:space="preserve">
+    <value>Episode Type:</value>
+  </data>
+  <data name="Select_TraktTV" xml:space="preserve">
+    <value>Trakt TV</value>
+  </data>
+  <data name="Select_TvDBDetails" xml:space="preserve">
+    <value>Select TvDB Details</value>
+  </data>
+  <data name="Select_Season" xml:space="preserve">
+    <value>Season</value>
+  </data>
+  <data name="Select_DefaultLanguage" xml:space="preserve">
+    <value>Select the default language</value>
+  </data>
+  <data name="Update_Update" xml:space="preserve">
+    <value>JMM Desktop Update Available!</value>
+  </data>
+  <data name="Update_UpdatePage" xml:space="preserve">
+    <value>Update Page</value>
+  </data>
+  <data name="Update_Changelog" xml:space="preserve">
+    <value>Changelog</value>
+  </data>
+  <data name="Update_AvailableVersion" xml:space="preserve">
+    <value>Available Version</value>
+  </data>
+  <data name="Update_YourVersion" xml:space="preserve">
+    <value>Your Version</value>
+  </data>
+  <data name="ViewComments_FromTrakt" xml:space="preserve">
+    <value>From Trakt</value>
+  </data>
+  <data name="ViewComments_Username" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="ViewComments_CommentDate" xml:space="preserve">
+    <value>Comment Date</value>
+  </data>
+  <data name="ViewComments_Comments" xml:space="preserve">
+    <value>Comments</value>
+  </data>
+  <data name="ViewComments_Website" xml:space="preserve">
+    <value>View on Website</value>
+  </data>
+  <data name="JMMDesktop" xml:space="preserve">
+    <value>JMM Desktop</value>
+  </data>
+  <data name="MoreInformation" xml:space="preserve">
+    <value>More Information</value>
+  </data>
+  <data name="Metro_Continue" xml:space="preserve">
+    <value>Continue Watching</value>
+  </data>
+  <data name="Metro_New" xml:space="preserve">
+    <value>New Episodes</value>
+  </data>
+  <data name="Metro_Random" xml:space="preserve">
+    <value>Random Series</value>
+  </data>
+  <data name="Metro_Trakt" xml:space="preserve">
+    <value>Trakt Activity</value>
+  </data>
+  <data name="MarkedFavorite" xml:space="preserve">
+    <value>This group is marked as a favorite</value>
+  </data>
+  <data name="Community_TraktValid" xml:space="preserve">
+    <value>Check my links are still valid on Trakt</value>
+  </data>
+  <data name="Community_TraktRemoveBad" xml:space="preserve">
+    <value>Automatically remove bad information from the database (highly recommended)</value>
+  </data>
+  <data name="Community_CommunityCheck" xml:space="preserve">
+    <value>Check if my links are different from the community recommendations</value>
+  </data>
+  <data name="Community_ProblemStop" xml:space="preserve">
+    <value>Stop after finding this many problems</value>
+  </data>
+  <data name="Trakt" xml:space="preserve">
+    <value>Trakt</value>
+  </data>
+  <data name="Start" xml:space="preserve">
+    <value>Start</value>
+  </data>
+  <data name="Stop" xml:space="preserve">
+    <value>Stop</value>
+  </data>
+  <data name="Community_Filter" xml:space="preserve">
+    <value>Filter:</value>
+  </data>
+  <data name="Community_Refresh" xml:space="preserve">
+    <value>Refresh data for this series</value>
+  </data>
+  <data name="Community_SeriesName" xml:space="preserve">
+    <value>Series Name</value>
+  </data>
+  <data name="Community_Status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="Community_ValidTraktLink" xml:space="preserve">
+    <value>Valid Trakt Link</value>
+  </data>
+  <data name="Community_HasTraktLink" xml:space="preserve">
+    <value>Has Trakt Link</value>
+  </data>
+  <data name="Community_CommunityLink" xml:space="preserve">
+    <value>Community Link</value>
+  </data>
+  <data name="Community_Match" xml:space="preserve">
+    <value>Links Match?</value>
+  </data>
+  <data name="Download_Bookmark" xml:space="preserve">
+    <value>Bookmark this anime to download later</value>
+  </data>
+  <data name="Download_SeriesSearch" xml:space="preserve">
+    <value>Search for downloads for this series</value>
+  </data>
+  <data name="Download_Approval" xml:space="preserve">
+    <value>Approval</value>
+  </data>
+  <data name="Download_YourVote" xml:space="preserve">
+    <value>Your Vote</value>
+  </data>
+  <data name="Download_RecommendPrompt" xml:space="preserve">
+    <value>This utility shows you a list of recommended anime which are not in your collection based on your own ratings and feedback from AniDB users</value>
+  </data>
+  <data name="Torrent" xml:space="preserve">
+    <value>Torrent</value>
+  </data>
+  <data name="Torrents" xml:space="preserve">
+    <value>Torrents</value>
+  </data>
+  <data name="Download_Name" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="Download_Size" xml:space="preserve">
+    <value>Size</value>
+  </data>
+  <data name="Download_Seeders" xml:space="preserve">
+    <value>Seeders</value>
+  </data>
+  <data name="Download_Leechers" xml:space="preserve">
+    <value>Leechers</value>
+  </data>
+  <data name="Download_ExtraInfo" xml:space="preserve">
+    <value>Extra Info</value>
+  </data>
+  <data name="Download_WrongSeries" xml:space="preserve">
+    <value>Wrong Series?</value>
+  </data>
+  <data name="Tooltip_WrongSeries" xml:space="preserve">
+    <value>This is JMMs attempt to guess which series you are looking at so you can compare to your local collection. If you do not have the series in your collection it will be incorrect.</value>
+  </data>
+  <data name="Download_ResetCookie" xml:space="preserve">
+    <value>Reset Cookie</value>
+  </data>
+  <data name="Download_AnimeBytesOnly" xml:space="preserve">
+    <value>AnimeBytes ONLY for Series</value>
+  </data>
+  <data name="Download_BakaBTOnly" xml:space="preserve">
+    <value>BakaBT ONLY for Series</value>
+  </data>
+  <data name="Available" xml:space="preserve">
+    <value>Available</value>
+  </data>
+  <data name="Selected" xml:space="preserve">
+    <value>Selected</value>
+  </data>
+  <data name="Download_Source" xml:space="preserve">
+    <value>Source</value>
+  </data>
+  <data name="Download_Server" xml:space="preserve">
+    <value>Server</value>
+  </data>
+  <data name="Download_RefreshInterval" xml:space="preserve">
+    <value>Refresh Interval (seconds)</value>
+  </data>
+  <data name="Download_AutoRefresh" xml:space="preserve">
+    <value>Auto Refresh</value>
+  </data>
+  <data name="Download_UseBlackHole" xml:space="preserve">
+    <value>Use Torrent Black Hole</value>
+  </data>
+  <data name="Download_FolderLocation" xml:space="preserve">
+    <value>Folder Location</value>
+  </data>
+  <data name="Download_Hash" xml:space="preserve">
+    <value>Hash</value>
+  </data>
+  <data name="Download_Queue" xml:space="preserve">
+    <value>#</value>
+  </data>
+  <data name="Download_Done" xml:space="preserve">
+    <value>Done</value>
+  </data>
+  <data name="Download_Peers" xml:space="preserve">
+    <value>Peers</value>
+  </data>
+  <data name="Download_DownSpeed" xml:space="preserve">
+    <value>Down Speed</value>
+  </data>
+  <data name="Download_UpSpeed" xml:space="preserve">
+    <value>Upload Speed</value>
+  </data>
+  <data name="Download_Ratio" xml:space="preserve">
+    <value>Ratio</value>
+  </data>
+  <data name="Download_InvalidCred" xml:space="preserve">
+    <value>You haven't specified valid uTorrent credentials</value>
+  </data>
+  <data name="Download_EnterCred" xml:space="preserve">
+    <value>Please enter your credentials on the setting tab and then return</value>
+  </data>
+  <data name="Download_Priority" xml:space="preserve">
+    <value>Priority</value>
+  </data>
+  <data name="Download_Downloaded" xml:space="preserve">
+    <value>Downloaded</value>
+  </data>
+  <data name="Settings_DeleteAction" xml:space="preserve">
+    <value>Delete Action</value>
+  </data>
+  <data name="Settings_AutoUpdateInfo" xml:space="preserve">
+    <value>Automatically Update Files With Missing Info</value>
+  </data>
+  <data name="Settings_HideDownloadButton" xml:space="preserve">
+    <value>Hide Episode Download Button When You Already Have Files</value>
+  </data>
+  <data name="Settings_RecreateGroups" xml:space="preserve">
+    <value>Recreate All Groups</value>
+  </data>
+  <data name="Settings_ScanOnStart" xml:space="preserve">
+    <value>Scan Drop Folders On Start</value>
+  </data>
+  <data name="Settings_ImagePath" xml:space="preserve">
+    <value>Image Path</value>
+  </data>
+  <data name="Settings_SelectFolder" xml:space="preserve">
+    <value>Select Folder</value>
+  </data>
+  <data name="Settings_FilePort" xml:space="preserve">
+    <value>File Port</value>
+  </data>
+  <data name="WebCache_TraktLinks" xml:space="preserve">
+    <value>Trakt Links</value>
+  </data>
+  <data name="VideoPlayer_MPC" xml:space="preserve">
+    <value>Media Player Classic</value>
+  </data>
+  <data name="VideoPlayer_MPCNote" xml:space="preserve">
+    <value>For MPC Integration you must enable two options (1) Store settings to .ini file and (2) Keep history of recently watched files. See the following screenshot for more details. The location of MPC is usually something like C:\Program Files (x86)\Combined Community Codec Pack\MPC</value>
+  </data>
+  <data name="VideoPlayer_MPCOptions" xml:space="preserve">
+    <value>MPC Options</value>
+  </data>
+  <data name="VideoPlayer_VLC" xml:space="preserve">
+    <value>VLC</value>
+  </data>
+  <data name="VideoPlayer_VLCNote" xml:space="preserve">
+    <value>VLC 2.2+ records recent files and timestamps by default (and disabling is an 'Advanced' option). Older versions do not support 'Resume from last position' functionality. The location of the VLC .ini file is usually something like C:\Users\username\AppData\Roaming\vlc\vlc-qt-interface.ini</value>
+  </data>
+  <data name="VideoPlayer_VLCOptions" xml:space="preserve">
+    <value>VLC Options</value>
+  </data>
+  <data name="VideoPlayer_PotPlayer" xml:space="preserve">
+    <value>PotPlayer</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerNote" xml:space="preserve">
+    <value>For PotPlayer Integration you must enable the following options (1) Preferences &gt; General &gt; Store Settings to .ini file (2) Preferences &gt; Playback &gt; Play from latest point. See the following screenshot for more details. The location of the PlotPlayer .ini file is usually something like C:\Users\username\AppData\Roaming\PotPlayer64\PotPlayer64.ini</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerOptions" xml:space="preserve">
+    <value>PotPlayer Options</value>
+  </data>
+  <data name="VideoPlayer_MPCINI" xml:space="preserve">
+    <value>Select MPC INI Folder</value>
+  </data>
+  <data name="VideoPlayer_VLCINI" xml:space="preserve">
+    <value>Select VLC INI Folder</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerINI" xml:space="preserve">
+    <value>Select PotPlayer INI Folder</value>
+  </data>
+  <data name="VideoPlayer_MPCTest" xml:space="preserve">
+    <value>Test MPC File</value>
+  </data>
+  <data name="VideoPlayer_VLCTest" xml:space="preserve">
+    <value>Test VLC File</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerTest" xml:space="preserve">
+    <value>Test PotPlayer File</value>
+  </data>
+  <data name="VideoPlayer_AutoMark" xml:space="preserve">
+    <value>Automatically mark files as watched when the following percentage is watched</value>
+  </data>
+  <data name="VideoPlayer_MPCFolder" xml:space="preserve">
+    <value>MPC INI Folder</value>
+  </data>
+  <data name="VideoPlayer_VLCFolder" xml:space="preserve">
+    <value>VLC INI Folder</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerFolder" xml:space="preserve">
+    <value>PotPlayer INI Folder</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote1" xml:space="preserve">
+    <value>Automatic File Selection Preferences - this refers to when you have more than file for an episode</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote2" xml:space="preserve">
+    <value>For a playlist it needs to choose one file, which will be based on you preferences below.</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote3" xml:space="preserve">
+    <value>For a single episode you can enable auto file selection or have JMM prompt you to select a file whenever you have more than one</value>
+  </data>
+  <data name="VideoPlayer_AutoFileFirstEpisode" xml:space="preserve">
+    <value>Automatic File Selection - First episode in series</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNextEpisode" xml:space="preserve">
+    <value>Automatic File Selection - Subsequent episodes in series</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote4" xml:space="preserve">
+    <value>If you select 'Release Group From Previously Played Episode' in the above setting you also need to do the following</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote5" xml:space="preserve">
+    <value>Uncheck 'Set file as watched if episode is watched' Under Settings - Essential - Import Settings</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote6" xml:space="preserve">
+    <value>Always Mark a File as watched and not an episode</value>
+  </data>
+  <data name="VideoPlayer_AutoFileEnable" xml:space="preserve">
+    <value>Enable auto file selection on single episodes</value>
+  </data>
+  <data name="TvDB_WideBannerMax" xml:space="preserve">
+    <value>Maximum Wide Banners</value>
+  </data>
+  <data name="TvDB_PostersMax" xml:space="preserve">
+    <value>Maximum Posters</value>
+  </data>
+  <data name="Trakt_Enable" xml:space="preserve">
+    <value>Enable Trakt</value>
+  </data>
+  <data name="Trakt_PIN" xml:space="preserve">
+    <value>Trakt PIN</value>
+  </data>
+  <data name="Trakt_GetPIN" xml:space="preserve">
+    <value>Get Pin</value>
+  </data>
+  <data name="Trakt_Authorize" xml:space="preserve">
+    <value>Authorize JMM</value>
+  </data>
+  <data name="Trakt_CurrentToken" xml:space="preserve">
+    <value>Current token is valid until:</value>
+  </data>
+  <data name="Trakt_AutoFanart" xml:space="preserve">
+    <value>Auto Download Fanart</value>
+  </data>
+  <data name="Trakt_AutoPosters" xml:space="preserve">
+    <value>Auto Download Posters</value>
+  </data>
+  <data name="Trakt_AutoEpisodeImages" xml:space="preserve">
+    <value>Auto Download Episode Images</value>
+  </data>
+  <data name="MovieDB_MaxPosters" xml:space="preserve">
+    <value>Maximum Posters</value>
+  </data>
+  <data name="AnimeGroup_Random" xml:space="preserve">
+    <value>Random Episode</value>
+  </data>
+  <data name="AnimeGroup_AllSeries" xml:space="preserve">
+    <value>All Series</value>
+  </data>
+  <data name="AnimeGroup_DoubleClick" xml:space="preserve">
+    <value>Double click on a series to view it directly</value>
+  </data>
+  <data name="PinnedSeries_Simple" xml:space="preserve">
+    <value>Show Simplified View</value>
+  </data>
+  <data name="Playlist_Add" xml:space="preserve">
+    <value>Add to Playlist</value>
+  </data>
+  <data name="Series_Overview" xml:space="preserve">
+    <value>Overview</value>
+  </data>
+  <data name="Series_MoreInfo" xml:space="preserve">
+    <value>More Information</value>
+  </data>
+  <data name="Series_CustomTags" xml:space="preserve">
+    <value>Custom Tags</value>
+  </data>
+  <data name="Series_ManageCustom" xml:space="preserve">
+    <value>Manage Custom Tags</value>
+  </data>
+  <data name="Series_Tag" xml:space="preserve">
+    <value>Tag</value>
+  </data>
+  <data name="Series_Add" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="Series_Files" xml:space="preserve">
+    <value>Files</value>
+  </data>
+  <data name="Series_Folder" xml:space="preserve">
+    <value>Folder</value>
+  </data>
+  <data name="SeriesSimple_TraktLink" xml:space="preserve">
+    <value>Go this episode on Trakt.TV</value>
+  </data>
+  <data name="SeriesSimple_Comments" xml:space="preserve">
+    <value>Comments</value>
+  </data>
+  <data name="SeriesSimple_Play" xml:space="preserve">
+    <value>Play</value>
+  </data>
+  <data name="SeriesSimple_Watched" xml:space="preserve">
+    <value>Watched:</value>
+  </data>
+  <data name="SeriesSimple_From" xml:space="preserve">
+    <value>From:</value>
+  </data>
+  <data name="SeriesSimple_AlreadyHave" xml:space="preserve">
+    <value>You already have this anime in your collection</value>
+  </data>
+  <data name="SeriesSimple_Details" xml:space="preserve">
+    <value>Details:</value>
+  </data>
+  <data name="SeriesSimple_Voteup" xml:space="preserve">
+    <value>Vote Up</value>
+  </data>
+  <data name="SeriesSimple_VoteDown" xml:space="preserve">
+    <value>Vote Down</value>
+  </data>
+  <data name="SeriesSimple_FromTrakt" xml:space="preserve">
+    <value>From Trakt</value>
+  </data>
+  <data name="SeriesSimple_View" xml:space="preserve">
+    <value>View</value>
+  </data>
+  <data name="SeriesSimple_FromAniDB" xml:space="preserve">
+    <value>From AniDB</value>
+  </data>
+  <data name="SeriesSimple_Aired" xml:space="preserve">
+    <value>Aired</value>
+  </data>
+  <data name="SeriesSimple_Episodes" xml:space="preserve">
+    <value>Episodes</value>
+  </data>
+  <data name="SeriesSimple_MyVote" xml:space="preserve">
+    <value>My Vote</value>
+  </data>
+  <data name="SeriesSimple_PlayNext" xml:space="preserve">
+    <value>Play Next Episode</value>
+  </data>
+  <data name="SeriesSimple_PlayUnWatched" xml:space="preserve">
+    <value>Play All UnWatched (</value>
+  </data>
+  <data name="SeriesSimple_YourSay" xml:space="preserve">
+    <value>Have Your Say...</value>
+  </data>
+  <data name="SeriesSimple_Spoiler" xml:space="preserve">
+    <value>Spoiler</value>
+  </data>
+  <data name="SeriesSimple_CommentTrakt" xml:space="preserve">
+    <value>Comment on Trakt</value>
+  </data>
+  <data name="SeriesSimple_Characters" xml:space="preserve">
+    <value>Characters</value>
+  </data>
+  <data name="SeriesSimple_AlsoLike" xml:space="preserve">
+    <value>You may also like</value>
+  </data>
+  <data name="SeriesSimple_PeopleSaying" xml:space="preserve">
+    <value>What People Are Saying</value>
+  </data>
+  <data name="SeriesSimple_Loading" xml:space="preserve">
+    <value>Loading...</value>
+  </data>
+  <data name="AvDump_Remove" xml:space="preserve">
+    <value>Remove from list</value>
+  </data>
+  <data name="AvDump_Clear" xml:space="preserve">
+    <value>Clear list</value>
+  </data>
+  <data name="AvDump_Dump" xml:space="preserve">
+    <value>Dump files</value>
+  </data>
+  <data name="Bookmarks_Downloading" xml:space="preserve">
+    <value>Downloading</value>
+  </data>
+  <data name="Bookmarks_NotDownloading" xml:space="preserve">
+    <value>Not Downloading</value>
+  </data>
+  <data name="Dashboard_YourVote" xml:space="preserve">
+    <value>Your Vote</value>
+  </data>
+  <data name="Dashboard_Bookmark" xml:space="preserve">
+    <value>Bookmark this anime to download later</value>
+  </data>
+  <data name="Dashboard_Download" xml:space="preserve">
+    <value>Search for downloads for this series</value>
+  </data>
+  <data name="Dashboard_NoRecommend" xml:space="preserve">
+    <value>No recommendations could be found.</value>
+  </data>
+  <data name="Dashboard_DownloadVotes" xml:space="preserve">
+    <value>Download your votes now, or vote on an anime to start getting recommendations.</value>
+  </data>
+  <data name="Dashboard_SyncVotes" xml:space="preserve">
+    <value>Sync Votes</value>
+  </data>
+  <data name="Dashboard_Added" xml:space="preserve">
+    <value>Added</value>
+  </data>
+  <data name="Dashboard_Metro" xml:space="preserve">
+    <value>Metro Dashboard</value>
+  </data>
+  <data name="Dashboard_UpdateCalendar" xml:space="preserve">
+    <value>Update Calendar Data</value>
+  </data>
+  <data name="Dashboard_Recent" xml:space="preserve">
+    <value>Recent Additions</value>
+  </data>
+  <data name="Metro_Options" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="Metro_General" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="Metro_ImageType" xml:space="preserve">
+    <value>Image Type</value>
+  </data>
+  <data name="Metro_Sections" xml:space="preserve">
+    <value>Sections</value>
+  </data>
+  <data name="Metro_Items" xml:space="preserve">
+    <value>Items</value>
+  </data>
+  <data name="Metro_Refresh" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="PlayVideo" xml:space="preserve">
+    <value>Play Video</value>
+  </data>
+  <data name="Episode_MoreInfo" xml:space="preserve">
+    <value>More Info..</value>
+  </data>
+  <data name="Episode_LessInfo" xml:space="preserve">
+    <value>Less Info..</value>
+  </data>
+  <data name="Episode_Manual" xml:space="preserve">
+    <value>Manual Link</value>
+  </data>
+  <data name="Episode_ForceAniDBUpdate" xml:space="preserve">
+    <value>Force update information from AniDB</value>
+  </data>
+  <data name="Episode_RecalculateHash" xml:space="preserve">
+    <value>Re-Calculate Hash</value>
+  </data>
+  <data name="Episode_Hash" xml:space="preserve">
+    <value>Hash</value>
+  </data>
+  <data name="Episode_CRC32" xml:space="preserve">
+    <value>CRC32</value>
+  </data>
+  <data name="Episode_SHA1" xml:space="preserve">
+    <value>SHA1</value>
+  </data>
+  <data name="Episode_MD5" xml:space="preserve">
+    <value>MD5</value>
+  </data>
+  <data name="Episode_DownloadSearch" xml:space="preserve">
+    <value>Search downloads for this episode</value>
+  </data>
+  <data name="Episode_PlaylistAdd" xml:space="preserve">
+    <value>Add to Playlist</value>
+  </data>
+  <data name="Episode_TvDBOverride" xml:space="preserve">
+    <value>Override the TvDB link for this episode</value>
+  </data>
+  <data name="Episode_TvDBRemove" xml:space="preserve">
+    <value>Remove the TvDB link for this episode</value>
+  </data>
+  <data name="Episode_AniDBForceUpdate" xml:space="preserve">
+    <value>Force update information from AniDB</value>
+  </data>
+  <data name="Episode_Type" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="Episode_Availability" xml:space="preserve">
+    <value>Availability</value>
+  </data>
+  <data name="Episode_WatchedState" xml:space="preserve">
+    <value>Watched State</value>
+  </data>
+  <data name="Rename_Script" xml:space="preserve">
+    <value>Script</value>
+  </data>
+  <data name="Rename_New" xml:space="preserve">
+    <value>New</value>
+  </data>
+  <data name="Rename_Save" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="Rename_Delete" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="Rename_Tag" xml:space="preserve">
+    <value>Tag</value>
+  </data>
+  <data name="Rename_Add" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="Rename_Test" xml:space="preserve">
+    <value>Test</value>
+  </data>
+  <data name="Rename_ScriptingHelp" xml:space="preserve">
+    <value>Help with scripting</value>
+  </data>
+  <data name="Rename_ImportRun" xml:space="preserve">
+    <value>Run this script when importing files into collection</value>
+  </data>
+  <data name="Rename_Filter" xml:space="preserve">
+    <value>Filter:</value>
+  </data>
+  <data name="Rename_Clear" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="Rename_AddFiles" xml:space="preserve">
+    <value>Add Files</value>
+  </data>
+  <data name="Rename_Rename" xml:space="preserve">
+    <value>Rename Now</value>
+  </data>
+  <data name="Rename_Preview" xml:space="preserve">
+    <value>Preview</value>
+  </data>
+  <data name="FileSearch_Rescan" xml:space="preserve">
+    <value>Rescan</value>
+  </data>
+  <data name="FileSearch_AniDBForceUpdate" xml:space="preserve">
+    <value>Force update information from AniDB</value>
+  </data>
+  <data name="GroupFilter_RandomSeries" xml:space="preserve">
+    <value>Random Series</value>
+  </data>
+  <data name="GroupFilter_RandomEpisode" xml:space="preserve">
+    <value>Random Episode</value>
+  </data>
+  <data name="IgnoredAnime_Delete" xml:space="preserve">
+    <value>Delete this entry</value>
+  </data>
+  <data name="IgnoredAnime_Note" xml:space="preserve">
+    <value>This utility will show you all the anime you have chosen to ignore from the recommendations. Deleting these records means they may show in recommendations again.</value>
+  </data>
+  <data name="ImportFolder_Watched" xml:space="preserve">
+    <value>This folder is being watched for new files</value>
+  </data>
+  <data name="MissingEpisodes_SelectColumns" xml:space="preserve">
+    <value>Select the columns to be used in the import</value>
+  </data>
+  <data name="MissingEpisodes_AiringState" xml:space="preserve">
+    <value>Airing State:</value>
+  </data>
+  <data name="RefreshWait" xml:space="preserve">
+    <value>Pressing the refresh button can take several minutes, so please be patient</value>
+  </data>
+  <data name="MissingEpisodes_Note" xml:space="preserve">
+    <value>This utility will show you a summary of all your missing episodes.</value>
+  </data>
+  <data name="MissingMyList_Missing" xml:space="preserve">
+    <value>View Missing File</value>
+  </data>
+  <data name="MissingMyList_RemoveAll" xml:space="preserve">
+    <value>Remove All Entries From AniDB</value>
+  </data>
+  <data name="MissingMyList_Note" xml:space="preserve">
+    <value>This utility will download your list of files from AniDB, and compare it to the files locally. You will then have the chance to remove those files from AniDB if they don't exist.</value>
+  </data>
+  <data name="Episode" xml:space="preserve">
+    <value>Episode</value>
+  </data>
+  <data name="Playlist_Random" xml:space="preserve">
+    <value>Random Episode</value>
+  </data>
+  <data name="Playlist_Default" xml:space="preserve">
+    <value>Default Play Order</value>
+  </data>
+  <data name="Playlist_Items" xml:space="preserve">
+    <value>Playlist Items</value>
+  </data>
+  <data name="PlayNext_Hidden" xml:space="preserve">
+    <value>Hidden to prevent spoilers</value>
+  </data>
+  <data name="Rankings_Overall" xml:space="preserve">
+    <value>By Overall User Rating</value>
+  </data>
+  <data name="Rankings_GroupedByYear" xml:space="preserve">
+    <value>Grouped By Year</value>
+  </data>
+  <data name="Rankings_CollectionState" xml:space="preserve">
+    <value>Collection State</value>
+  </data>
+  <data name="Rankings_Voted" xml:space="preserve">
+    <value>Voted</value>
+  </data>
+  <data name="Rankings_Completed" xml:space="preserve">
+    <value>Completed</value>
+  </data>
+  <data name="Rankings_Anime" xml:space="preserve">
+    <value> Anime</value>
+  </data>
+  <data name="Rankings_AniDB" xml:space="preserve">
+    <value>AniDB Rating</value>
+  </data>
+  <data name="Rankings_User" xml:space="preserve">
+    <value>Your Rating</value>
+  </data>
+  <data name="Rankings_Year" xml:space="preserve">
+    <value>Year</value>
+  </data>
+  <data name="Rankings_View" xml:space="preserve">
+    <value>View Series</value>
+  </data>
+  <data name="Rankings_MyVote" xml:space="preserve">
+    <value>My Vote</value>
+  </data>
+  <data name="Related_Bookmark" xml:space="preserve">
+    <value>Bookmark this anime to download later</value>
+  </data>
+  <data name="Related_Search" xml:space="preserve">
+    <value>Search for downloads for this series</value>
+  </data>
+  <data name="SeriesWithoutFiles_Delete" xml:space="preserve">
+    <value>Delete this series from the database</value>
+  </data>
+  <data name="SeriesWithoutFiles_Note" xml:space="preserve">
+    <value>This utility will show you all the series which do not have any files. Deleting the series will also delete the group if no other series in that group have files.</value>
+  </data>
+  <data name="TraktShouts_View" xml:space="preserve">
+    <value>View</value>
+  </data>
+  <data name="TraktShouts_FromAniDB" xml:space="preserve">
+    <value>From AniDB</value>
+  </data>
+  <data name="TraktShouts_Spoiler" xml:space="preserve">
+    <value>Spoiler</value>
+  </data>
+  <data name="TraktShouts_Loading" xml:space="preserve">
+    <value>Loading...</value>
+  </data>
+  <data name="TraktShouts_Comments" xml:space="preserve">
+    <value>Comments</value>
+  </data>
+  <data name="CommunityLinks_Start" xml:space="preserve">
+    <value>Start:</value>
+  </data>
+  <data name="CommunityLinks_Edit" xml:space="preserve">
+    <value>Edit Details</value>
+  </data>
+  <data name="CommunityLinks_AniDBStart" xml:space="preserve">
+    <value>AniDB Start:</value>
+  </data>
+  <data name="CommunityLinks_TvDB" xml:space="preserve">
+    <value>TvDB: </value>
+  </data>
+  <data name="CommunityLinks_Trakt" xml:space="preserve">
+    <value>Trakt: </value>
+  </data>
+  <data name="CommunityLinks_TMDb" xml:space="preserve">
+    <value>The Movie DB</value>
+  </data>
+  <data name="CommunityLinks_MAL" xml:space="preserve">
+    <value>MyAnimeList</value>
+  </data>
+  <data name="CommunityLinks_AutoLink" xml:space="preserve">
+    <value>Auto Link</value>
+  </data>
+  <data name="Tooltip_DeleteTitle" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="Tooltip_DeleteInfo" xml:space="preserve">
+    <value>Delete this Link</value>
+  </data>
+  <data name="Tooltip_EditTitle" xml:space="preserve">
+    <value>Edit</value>
+  </data>
+  <data name="Tooltip_EditInfo" xml:space="preserve">
+    <value>Edit the details of this Link</value>
+  </data>
+  <data name="Tooltip_UpdateTitle" xml:space="preserve">
+    <value>Update</value>
+  </data>
+  <data name="Tooltip_UpdateTvDB" xml:space="preserve">
+    <value>Download fresh data from The TvDB and update the local database</value>
+  </data>
+  <data name="Tooltip_ReportLinkTitle" xml:space="preserve">
+    <value>Report Linking Error</value>
+  </data>
+  <data name="Tooltip_ReportLinkInfo" xml:space="preserve">
+    <value>If this is linked to the wrong series click here to let the developers know</value>
+  </data>
+  <data name="Tooltip_UpdateTrakt" xml:space="preserve">
+    <value>Download fresh data from Trakt and update the local database</value>
+  </data>
+  <data name="Tooltip_Sync" xml:space="preserve">
+    <value>Sync</value>
+  </data>
+  <data name="Tooltip_SyncTrakt" xml:space="preserve">
+    <value>Sync your collection and history data with Trakt</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTitle" xml:space="preserve">
+    <value>Auto Linking Disabled</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTvDB" xml:space="preserve">
+    <value>Auto linking from this anime to a TvDB series is currently disabled</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTitle" xml:space="preserve">
+    <value>Auto Linking Enabled</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTvDB" xml:space="preserve">
+    <value>Auto linking from this anime to a TvDB series is currently enabled. If JMM Server finds a close match or community recommendation it will automatically create a link</value>
+  </data>
+  <data name="CommunityLinks_TraktTV" xml:space="preserve">
+    <value>Trakt TV</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTrakt" xml:space="preserve">
+    <value>Auto linking from this anime to a Trakt series is currently disabled</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTrakt" xml:space="preserve">
+    <value>Auto linking from this anime to a Trakt series is currently enabled. If JMM Server finds a close match or community recommendation it will automatically create a link</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledMAL" xml:space="preserve">
+    <value>Auto linking from this anime to a MAL series is currently disabled</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledMAL" xml:space="preserve">
+    <value>Auto linking from this anime to a MAL series is currently enabled. If JMM Server finds a close match or community recommendation it will automatically create a link</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTMDb" xml:space="preserve">
+    <value>Auto linking from this anime to a MovieDB series is currently disabled</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTMDb" xml:space="preserve">
+    <value>Auto linking from this anime to a MovieDB series is currently enabled. If JMM Server finds a close match or community recommendation it will automatically create a link</value>
+  </data>
+  <data name="Tooltip_CommunityAdminTitle" xml:space="preserve">
+    <value>Community Admin</value>
+  </data>
+  <data name="Tooltip_CommunityAdminInfo" xml:space="preserve">
+    <value>Go to the Community admin tab and edit the recommended links for this anime</value>
+  </data>
+  <data name="Unrecognized_Rescan" xml:space="preserve">
+    <value>Rescan</value>
+  </data>
+  <data name="Unrecognized_ForceAniDB" xml:space="preserve">
+    <value>Force update information from AniDB</value>
+  </data>
+  <data name="Unrecognized_Hash" xml:space="preserve">
+    <value>Hash</value>
+  </data>
+  <data name="Unrecognized_CRC32" xml:space="preserve">
+    <value>CRC32</value>
+  </data>
+  <data name="Unrecognized_Rehash" xml:space="preserve">
+    <value>Re-hash All</value>
+  </data>
+  <data name="Unrecognized_Logs" xml:space="preserve">
+    <value>Logs</value>
+  </data>
+  <data name="Unrecognized_NA" xml:space="preserve">
+    <value>NA</value>
+  </data>
+  <data name="Unrecognized_RefreshSeries" xml:space="preserve">
+    <value>Refresh Series List</value>
+  </data>
+  <data name="Unrecognized_To" xml:space="preserve">
+    <value>to</value>
+  </data>
+  <data name="UpdateAniDB_UpdateLocal" xml:space="preserve">
+    <value>Update Local AniDB File Data</value>
+  </data>
+  <data name="UpdateAniDB_Info1" xml:space="preserve">
+    <value>Data relating to files is downloaded from AniDB and then stored in your local database when you first import a file. In some cases this data may not be complete when you first download it. Or extra data may be downloaded but newer versions of JMM. This utility will allow you to get a fresh copy of that information from AniDB</value>
+  </data>
+  <data name="UpdateAniDB_MissingInfo" xml:space="preserve">
+    <value>Update Files with Missing Info</value>
+  </data>
+  <data name="UpdateAniDB_Info2" xml:space="preserve">
+    <value>Missing data usually relates to missing codec and resolution information. You may see Resolution: 0x0 next to these files</value>
+  </data>
+  <data name="UpdateAniDB_Version" xml:space="preserve">
+    <value>Update files to Internal Version 2</value>
+  </data>
+  <data name="UpdateAniDB_Info3" xml:space="preserve">
+    <value>Internal Version 2 added the following information - File version (v2, v3 etc), Is Censored, Is Deprecated</value>
+  </data>
+  <data name="UpdateAniDB_Info4" xml:space="preserve">
+    <value>Sending too many commands to AniDB, may cause a temporary ban. Use at your own risk</value>
+  </data>
+  <data name="UpdateAniDB_HowManyQueued" xml:space="preserve">
+    <value>How Many Commands Will Be Queued?</value>
+  </data>
+  <data name="UpdateAniDB_Queued" xml:space="preserve">
+    <value>Queue Commands</value>
+  </data>
+  <data name="User_HideTags" xml:space="preserve">
+    <value>Hide Tags</value>
+  </data>
+  <data name="User_ChangePassword" xml:space="preserve">
+    <value>Change Password</value>
+  </data>
+  <data name="Sort_Error" xml:space="preserve">
+    <value>Error trying to sort list of </value>
+  </data>
+  <data name="Sort_Using" xml:space="preserve">
+    <value> using </value>
+  </data>
+  <data name="Sort_Property" xml:space="preserve">
+    <value>property </value>
+  </data>
+  <data name="Sort_Field" xml:space="preserve">
+    <value>field </value>
+  </data>
+  <data name="Sort_Exception" xml:space="preserve">
+    <value>Exception in MultiSort while sorting a list of </value>
+  </data>
+  <data name="Sort_PassedEmpty" xml:space="preserve">
+    <value>MultiSort parameter rgSortBy was passed an empty field name in rgSortBy[</value>
+  </data>
+  <data name="Selected_DoesNotExist" xml:space="preserve">
+    <value>The specified file or folder doesn't exists : </value>
+  </data>
+  <data name="ValueCompare_PropertyName" xml:space="preserve">
+    <value>Property name </value>
+  </data>
+  <data name="ValueCompare_NotFound" xml:space="preserve">
+    <value> not found while trying to compare objects of type </value>
+  </data>
+  <data name="ValueCompare_FieldName" xml:space="preserve">
+    <value>Field name </value>
+  </data>
+  <data name="Video_VLCError1" xml:space="preserve">
+    <value>Unable to parse URI in VLC ini file</value>
+  </data>
+  <data name="Video_VLCError2" xml:space="preserve">
+    <value>The count of Recent Files and Timestamps in the VLC ini file differ</value>
+  </data>
+  <data name="Video_Complete" xml:space="preserve">
+    <value>Complete</value>
+  </data>
+  <data name="Video_Position" xml:space="preserve">
+    <value>Video position for</value>
+  </data>
+  <data name="Video_HasChanged" xml:space="preserve">
+    <value>has changed to</value>
+  </data>
+  <data name="Video_Updating" xml:space="preserve">
+    <value>Updating to watched by media player: </value>
+  </data>
+  <data name="AniDB_DataMissing" xml:space="preserve">
+    <value>Data Missing</value>
+  </data>
+  <data name="AniDB_Votes" xml:space="preserve">
+    <value>Votes</value>
+  </data>
+  <data name="AniDB_GotVids" xml:space="preserve">
+    <value>Got vids for anime from service:</value>
+  </data>
+  <data name="AniDB_In" xml:space="preserve">
+    <value>in</value>
+  </data>
+  <data name="AniDB_ForFans" xml:space="preserve">
+    <value>For Fans</value>
+  </data>
+  <data name="AniDB_Recommended" xml:space="preserve">
+    <value>Recommended</value>
+  </data>
+  <data name="AniDB_MustSee" xml:space="preserve">
+    <value>Must See</value>
+  </data>
+  <data name="AniDB_Collecting" xml:space="preserve">
+    <value>Collecting:</value>
+  </data>
+  <data name="AniDB_Files" xml:space="preserve">
+    <value>Files:</value>
+  </data>
+  <data name="AnimeEpisode_Previous" xml:space="preserve">
+    <value>Previous Episode</value>
+  </data>
+  <data name="AnimeEpisode_Next" xml:space="preserve">
+    <value>Next Episode</value>
+  </data>
+  <data name="AnimeEpisode_NoOverview" xml:space="preserve">
+    <value>Episode Overview Not Available</value>
+  </data>
+  <data name="Anime_Groups" xml:space="preserve">
+    <value>Groups</value>
+  </data>
+  <data name="Anime_Series" xml:space="preserve">
+    <value>Series</value>
+  </data>
+  <data name="Anime_GroupName" xml:space="preserve">
+    <value>Group name must be populated</value>
+  </data>
+  <data name="Anime_SortName" xml:space="preserve">
+    <value>Sort name must be populated</value>
+  </data>
+  <data name="Anime_GotVids" xml:space="preserve">
+    <value>Got vids for anime from service:</value>
+  </data>
+  <data name="Anime_GotEpisodes" xml:space="preserve">
+    <value>Got episode data from service:</value>
+  </data>
+  <data name="Anime_In" xml:space="preserve">
+    <value>in</value>
+  </data>
+  <data name="Anime_Contracts" xml:space="preserve">
+    <value>Got episode contracts:</value>
+  </data>
+  <data name="Anime_Sorted" xml:space="preserve">
+    <value>Sorted episode contracts:</value>
+  </data>
+  <data name="AVDump_ToBe" xml:space="preserve">
+    <value>To be processed</value>
+  </data>
+  <data name="Group_Groups" xml:space="preserve">
+    <value>Groups</value>
+  </data>
+  <data name="Group_FilterName" xml:space="preserve">
+    <value>Filter Name must be populated</value>
+  </data>
+  <data name="Ignore_RecDown" xml:space="preserve">
+    <value>Recommendations - Download</value>
+  </data>
+  <data name="Ignore_RecWatch" xml:space="preserve">
+    <value>Recommendations - Watch</value>
+  </data>
+  <data name="Ignore_AnimeID" xml:space="preserve">
+    <value>Anime ID:</value>
+  </data>
+  <data name="JMMServer_TraktAuth" xml:space="preserve">
+    <value>Trakt Auth</value>
+  </data>
+  <data name="JMMServer_Success" xml:space="preserve">
+    <value>Success</value>
+  </data>
+  <data name="JMMServer_Error" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="Missing_Episode" xml:space="preserve">
+    <value>Episode</value>
+  </data>
+  <data name="Missing_File" xml:space="preserve">
+    <value>File</value>
+  </data>
+  <data name="Playlist_Name" xml:space="preserve">
+    <value>Enter playlist name: </value>
+  </data>
+  <data name="Playlist_NameBlank" xml:space="preserve">
+    <value>Please enter a playlist name</value>
+  </data>
+  <data name="Recommendation_Missing" xml:space="preserve">
+    <value>Data Missing</value>
+  </data>
+  <data name="Recommendation_NoOverview" xml:space="preserve">
+    <value>Overview not available</value>
+  </data>
+  <data name="uTorrent_NotConnected" xml:space="preserve">
+    <value>Not Connected</value>
+  </data>
+  <data name="uTorrent_Connecting" xml:space="preserve">
+    <value>Connecting...</value>
+  </data>
+  <data name="Constants_Continue" xml:space="preserve">
+    <value>Continue Watching (SYSTEM)</value>
+  </data>
+  <data name="Constants_MainCharacter" xml:space="preserve">
+    <value>main character in</value>
+  </data>
+  <data name="Group_GroupCount" xml:space="preserve">
+    <value> Groups</value>
+  </data>
+  <data name="Tab_Playlists" xml:space="preserve">
+    <value>Playlists</value>
+  </data>
+  <data name="Playlist_NewPlaylist" xml:space="preserve">
+    <value>New Playlist</value>
+  </data>
+  <data name="Tab_Bookmarks" xml:space="preserve">
+    <value>Bookmarks</value>
+  </data>
+  <data name="JMMServer_ImportFolders" xml:space="preserve">
+    <value>Import Folders</value>
+  </data>
+  <data name="JMMServer_ServerStatus" xml:space="preserve">
+    <value>Server Status</value>
+  </data>
+  <data name="Tooltip_ClearHash" xml:space="preserve">
+    <value>Clear all queued hash commands</value>
+  </data>
+  <data name="JMMServer_Running" xml:space="preserve">
+    <value>Running</value>
+  </data>
+  <data name="JMMServer_Paused" xml:space="preserve">
+    <value>Paused</value>
+  </data>
+  <data name="Tooltip_ClearGeneral" xml:space="preserve">
+    <value>Clear all queued general commands</value>
+  </data>
+  <data name="Tooltip_ClearImages" xml:space="preserve">
+    <value>Clear all queued server image download commands</value>
+  </data>
+  <data name="JMMServer_ServerImage" xml:space="preserve">
+    <value>Server Images Queue</value>
+  </data>
+  <data name="Tab_AniDBAVDump" xml:space="preserve">
+    <value>AniDB AV Dump</value>
+  </data>
+  <data name="Tab_FileSearch" xml:space="preserve">
+    <value>File Search</value>
+  </data>
+  <data name="Tab_FileRename" xml:space="preserve">
+    <value>File Renaming</value>
+  </data>
+  <data name="Tab_UpdateAniDB" xml:space="preserve">
+    <value>Update AniDB Data</value>
+  </data>
+  <data name="Tab_CommunityData" xml:space="preserve">
+    <value>Community Data</value>
+  </data>
+  <data name="Tab_MyVotes" xml:space="preserve">
+    <value>My Votes</value>
+  </data>
+  <data name="VideoPlayer_MPCI" xml:space="preserve">
+    <value>Media Player Classic Integration</value>
+  </data>
+  <data name="VideoPlayer_AutoFile" xml:space="preserve">
+    <value>Automatic File Selection</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_MAL" xml:space="preserve">
+    <value>My Anime List</value>
+  </data>
+  <data name="Tab_Downloads" xml:space="preserve">
+    <value>Downloads</value>
+  </data>
+  <data name="Downloads_uTorrentInfo" xml:space="preserve">
+    <value>This uses the uTorrent WebUI API, which you need to enable in your uTorrent client first</value>
+  </data>
+  <data name="Downloads_uTorrentWebUI" xml:space="preserve">
+    <value>uTorrent WebUI details</value>
+  </data>
+  <data name="Downloads_TorrentBlackHole" xml:space="preserve">
+    <value>Torrent Black Hole Settings</value>
+  </data>
+  <data name="Downloads_TorrentDefault" xml:space="preserve">
+    <value>Default Torrent Sources for Searching</value>
+  </data>
+  <data name="Downloads_BakaBT" xml:space="preserve">
+    <value>BakaBT Settings</value>
+  </data>
+  <data name="Downloads_AnimeBytes" xml:space="preserve">
+    <value>AnimeBytes Settings</value>
+  </data>
+  <data name="Downloads_BakaBTInfo" xml:space="preserve">
+    <value>BakaBT is an anime torrent site which specializes in full series downloads, however it requires an account first</value>
+  </data>
+  <data name="Downloads_AnimeBytesInfo" xml:space="preserve">
+    <value>AnimeBytes is an anime torrent site which specializes in full series downloads, however it requires an account first</value>
+  </data>
+  <data name="Downloads_GoTo" xml:space="preserve">
+    <value>Go to Website</value>
+  </data>
+  <data name="Tab_Search" xml:space="preserve">
+    <value>Search</value>
+  </data>
+  <data name="Tab_Community" xml:space="preserve">
+    <value>Community</value>
+  </data>
+  <data name="Main_Messages" xml:space="preserve">
+    <value>Messages</value>
+  </data>
+  <data name="Main_Paused" xml:space="preserve">
+    <value>Paused due to BAN from AniDB (</value>
+  </data>
+  <data name="Main_User" xml:space="preserve">
+    <value>User</value>
+  </data>
+  <data name="Main_Feed" xml:space="preserve">
+    <value>Feed</value>
+  </data>
+  <data name="Main_About" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="Tab_uTorrent" xml:space="preserve">
+    <value>uTorrent</value>
+  </data>
+  <data name="Tab_BrowseTorrents" xml:space="preserve">
+    <value>Browse Torrents</value>
+  </data>
+  <data name="Tab_SearchTorrents" xml:space="preserve">
+    <value>Search Torrents</value>
+  </data>
+  <data name="Tab_Recommendations" xml:space="preserve">
+    <value>Recommendations</value>
+  </data>
+  <data name="Tab_Settings" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="Tab_SeriesInfo" xml:space="preserve">
+    <value>Series Info</value>
+  </data>
+  <data name="Tab_Comments" xml:space="preserve">
+    <value>Comments From Users</value>
+  </data>
+  <data name="Tab_Files" xml:space="preserve">
+    <value>Files</value>
+  </data>
+  <data name="Download_TorrentFolder" xml:space="preserve">
+    <value>Torrent Folder Location</value>
+  </data>
+  <data name="Search_TitleOnly" xml:space="preserve">
+    <value>Title Only</value>
   </data>
 </root>

--- a/JMMClient/Properties/Resources.ru.resx
+++ b/JMMClient/Properties/Resources.ru.resx
@@ -1,0 +1,3179 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AirDate" xml:space="preserve">
+    <value>Дата воздуха</value>
+  </data>
+  <data name="AniDBRating" xml:space="preserve">
+    <value>Рейтинг AniDB</value>
+  </data>
+  <data name="AniDBVoteCount" xml:space="preserve">
+    <value>Подсчет голосов AniDB</value>
+  </data>
+  <data name="Episodes" xml:space="preserve">
+    <value>Эпизоды</value>
+  </data>
+  <data name="EpisodeType" xml:space="preserve">
+    <value>Тип эпизод</value>
+  </data>
+  <data name="EpisodeType_Credits" xml:space="preserve">
+    <value>Кредиты</value>
+  </data>
+  <data name="EpisodeType_Normal" xml:space="preserve">
+    <value>Эпизоды</value>
+  </data>
+  <data name="EpisodeType_Other" xml:space="preserve">
+    <value>Другие</value>
+  </data>
+  <data name="EpisodeType_Parody" xml:space="preserve">
+    <value>Пародия</value>
+  </data>
+  <data name="EpisodeType_Specials" xml:space="preserve">
+    <value>Специальные предложения</value>
+  </data>
+  <data name="EpisodeType_Trailer" xml:space="preserve">
+    <value>Прицепы</value>
+  </data>
+  <data name="Favorite" xml:space="preserve">
+    <value>Любимый</value>
+  </data>
+  <data name="GroupFilter_All" xml:space="preserve">
+    <value>Все</value>
+  </data>
+  <data name="GroupFilter_Favorites" xml:space="preserve">
+    <value>Избранное</value>
+  </data>
+  <data name="IsWatched" xml:space="preserve">
+    <value>Смотрел</value>
+  </data>
+  <data name="MyRating" xml:space="preserve">
+    <value>MyRating</value>
+  </data>
+  <data name="Refresh" xml:space="preserve">
+    <value>Обновить</value>
+  </data>
+  <data name="RunTime" xml:space="preserve">
+    <value>Во время выполнения</value>
+  </data>
+  <data name="SortName" xml:space="preserve">
+    <value>Имя сортировки</value>
+  </data>
+  <data name="Series" xml:space="preserve">
+    <value>Серия</value>
+  </data>
+  <data name="TAB_Config" xml:space="preserve">
+    <value>Конфигурации</value>
+  </data>
+  <data name="TAB_Episodes" xml:space="preserve">
+    <value>Эпизоды</value>
+  </data>
+  <data name="TAB_FileManager" xml:space="preserve">
+    <value>Файловый менеджер</value>
+  </data>
+  <data name="TAB_Images" xml:space="preserve">
+    <value>Изображения</value>
+  </data>
+  <data name="TAB_Relations" xml:space="preserve">
+    <value>Отношения</value>
+  </data>
+  <data name="TAB_SeriesEpisodes" xml:space="preserve">
+    <value>Коллекция</value>
+  </data>
+  <data name="TAB_Server" xml:space="preserve">
+    <value>Сервера</value>
+  </data>
+  <data name="TAB_TvDB" xml:space="preserve">
+    <value>TvDB</value>
+  </data>
+  <data name="ViewLabel" xml:space="preserve">
+    <value>Вид: </value>
+  </data>
+  <data name="Back" xml:space="preserve">
+    <value>Назад</value>
+  </data>
+  <data name="Language" xml:space="preserve">
+    <value>Язык</value>
+  </data>
+  <data name="Delete" xml:space="preserve">
+    <value>Удалить</value>
+  </data>
+  <data name="RunImport" xml:space="preserve">
+    <value>Выполнить импорт</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Сохранить</value>
+  </data>
+  <data name="AnimeTitles" xml:space="preserve">
+    <value>Титулы</value>
+  </data>
+  <data name="AnimeTitlesMain" xml:space="preserve">
+    <value>Основной заголовок</value>
+  </data>
+  <data name="AnimeTitlesOfficial" xml:space="preserve">
+    <value>Официальный</value>
+  </data>
+  <data name="AnimeTitlesShort" xml:space="preserve">
+    <value>Короткие</value>
+  </data>
+  <data name="AnimeTitlesSynonym" xml:space="preserve">
+    <value>Синоним</value>
+  </data>
+  <data name="Categories" xml:space="preserve">
+    <value>Категории</value>
+  </data>
+  <data name="Tags" xml:space="preserve">
+    <value>Теги (может содержать спойлеры)</value>
+  </data>
+  <data name="CategoryWeighting" xml:space="preserve">
+    <value>Взвешивание</value>
+  </data>
+  <data name="TagApproval" xml:space="preserve">
+    <value>Утверждение</value>
+  </data>
+  <data name="Episodes_AvAll" xml:space="preserve">
+    <value>Все эпизоды</value>
+  </data>
+  <data name="Episodes_AvMissing" xml:space="preserve">
+    <value>Нет файлов Aavailable</value>
+  </data>
+  <data name="Episodes_AvOnly" xml:space="preserve">
+    <value>Только доступные файлы</value>
+  </data>
+  <data name="Episodes_Watched_All" xml:space="preserve">
+    <value>Все</value>
+  </data>
+  <data name="Episodes_Watched_Unwatched" xml:space="preserve">
+    <value>Непросмотренные</value>
+  </data>
+  <data name="Episodes_Watched_Watched" xml:space="preserve">
+    <value>Смотрел</value>
+  </data>
+  <data name="Play" xml:space="preserve">
+    <value>Играть</value>
+  </data>
+  <data name="Tooltip_FileFound" xml:space="preserve">
+    <value>Этот файл доступен</value>
+  </data>
+  <data name="Tooltip_FileNotFound" xml:space="preserve">
+    <value>Этот файл не существует</value>
+  </data>
+  <data name="Tooltip_FutureDated" xml:space="preserve">
+    <value>Этот эпизод не имеет пока трансляции</value>
+  </data>
+  <data name="Tooltip_Unwatched" xml:space="preserve">
+    <value>Жизнь - щелкните Пометить как смотрел</value>
+  </data>
+  <data name="Tooltip_Watched" xml:space="preserve">
+    <value>Смотрел - щелкните Пометить как непросмотренные</value>
+  </data>
+  <data name="Tooltip_ZeroFiles" xml:space="preserve">
+    <value>Нет файлов, доступных для этого эпизода</value>
+  </data>
+  <data name="Unwatched" xml:space="preserve">
+    <value>Непросмотренные</value>
+  </data>
+  <data name="Watched" xml:space="preserve">
+    <value>Смотрел</value>
+  </data>
+  <data name="Rating" xml:space="preserve">
+    <value>Рейтинг</value>
+  </data>
+  <data name="Votes" xml:space="preserve">
+    <value>Голоса</value>
+  </data>
+  <data name="AnimeType_Movie" xml:space="preserve">
+    <value>Фильм</value>
+  </data>
+  <data name="AnimeType_Other" xml:space="preserve">
+    <value>Другие</value>
+  </data>
+  <data name="AnimeType_OVA" xml:space="preserve">
+    <value>OVA</value>
+  </data>
+  <data name="AnimeType_TVSeries" xml:space="preserve">
+    <value>Сериал</value>
+  </data>
+  <data name="AnimeType_TVSpecial" xml:space="preserve">
+    <value>Специальный ТВ</value>
+  </data>
+  <data name="AnimeType_Web" xml:space="preserve">
+    <value>Веб</value>
+  </data>
+  <data name="Ongoing" xml:space="preserve">
+    <value>Текущие</value>
+  </data>
+  <data name="To" xml:space="preserve">
+    <value>Кому</value>
+  </data>
+  <data name="LastWatched" xml:space="preserve">
+    <value>Последний смотрел</value>
+  </data>
+  <data name="Today" xml:space="preserve">
+    <value>Сегодня</value>
+  </data>
+  <data name="Yesterday" xml:space="preserve">
+    <value>Вчера</value>
+  </data>
+  <data name="GroupsAvailableFrom" xml:space="preserve">
+    <value>Доступна с:</value>
+  </data>
+  <data name="Missing" xml:space="preserve">
+    <value>Отсутствует</value>
+  </data>
+  <data name="Tooltip_MissingEps" xml:space="preserve">
+    <value>Отсутствующие эпизоды из всех групп, релиз</value>
+  </data>
+  <data name="Tooltip_MissingEpsGroups" xml:space="preserve">
+    <value>Отсутствующие эпизодов от релиз группы, которые я собираю</value>
+  </data>
+  <data name="Tooltip_QueueImages" xml:space="preserve">
+    <value>Очереди ожидающих загрузки изображений</value>
+  </data>
+  <data name="Specials" xml:space="preserve">
+    <value>Специальные предложения</value>
+  </data>
+  <data name="GroupFilter_Missing" xml:space="preserve">
+    <value>Отсутствующие эпизодов</value>
+  </data>
+  <data name="RemoveMissingFiles" xml:space="preserve">
+    <value>Удалить отсутствующие файлы</value>
+  </data>
+  <data name="ServerActions" xml:space="preserve">
+    <value>Серверные действия</value>
+  </data>
+  <data name="NewGroup" xml:space="preserve">
+    <value>Новая группа</value>
+  </data>
+  <data name="AllFilters" xml:space="preserve">
+    <value>Все фильтры</value>
+  </data>
+  <data name="Filter" xml:space="preserve">
+    <value>Фильтр</value>
+  </data>
+  <data name="Group" xml:space="preserve">
+    <value>Группа</value>
+  </data>
+  <data name="AddSubGroup" xml:space="preserve">
+    <value>Новая группа Sub</value>
+  </data>
+  <data name="Edit" xml:space="preserve">
+    <value>Редактировать</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Отмена</value>
+  </data>
+  <data name="SubGroup" xml:space="preserve">
+    <value>Группа суб</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Параметры</value>
+  </data>
+  <data name="NewSeries" xml:space="preserve">
+    <value>Новая серия</value>
+  </data>
+  <data name="MoveSeries" xml:space="preserve">
+    <value>Перемещение серии</value>
+  </data>
+  <data name="MoveToGroup" xml:space="preserve">
+    <value>Перейти к выбранной группе</value>
+  </data>
+  <data name="OK" xml:space="preserve">
+    <value>Хорошо</value>
+  </data>
+  <data name="QueueGeneral" xml:space="preserve">
+    <value>Очередь AniDB</value>
+  </data>
+  <data name="QueueHasher" xml:space="preserve">
+    <value>Hasher очередь</value>
+  </data>
+  <data name="Tooltip_QueueGeneral" xml:space="preserve">
+    <value>AniDB команды в очереди</value>
+  </data>
+  <data name="Tooltip_QueueHasher" xml:space="preserve">
+    <value>Файлы, ожидающие хэшируемую</value>
+  </data>
+  <data name="Pause" xml:space="preserve">
+    <value>Пауза</value>
+  </data>
+  <data name="Resume" xml:space="preserve">
+    <value>Резюме</value>
+  </data>
+  <data name="Video_Bluray" xml:space="preserve">
+    <value>BluRay</value>
+  </data>
+  <data name="Video_DVD" xml:space="preserve">
+    <value>DVD</value>
+  </data>
+  <data name="Video_FullHD" xml:space="preserve">
+    <value>Full HD</value>
+  </data>
+  <data name="Video_HD" xml:space="preserve">
+    <value>HD</value>
+  </data>
+  <data name="NewFolder" xml:space="preserve">
+    <value>Новая папка</value>
+  </data>
+  <data name="DropDestination" xml:space="preserve">
+    <value>Удаление назначения</value>
+  </data>
+  <data name="DropSource" xml:space="preserve">
+    <value>Удалить источник</value>
+  </data>
+  <data name="ImportFolderName" xml:space="preserve">
+    <value>Имя папки импорта</value>
+  </data>
+  <data name="ImportFolderPath" xml:space="preserve">
+    <value>Путь к папке Импорт</value>
+  </data>
+  <data name="LocalMapping" xml:space="preserve">
+    <value>Локальное сопоставление</value>
+  </data>
+  <data name="LocalPath" xml:space="preserve">
+    <value>Локальный путь</value>
+  </data>
+  <data name="ServerDetails" xml:space="preserve">
+    <value>Подробные сведения о сервере</value>
+  </data>
+  <data name="MSG_ERR_DropSourceDestCheck" xml:space="preserve">
+    <value>Папка импорта не может быть источником перетаскивания и падение назначения</value>
+  </data>
+  <data name="MSG_ERR_ImportFolderLocationCheck" xml:space="preserve">
+    <value>Местоположение папки импорта не может быть пустым. Введите допустимый путь на сервере OMM</value>
+  </data>
+  <data name="TAB_UnrecognisedFiles" xml:space="preserve">
+    <value>Нераспознанные</value>
+  </data>
+  <data name="Confirm" xml:space="preserve">
+    <value>Подтвердите</value>
+  </data>
+  <data name="NothingSelected" xml:space="preserve">
+    <value>Ничего не выбрано</value>
+  </data>
+  <data name="SelectSeriesEp" xml:space="preserve">
+    <value>Выберите серии и эпизод</value>
+  </data>
+  <data name="AssociateFile" xml:space="preserve">
+    <value>Связывание файла с эпизод</value>
+  </data>
+  <data name="Ignore" xml:space="preserve">
+    <value>Игнорировать</value>
+  </data>
+  <data name="OpenFolder" xml:space="preserve">
+    <value>Открыть папку</value>
+  </data>
+  <data name="MSG_ERR_FileNotFound" xml:space="preserve">
+    <value>Не удалось найти файл</value>
+  </data>
+  <data name="FilesSelected" xml:space="preserve">
+    <value>Выбранные файлы</value>
+  </data>
+  <data name="StartingEpisodeNumber" xml:space="preserve">
+    <value>Стартовый номер эпизод</value>
+  </data>
+  <data name="Existing" xml:space="preserve">
+    <value>Существующие</value>
+  </data>
+  <data name="SelectGroup" xml:space="preserve">
+    <value>Выберите группу</value>
+  </data>
+  <data name="SelectAnime" xml:space="preserve">
+    <value>Выберите аниме AniDB</value>
+  </data>
+  <data name="New" xml:space="preserve">
+    <value>Новые функции</value>
+  </data>
+  <data name="GroupName" xml:space="preserve">
+    <value>Имя группы</value>
+  </data>
+  <data name="AniDBID" xml:space="preserve">
+    <value>AniDB ID</value>
+  </data>
+  <data name="MSG_ERR_AnimeIDRequired" xml:space="preserve">
+    <value>Пожалуйста, введите действительный идентификатор AniDB аниме</value>
+  </data>
+  <data name="MSG_ERR_AnimeSelectionRequired" xml:space="preserve">
+    <value>Пожалуйста, выберите существующий аниме</value>
+  </data>
+  <data name="MSG_ERR_GroupNameRequired" xml:space="preserve">
+    <value>Пожалуйста, введите имя группы</value>
+  </data>
+  <data name="MSG_ERR_GroupSelectionRequired" xml:space="preserve">
+    <value>Выберите существующую группу</value>
+  </data>
+  <data name="MSG_ERR_InvalidEpGetAnime" xml:space="preserve">
+    <value>Недопустимый диапазон эпизод номер, введенный вами, вы хотите обновить данные из AniDB?</value>
+  </data>
+  <data name="MSG_ERR_InvalidEp" xml:space="preserve">
+    <value>Недопустимый диапазон эпизод, которую вы ввели.</value>
+  </data>
+  <data name="DeleteLink" xml:space="preserve">
+    <value>Удалить связь</value>
+  </data>
+  <data name="Tooltip_DeleteLink" xml:space="preserve">
+    <value>Удалите связь между этот файл и эпизод.</value>
+  </data>
+  <data name="TAB_IgnoredFiles" xml:space="preserve">
+    <value>Игнорируется</value>
+  </data>
+  <data name="Restore" xml:space="preserve">
+    <value>Восстановление</value>
+  </data>
+  <data name="TAB_ManuallyLinked" xml:space="preserve">
+    <value>Связанный вручную</value>
+  </data>
+  <data name="AniDBLogin" xml:space="preserve">
+    <value>AniDB логин</value>
+  </data>
+  <data name="Client" xml:space="preserve">
+    <value>Клиент</value>
+  </data>
+  <data name="ImportFolders" xml:space="preserve">
+    <value>Импорт папки</value>
+  </data>
+  <data name="JMMServer" xml:space="preserve">
+    <value>Модель памяти JMM сервера</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Пароль</value>
+  </data>
+  <data name="Port" xml:space="preserve">
+    <value>Порт</value>
+  </data>
+  <data name="Server" xml:space="preserve">
+    <value>Сервера</value>
+  </data>
+  <data name="ServerPath" xml:space="preserve">
+    <value>Путь сервера</value>
+  </data>
+  <data name="TAB_SettingsAniDB" xml:space="preserve">
+    <value>AniDB</value>
+  </data>
+  <data name="TAB_SettingsDisplay" xml:space="preserve">
+    <value>Дисплей</value>
+  </data>
+  <data name="TAB_SettingsEssential" xml:space="preserve">
+    <value>Основные</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB" xml:space="preserve">
+    <value>Сайты сообществ</value>
+  </data>
+  <data name="Test" xml:space="preserve">
+    <value>Тест</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Имя пользователя</value>
+  </data>
+  <data name="TestAndSave" xml:space="preserve">
+    <value>Тест и сохранить</value>
+  </data>
+  <data name="Success" xml:space="preserve">
+    <value>Успех!</value>
+  </data>
+  <data name="INFO_SettingsEssential" xml:space="preserve">
+    <value>Все параметры на этой странице должны быть заполнены. Убедитесь, что проверить и сохранить модель памяти JMM сервера и AniDB детали перед продолжением. Если это ваш первый раз, запуск приложения введите по крайней мере один импорта папки и нажать кнопку выполнить импорт.</value>
+  </data>
+  <data name="Search" xml:space="preserve">
+    <value>Поиск</value>
+  </data>
+  <data name="Tooltip_GroupSearch" xml:space="preserve">
+    <value>Поиск группы по имени (на любом языке), категории или Теги</value>
+  </data>
+  <data name="AniDBDownloadChar" xml:space="preserve">
+    <value>Загрузка символов/создатели</value>
+  </data>
+  <data name="AniDBDownloadOptions" xml:space="preserve">
+    <value>Опции загрузки AniDB</value>
+  </data>
+  <data name="AniDBDownloadRelated" xml:space="preserve">
+    <value>Скачать похожие аниме</value>
+  </data>
+  <data name="AniDBDownloadReleaseGroups" xml:space="preserve">
+    <value>Скачать релиз группы</value>
+  </data>
+  <data name="AniDBDownloadReviews" xml:space="preserve">
+    <value>Скачать Отзывы</value>
+  </data>
+  <data name="AniDBDownloadSimilar" xml:space="preserve">
+    <value>Скачать аналогичные аниме</value>
+  </data>
+  <data name="AniDBMyListAddFiles" xml:space="preserve">
+    <value>Добавление файлов</value>
+  </data>
+  <data name="AniDBMylistOptions" xml:space="preserve">
+    <value>Параметры AniDB MyList</value>
+  </data>
+  <data name="AniDBMyListReadUnwatched" xml:space="preserve">
+    <value>Жизнь чтения</value>
+  </data>
+  <data name="AniDBMyListReadWatched" xml:space="preserve">
+    <value>Смотрел чтения</value>
+  </data>
+  <data name="AniDBMyListSetUnwatched" xml:space="preserve">
+    <value>Установите непросмотренные</value>
+  </data>
+  <data name="AniDBMyListSetWatched" xml:space="preserve">
+    <value>Набор смотрел</value>
+  </data>
+  <data name="AniDBMyListState" xml:space="preserve">
+    <value>Состояние хранения</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadChar" xml:space="preserve">
+    <value>Скачать информацию и изображения о персонажах и сэйю, которые появляются в аниме</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadRelated" xml:space="preserve">
+    <value>При загрузке сведений о аниме, также Скачайте информацию о всех соответствующих аниме. Это необходимо для правильной группы связанных аниме во время процесса импорта.</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadReleaseGroups" xml:space="preserve">
+    <value>Скачать подробную информацию о выпуске/заменял группы для вашего аниме</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadReviews" xml:space="preserve">
+    <value>Скачать аниме отзывы пользователей AniDB</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadSimilar" xml:space="preserve">
+    <value>При загрузке сведений о аниме, также Скачайте информацию о подобных и рекомендуемые названия</value>
+  </data>
+  <data name="Tooltip_AniDBMyListAddFiles" xml:space="preserve">
+    <value>Если при импорте файлов выбран, файлы будут добавлены на ваш счет AniDB</value>
+  </data>
+  <data name="Tooltip_AniDBMyListReadUnwatched" xml:space="preserve">
+    <value>Если файл имеет значение как ООН смотрел на AniDB, он также будет назначена ООН смотрел на вашей локальной коллекции</value>
+  </data>
+  <data name="Tooltip_AniDBMyListReadWatched" xml:space="preserve">
+    <value>Если файл имеет значение как смотрел на AniDB, он будет также установлено как смотрел на вашей локальной коллекции</value>
+  </data>
+  <data name="Tooltip_AniDBMyListSetUnwatched" xml:space="preserve">
+    <value>Когда вы вручную отметить видео как смотрел, также будут обновлены AniDB</value>
+  </data>
+  <data name="Tooltip_AniDBMyListSetWatched" xml:space="preserve">
+    <value>Когда вы закончить просмотр видео, или вручную отметить видео как смотрел, также будут обновлены AniDB</value>
+  </data>
+  <data name="Tooltip_AniDBMyListState" xml:space="preserve">
+    <value>Файлы хранения состояния будет присвоено значение при добавлении в список</value>
+  </data>
+  <data name="SyncMyList" xml:space="preserve">
+    <value>Синхронизация AniDB MyList</value>
+  </data>
+  <data name="Rehash" xml:space="preserve">
+    <value>Переделывать</value>
+  </data>
+  <data name="MSG_INFO_AddedQueueCmds" xml:space="preserve">
+    <value>Команды были добавлены в очередь</value>
+  </data>
+  <data name="MultiTypeRange" xml:space="preserve">
+    <value>Диапазона Эпизод</value>
+  </data>
+  <data name="MultiTypeSingle" xml:space="preserve">
+    <value>Один эпизод</value>
+  </data>
+  <data name="AniDBScheduleCalendar" xml:space="preserve">
+    <value>Автоматически обновлять календарь</value>
+  </data>
+  <data name="AniDBScheduleHTTP" xml:space="preserve">
+    <value>Автоматически обновлять информацию эпизод и аниме</value>
+  </data>
+  <data name="AniDBScheduleMyList" xml:space="preserve">
+    <value>Автоматически синхронизировать MyList информация</value>
+  </data>
+  <data name="AniDBScheduleOptions" xml:space="preserve">
+    <value>Обновление по расписанию</value>
+  </data>
+  <data name="Tooltip_AniDBScheduleCalendar" xml:space="preserve">
+    <value>Скачайте информацию о предстоящих аниме.</value>
+  </data>
+  <data name="Tooltip_AniDBScheduleHTTP" xml:space="preserve">
+    <value>Обновление сведений о аниме и получить новый эпизод информацию. Будут загружены только те данные, которые изменились с момента последнего обновления.</value>
+  </data>
+  <data name="Tooltip_AniDBScheduleMyList" xml:space="preserve">
+    <value>Синхронизировать информацию от AniDB согласно параметрам, указанным в разделе MyList.</value>
+  </data>
+  <data name="TAB_SettingsWebCache" xml:space="preserve">
+    <value>Веб-кэша</value>
+  </data>
+  <data name="DetailedInformationLink" xml:space="preserve">
+    <value>Следуйте по этой ссылке для углубленного объяснения</value>
+  </data>
+  <data name="Get" xml:space="preserve">
+    <value>Получить</value>
+  </data>
+  <data name="INFO_SettingsWebCache" xml:space="preserve">
+    <value>Веб-кэш является онлайн база данных, созданная разработчиками JMM и MyAnime. Его цель заключается в том, чтобы заполнить пробелы, которые другие базы данных не обслуживать, а также сделать процесс импорта быстрее путем обмена информацией с другими пользователями JMM.</value>
+  </data>
+  <data name="Send" xml:space="preserve">
+    <value>Отправить</value>
+  </data>
+  <data name="Tooltip_WebCache_Anonymous" xml:space="preserve">
+    <value>При выборе этого параметра AniDB пользователя не будет направляться веб-кэша. Однако это означает, что вы не будете получать пособие вспоминать свой собственный личный выбор.</value>
+  </data>
+  <data name="Tooltip_WebCache_FileEpisodes" xml:space="preserve">
+    <value>Когда файлы не отображаются в AniDB, веб-кэша может иметь информацию о эпизода, относящихся к этому файлу. Это особенно полезно, когда вы вручную связать файлы и не хотите потерять эту информацию.</value>
+  </data>
+  <data name="Tooltip_WebCache_FileHashes" xml:space="preserve">
+    <value>Попробуйте получить файл хэш от веб-кэша до перемешивании локально. Это может сэкономить много времени при импорте.</value>
+  </data>
+  <data name="Tooltip_WebCache_TvDBAssociations" xml:space="preserve">
+    <value>Используйте Web-кэша для искать связи между AniDB и TvDB. Если не выбран вам будет нужно вручную выполнить поиск всех TvDB ссылки.</value>
+  </data>
+  <data name="TvDB_FanartAutoDownload" xml:space="preserve">
+    <value>Автоматическая загрузка фанарт</value>
+  </data>
+  <data name="TvDB_FanartCount" xml:space="preserve">
+    <value>Максимальная Fanarts</value>
+  </data>
+  <data name="TvDB_PosterAutoDownload" xml:space="preserve">
+    <value>Автоматическая загрузка плакаты</value>
+  </data>
+  <data name="TvDB_WideBannerAutoDownload" xml:space="preserve">
+    <value>Автоматическая загрузка широкий баннеры</value>
+  </data>
+  <data name="WebCache_Anonymous" xml:space="preserve">
+    <value>Остаться анонимным</value>
+  </data>
+  <data name="WebCache_FileEpisodes" xml:space="preserve">
+    <value>Файл эпизод ссылки</value>
+  </data>
+  <data name="WebCache_FileHashes" xml:space="preserve">
+    <value>Хэши файлов</value>
+  </data>
+  <data name="WebCache_TvDBAssociations" xml:space="preserve">
+    <value>TvDB ссылки</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_MovieDB" xml:space="preserve">
+    <value>Фильм DB</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_TvDB" xml:space="preserve">
+    <value>TvDB</value>
+  </data>
+  <data name="Tooltip_TvDB_FanartAutoDownload" xml:space="preserve">
+    <value>Автоматически Загрузите новый фанарт, всякий раз, когда выполняется импорт.</value>
+  </data>
+  <data name="Tooltip_TvDB_FanartCount" xml:space="preserve">
+    <value>Максимальное количество фанарт изображения для загрузки</value>
+  </data>
+  <data name="Tooltip_TvDB_PosterAutoDownload" xml:space="preserve">
+    <value>Автоматически Загрузите новые плакаты, всякий раз, когда выполняется импорт.</value>
+  </data>
+  <data name="Tooltip_TvDB_WideBannerAutoDownload" xml:space="preserve">
+    <value>Автоматически Загрузите новые широкие баннеры, всякий раз, когда выполняется импорт.</value>
+  </data>
+  <data name="ImportSettings_HashCRC32" xml:space="preserve">
+    <value>Вычислить CRC32</value>
+  </data>
+  <data name="ImportSettings_HashMD5" xml:space="preserve">
+    <value>Вычислить MD5</value>
+  </data>
+  <data name="ImportSettings_ImportOnStart" xml:space="preserve">
+    <value>Импорт на старте</value>
+  </data>
+  <data name="ImportSettings_SHA1" xml:space="preserve">
+    <value>Вычисления SHA1</value>
+  </data>
+  <data name="ImportSettings_VideoExtensions" xml:space="preserve">
+    <value>Видео расширения</value>
+  </data>
+  <data name="ImportSettings_WatchFiles" xml:space="preserve">
+    <value>Часы для новых файлов</value>
+  </data>
+  <data name="MovieDB_FanartAutoDownload" xml:space="preserve">
+    <value>Автоматическая загрузка фанарт</value>
+  </data>
+  <data name="MovieDB_FanartCount" xml:space="preserve">
+    <value>Максимальная Fanarts</value>
+  </data>
+  <data name="MovieDB_PosterAutoDownload" xml:space="preserve">
+    <value>Автоматическая загрузка плакаты</value>
+  </data>
+  <data name="TAB_Settings_ImportSettings" xml:space="preserve">
+    <value>Параметры импорта</value>
+  </data>
+  <data name="Tooltip_MovieDB_FanartAutoDownload" xml:space="preserve">
+    <value>Автоматически Загрузите новый фанарт, всякий раз, когда выполняется импорт.</value>
+  </data>
+  <data name="Tooltip_MovieDB_FanartCount" xml:space="preserve">
+    <value>Максимальное количество фанарт изображения для загрузки</value>
+  </data>
+  <data name="Tooltip_MovieDB_PosterAutoDownload" xml:space="preserve">
+    <value>Автоматически Загрузите новые плакаты, всякий раз, когда выполняется импорт.</value>
+  </data>
+  <data name="Down" xml:space="preserve">
+    <value>Вниз</value>
+  </data>
+  <data name="LanguageUseSynonyms" xml:space="preserve">
+    <value>Также использовать синонимы</value>
+  </data>
+  <data name="TAB_Settings_Language" xml:space="preserve">
+    <value>Языковые предпочтения</value>
+  </data>
+  <data name="Tooltip_LanguageUseSynonyms" xml:space="preserve">
+    <value>Также используйте синонимы из выбранных предпочтительный язык для отображения серии и групп. Не будет использоваться английский и ромадзи синонимы</value>
+  </data>
+  <data name="Up" xml:space="preserve">
+    <value>Вверх</value>
+  </data>
+  <data name="GroupFilterConditions" xml:space="preserve">
+    <value>Условия фильтра</value>
+  </data>
+  <data name="GroupFilterConditionType" xml:space="preserve">
+    <value>Тип условия</value>
+  </data>
+  <data name="GroupFilterConditionType_AirDate" xml:space="preserve">
+    <value>Эфир</value>
+  </data>
+  <data name="GroupFilterConditionType_AllEpisodesWatched" xml:space="preserve">
+    <value>Все эпизоды смотрел</value>
+  </data>
+  <data name="GroupFilterConditionType_AnimeGroup" xml:space="preserve">
+    <value>Группа</value>
+  </data>
+  <data name="GroupFilterConditionType_AnimeType" xml:space="preserve">
+    <value>Тип аниме</value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedTvDBInfo" xml:space="preserve">
+    <value>TvDB ссылка</value>
+  </data>
+  <data name="GroupFilterConditionType_Category" xml:space="preserve">
+    <value>Категория</value>
+  </data>
+  <data name="GroupFilterConditionType_CompletedSeries" xml:space="preserve">
+    <value>Завершенные серии</value>
+  </data>
+  <data name="GroupFilterConditionType_Favourite" xml:space="preserve">
+    <value>Любимый</value>
+  </data>
+  <data name="GroupFilterConditionType_HasUnwatchedEpisodes" xml:space="preserve">
+    <value>Жизнь эпизоды</value>
+  </data>
+  <data name="GroupFilterConditionType_MissingEpisodes" xml:space="preserve">
+    <value>Отсутствующие эпизодов</value>
+  </data>
+  <data name="GroupFilterConditionType_ReleaseGroup" xml:space="preserve">
+    <value>Релиз группа</value>
+  </data>
+  <data name="GroupFilterConditionType_Studio" xml:space="preserve">
+    <value>Студия</value>
+  </data>
+  <data name="GroupFilterConditionType_Tag" xml:space="preserve">
+    <value>Тег</value>
+  </data>
+  <data name="GroupFilterConditionType_UserVoted" xml:space="preserve">
+    <value>Пользователь, проголосовали (Пермь)</value>
+  </data>
+  <data name="GroupFilterConditionType_VideoQuality" xml:space="preserve">
+    <value>Качество видео</value>
+  </data>
+  <data name="GroupFilterOperator" xml:space="preserve">
+    <value>Оператор</value>
+  </data>
+  <data name="GroupFilterOperator_Equals" xml:space="preserve">
+    <value>Равняется</value>
+  </data>
+  <data name="GroupFilterOperator_Exclude" xml:space="preserve">
+    <value>Исключить</value>
+  </data>
+  <data name="GroupFilterOperator_GreaterThan" xml:space="preserve">
+    <value>Больше или равно</value>
+  </data>
+  <data name="GroupFilterOperator_Include" xml:space="preserve">
+    <value>Включить</value>
+  </data>
+  <data name="GroupFilterOperator_LessThan" xml:space="preserve">
+    <value>Меньше или равно</value>
+  </data>
+  <data name="GroupFilterOperator_NotEquals" xml:space="preserve">
+    <value>Не равно</value>
+  </data>
+  <data name="GroupFilterSorting" xml:space="preserve">
+    <value>Сортировка</value>
+  </data>
+  <data name="ImageSize_GroupList" xml:space="preserve">
+    <value>Группы и список серии</value>
+  </data>
+  <data name="ImageSize_SeriesPoster" xml:space="preserve">
+    <value>Серия плакатов</value>
+  </data>
+  <data name="ImageSize_SubGroupList" xml:space="preserve">
+    <value>Sub групп списка и серии</value>
+  </data>
+  <data name="INFO_SettingsDisplayStyle" xml:space="preserve">
+    <value>Вам нужно будет обновить список группы, чтобы увидеть эффект изменения</value>
+  </data>
+  <data name="MSG_ERR_SelectDate" xml:space="preserve">
+    <value>Сначала выберите дату</value>
+  </data>
+  <data name="NewGroupFilter" xml:space="preserve">
+    <value>Новый групповой фильтр</value>
+  </data>
+  <data name="RenameGroups" xml:space="preserve">
+    <value>Переименование всех групп</value>
+  </data>
+  <data name="Style_GroupList" xml:space="preserve">
+    <value>Список групп</value>
+  </data>
+  <data name="Style_GroupList_MediumDetail" xml:space="preserve">
+    <value>Средний деталь</value>
+  </data>
+  <data name="Style_GroupList_Simple" xml:space="preserve">
+    <value>Простой</value>
+  </data>
+  <data name="TAB_SettingsImageSizes" xml:space="preserve">
+    <value>Размеры изображения</value>
+  </data>
+  <data name="TAB_SettingsStyle" xml:space="preserve">
+    <value>Стили</value>
+  </data>
+  <data name="Tooltip_ImageSize_GroupList" xml:space="preserve">
+    <value>Показано в основной список при просмотре групп и серии изображений</value>
+  </data>
+  <data name="Tooltip_ImageSize_SeriesPoster" xml:space="preserve">
+    <value>Изображения показаны в правой панели для всех серий, принадлежащих к группе</value>
+  </data>
+  <data name="Tooltip_ImageSize_SubGroupList" xml:space="preserve">
+    <value>Изображения, показано в основной список при просмотре подгрупп или серии</value>
+  </data>
+  <data name="Tooltip_Style_GroupList" xml:space="preserve">
+    <value>Стиль группы при отображении в списке основных (также подгруппы)</value>
+  </data>
+  <data name="FilterValue" xml:space="preserve">
+    <value>Значение фильтра</value>
+  </data>
+  <data name="MSG_ERR_EnterValue" xml:space="preserve">
+    <value>Введите значение</value>
+  </data>
+  <data name="PreviewFilter" xml:space="preserve">
+    <value>Предварительный просмотр результатов фильтра</value>
+  </data>
+  <data name="GroupFilter_ApplyToSeries" xml:space="preserve">
+    <value>Применить фильтр на уровне серии, а не группы</value>
+  </data>
+  <data name="GroupFilter_BaseCondition" xml:space="preserve">
+    <value>Базового условие</value>
+  </data>
+  <data name="GroupFilter_BaseCondition_ExcludeAll" xml:space="preserve">
+    <value>Исключить все</value>
+  </data>
+  <data name="GroupFilter_BaseCondition_IncludeAll" xml:space="preserve">
+    <value>Включить все</value>
+  </data>
+  <data name="Tooltip_GroupFilter_BaseCondition" xml:space="preserve">
+    <value>Включите все так, что все группы включены по умолчанию. Исключить все так, что группы не включены, это означало для использования, когда вы хотите, чтобы вручную указать группы на основе физических.</value>
+  </data>
+  <data name="GroupFilterOperator_In" xml:space="preserve">
+    <value>В</value>
+  </data>
+  <data name="GroupFilterOperator_NotIn" xml:space="preserve">
+    <value>Не в</value>
+  </data>
+  <data name="GroupFilter_Category_Help" xml:space="preserve">
+    <value>Дважды щелкните на категорий, чтобы добавить их к списку выбранных</value>
+  </data>
+  <data name="GroupFilterConditionType_AniDBRating" xml:space="preserve">
+    <value>Рейтинг - AniDB</value>
+  </data>
+  <data name="GroupFilterConditionType_UserRating" xml:space="preserve">
+    <value>Рейтинг - пользователя</value>
+  </data>
+  <data name="MSG_ERR_RatingValue" xml:space="preserve">
+    <value>Рейтинг должен быть значением от 0 до 10. Разрешены десятичные точки.</value>
+  </data>
+  <data name="ScanFolder" xml:space="preserve">
+    <value>Сканировать эту папку сейчас</value>
+  </data>
+  <data name="GroupFilterConditionType_EpisodeAddedDate" xml:space="preserve">
+    <value>Эпизод Добавлена Дата</value>
+  </data>
+  <data name="GroupFilterConditionType_EpisodeWatchedDate" xml:space="preserve">
+    <value>Эпизод посмотрели Дата</value>
+  </data>
+  <data name="GroupFilterConditionType_SeriesDate" xml:space="preserve">
+    <value>Дата добавлена серия</value>
+  </data>
+  <data name="GroupFilterOperator_LastXDays" xml:space="preserve">
+    <value>Последние X дней</value>
+  </data>
+  <data name="SelectDate" xml:space="preserve">
+    <value>Выберите дату</value>
+  </data>
+  <data name="MSG_ERR_DaysValue" xml:space="preserve">
+    <value>Пожалуйста, введите число дней, в как целое число (минимальное значение равно 1)</value>
+  </data>
+  <data name="SyncVotes" xml:space="preserve">
+    <value>Синхронизация AniDB голосов</value>
+  </data>
+  <data name="UserVote" xml:space="preserve">
+    <value>Мой голос</value>
+  </data>
+  <data name="VoteNow" xml:space="preserve">
+    <value>Проголосуйте сейчас</value>
+  </data>
+  <data name="VoteRevoke" xml:space="preserve">
+    <value>Отменить</value>
+  </data>
+  <data name="GroupFilterConditionType_FinishedAiring" xml:space="preserve">
+    <value>Готовые проветривания</value>
+  </data>
+  <data name="VoteTypeAnimePermanent" xml:space="preserve">
+    <value>Постоянный</value>
+  </data>
+  <data name="VoteTypeAnimeTemporary" xml:space="preserve">
+    <value>Временные</value>
+  </data>
+  <data name="AniDBMyListLocalActions" xml:space="preserve">
+    <value>Местные действия</value>
+  </data>
+  <data name="AniDBMyListSyncAndImport" xml:space="preserve">
+    <value>MyList Sync и параметры импорта</value>
+  </data>
+  <data name="EpisodeMarkAllUnwatched" xml:space="preserve">
+    <value>Марк все непросмотренные</value>
+  </data>
+  <data name="EpisodeMarkAllWatched" xml:space="preserve">
+    <value>Марк все смотрели</value>
+  </data>
+  <data name="EpisodeMarkAllWatchedPrevious" xml:space="preserve">
+    <value>Пометить все предыдущие смотрел, включая EP #</value>
+  </data>
+  <data name="GroupFilter_VideoQuality_Help" xml:space="preserve">
+    <value>Дважды щелкните на записи, чтобы добавить их в список</value>
+  </data>
+  <data name="GroupFilterConditionType_MissingEpisodesCollecting" xml:space="preserve">
+    <value>Отсутствующие эпизодов (сбор)</value>
+  </data>
+  <data name="GroupFilterOperator_InAllEpisodes" xml:space="preserve">
+    <value>В (все эпизоды)</value>
+  </data>
+  <data name="GroupFilterOperator_NotInAllEpisodes" xml:space="preserve">
+    <value>Не в (все эпизоды)</value>
+  </data>
+  <data name="GroupFilterConditionType_AudioLanguage" xml:space="preserve">
+    <value>Язык аудио</value>
+  </data>
+  <data name="GroupFilterConditionType_SubtitleLanguage" xml:space="preserve">
+    <value>Язык субтитров</value>
+  </data>
+  <data name="GroupFilterSortDirection_Asc" xml:space="preserve">
+    <value>ASC</value>
+  </data>
+  <data name="GroupFilterSortDirection_Desc" xml:space="preserve">
+    <value>По убыванию</value>
+  </data>
+  <data name="GroupFilterSorting_AniDBRating" xml:space="preserve">
+    <value>Рейтинг AniDB</value>
+  </data>
+  <data name="GroupFilterSorting_EpisodeAddedDate" xml:space="preserve">
+    <value>Эпизод Добавлена Дата</value>
+  </data>
+  <data name="GroupFilterSorting_EpisodeAirDate" xml:space="preserve">
+    <value>Дата воздуха эпизод</value>
+  </data>
+  <data name="GroupFilterSorting_EpisodeWatchedDate" xml:space="preserve">
+    <value>Эпизод посмотрели Дата</value>
+  </data>
+  <data name="GroupFilterSorting_GroupName" xml:space="preserve">
+    <value>Имя группы</value>
+  </data>
+  <data name="GroupFilterSorting_MissingEpisodeCount" xml:space="preserve">
+    <value>Количество пропавших эпизод</value>
+  </data>
+  <data name="GroupFilterSorting_SeriesAddedDate" xml:space="preserve">
+    <value>Дата добавлена серия</value>
+  </data>
+  <data name="GroupFilterSorting_SeriesCount" xml:space="preserve">
+    <value>Серии игр</value>
+  </data>
+  <data name="GroupFilterSorting_UnwatchedEpisodeCount" xml:space="preserve">
+    <value>Непросмотренные эпизод фото</value>
+  </data>
+  <data name="GroupFilterSorting_UserRating" xml:space="preserve">
+    <value>Рейтинг пользователей</value>
+  </data>
+  <data name="GroupFilterSorting_Year" xml:space="preserve">
+    <value>Год</value>
+  </data>
+  <data name="GroupFilterSorting_SortName" xml:space="preserve">
+    <value>Имя сортировки</value>
+  </data>
+  <data name="GroupFilterDirection" xml:space="preserve">
+    <value>Направление</value>
+  </data>
+  <data name="GroupFilterSortType" xml:space="preserve">
+    <value>Тип сортировки</value>
+  </data>
+  <data name="QuickSort" xml:space="preserve">
+    <value>Быстрая сортировка</value>
+  </data>
+  <data name="TAB_DuplicateFiles" xml:space="preserve">
+    <value>Дубликаты файлов</value>
+  </data>
+  <data name="INFO_DuplicateFiles" xml:space="preserve">
+    <value>Дублирующиеся файлы, где у вас есть два или более файлов, которые в точности совпадают, за исключением они находятся в разных папках или названы по-разному. Модель памяти JMM позволяет только один файл с хеш в коллекции.</value>
+  </data>
+  <data name="Tooltip_DeleteDuplicateFileAll" xml:space="preserve">
+    <value>Удаляет запись базы данных и выбранного файла на диске.</value>
+  </data>
+  <data name="Tooltip_DeleteDuplicateFileEntry" xml:space="preserve">
+    <value>Удалите только записи базы данных. Файлы на диске, не будут затронуты.</value>
+  </data>
+  <data name="Files" xml:space="preserve">
+    <value>Файлы</value>
+  </data>
+  <data name="ReevaluateDuplicateFiles" xml:space="preserve">
+    <value>Пересмотреть все записи</value>
+  </data>
+  <data name="Tooltip_ReevaluateDuplicateFiles" xml:space="preserve">
+    <value>Проверьте все записи дубликатов файлов, чтобы увидеть ли файлы по-прежнему существуют. Если не удалить запись базы данных</value>
+  </data>
+  <data name="TAB_MultipleFiles" xml:space="preserve">
+    <value>Несколько файлов</value>
+  </data>
+  <data name="INFO_MultipleFiles" xml:space="preserve">
+    <value>Несколько файлов, где у вас есть два или более файлов для тот же эпизод. Эта утилита позволит вам изучить все эти случаи и решить, какие из них вы хотите сохранить</value>
+  </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Загрузка...</value>
+  </data>
+  <data name="TotalFileCount" xml:space="preserve">
+    <value>Общее количество файлов</value>
+  </data>
+  <data name="ImportSettings_UseEpisodeStatus" xml:space="preserve">
+    <value>Установите файл как смотрел, если смотрел эпизод</value>
+  </data>
+  <data name="Tooltip_TvDB_Schedule_Updates" xml:space="preserve">
+    <value>Обновление информации каждые 12 часов серии и эпизод, а также скачать любой новый фанарт, плакаты и баннеры широкий</value>
+  </data>
+  <data name="TvDB_Schedule_Updates" xml:space="preserve">
+    <value>Обновление информации каждые 12 часов</value>
+  </data>
+  <data name="RescanAll" xml:space="preserve">
+    <value>Повторно сканировать все</value>
+  </data>
+  <data name="DeleteAll" xml:space="preserve">
+    <value>Удалить все</value>
+  </data>
+  <data name="CrossRefSummary" xml:space="preserve">
+    <value>TvDB и другие не ссылки AniDB</value>
+  </data>
+  <data name="FileSummary" xml:space="preserve">
+    <value>Файл резюме</value>
+  </data>
+  <data name="TheTvDB" xml:space="preserve">
+    <value>TvDB</value>
+  </data>
+  <data name="SeasonNumber" xml:space="preserve">
+    <value>Сезон #</value>
+  </data>
+  <data name="CommunityRecommendation" xml:space="preserve">
+    <value>Рекомендацию сообщества</value>
+  </data>
+  <data name="TvDBSearchPrompt" xml:space="preserve">
+    <value>Поиск по TvDB или введите ID серии TvDB</value>
+  </data>
+  <data name="TvDBShow" xml:space="preserve">
+    <value>Перейти к TvDB</value>
+  </data>
+  <data name="UseThis" xml:space="preserve">
+    <value>Используйте этот</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Закрыть</value>
+  </data>
+  <data name="SwitchSeason" xml:space="preserve">
+    <value>Переключатель сезон</value>
+  </data>
+  <data name="AniDB" xml:space="preserve">
+    <value>AniDB</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>Обновление</value>
+  </data>
+  <data name="UpdateAniDBInfo" xml:space="preserve">
+    <value>Обновление информации о AniDB</value>
+  </data>
+  <data name="UpdateInfo" xml:space="preserve">
+    <value>Обновление информации о</value>
+  </data>
+  <data name="ImageSize_EpisodeImage" xml:space="preserve">
+    <value>Эпизод изображение</value>
+  </data>
+  <data name="Tooltip_ImageSize_EpisodeImage" xml:space="preserve">
+    <value>Изображения показывают подробно эпизод</value>
+  </data>
+  <data name="EpisodeDetailStyle" xml:space="preserve">
+    <value>Эпизод деталь стиля</value>
+  </data>
+  <data name="EpisodeDetailStyle_Option1" xml:space="preserve">
+    <value>Изображения/обзор резюме</value>
+  </data>
+  <data name="EpisodeDetailStyle_Option2" xml:space="preserve">
+    <value>Изображения/обзор когда развернута только</value>
+  </data>
+  <data name="EpisodeDetailStyle_Option3" xml:space="preserve">
+    <value>Изображения/обзор инвалидов</value>
+  </data>
+  <data name="HideEpisodeImageWhenUnwatched" xml:space="preserve">
+    <value>Скрыть изображение эпизод, когда жизнь</value>
+  </data>
+  <data name="HideEpisodeOverviewWhenUnwatched" xml:space="preserve">
+    <value>Скрыть обзор эпизод, когда жизнь</value>
+  </data>
+  <data name="Tooltip_HideEpisodeImageWhenUnwatched" xml:space="preserve">
+    <value>Эпизод изображение будет скрыта до тех пор, пока смотрел эпизод</value>
+  </data>
+  <data name="Tooltip_HideEpisodeOverviewWhenUnwatched" xml:space="preserve">
+    <value>Обзор эпизод (описание) будут скрыты до тех пор, пока смотрел эпизод</value>
+  </data>
+  <data name="Fanart" xml:space="preserve">
+    <value>Фанарт</value>
+  </data>
+  <data name="Images" xml:space="preserve">
+    <value>Изображения</value>
+  </data>
+  <data name="Image_Disabled" xml:space="preserve">
+    <value>Изображения в настоящее время отключен</value>
+  </data>
+  <data name="Image_Dynamic" xml:space="preserve">
+    <value>Установите этот образ как единственный образ, который будет показан</value>
+  </data>
+  <data name="Image_Enabled" xml:space="preserve">
+    <value>Изображения в настоящее время включена</value>
+  </data>
+  <data name="Image_Static" xml:space="preserve">
+    <value>Это изображение является только изображение, которое будет показано</value>
+  </data>
+  <data name="Image_View" xml:space="preserve">
+    <value>Просмотр изображения</value>
+  </data>
+  <data name="Posters" xml:space="preserve">
+    <value>Плакаты</value>
+  </data>
+  <data name="WideBanners" xml:space="preserve">
+    <value>Широкий баннеры</value>
+  </data>
+  <data name="TheMovieDB" xml:space="preserve">
+    <value>Фильм DB</value>
+  </data>
+  <data name="MovieDBShow" xml:space="preserve">
+    <value>Перейти к MovieDB</value>
+  </data>
+  <data name="MovieDBSearchPrompt" xml:space="preserve">
+    <value>Поиск по MovieDB или введите MovieDB ID</value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedTvDBOrMovieDBInfo" xml:space="preserve">
+    <value>Имеет TvDB или ссылку MovieDB</value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedMovieDBInfo" xml:space="preserve">
+    <value>Ссылка MovieDB</value>
+  </data>
+  <data name="Image_Default" xml:space="preserve">
+    <value>Только этот образ будет использоваться</value>
+  </data>
+  <data name="Image_NotDefault" xml:space="preserve">
+    <value>Это изображение не является значением по умолчанию</value>
+  </data>
+  <data name="PlayNextEpisode" xml:space="preserve">
+    <value>Играть в следующем эпизоде</value>
+  </data>
+  <data name="AllEpisodesWatched" xml:space="preserve">
+    <value>Все эпизоды уже наблюдали</value>
+  </data>
+  <data name="FinishEditing" xml:space="preserve">
+    <value>Завершить редактирование</value>
+  </data>
+  <data name="TAB_Dashboard" xml:space="preserve">
+    <value>Панель мониторинга</value>
+  </data>
+  <data name="Dash_WatchNextEp_Recent" xml:space="preserve">
+    <value>Продолжить просмотр... (Недавно смотрел)</value>
+  </data>
+  <data name="DeleteSeries" xml:space="preserve">
+    <value>Удаление серии</value>
+  </data>
+  <data name="DeleteSeriesConfirm" xml:space="preserve">
+    <value>Вы уверены, что вы хотите удалить этой группы рядов?</value>
+  </data>
+  <data name="DeleteSeriesConfirm_Files" xml:space="preserve">
+    <value>Также удалите все физические файлы?</value>
+  </data>
+  <data name="Dash_SeriesMissingEps" xml:space="preserve">
+    <value>Отсутствующие эпизодов (по недавно смотрел)</value>
+  </data>
+  <data name="LatestEp_Anime" xml:space="preserve">
+    <value>Последний эпизод</value>
+  </data>
+  <data name="LatestEp_Yours" xml:space="preserve">
+    <value>Ваш последний эпизод</value>
+  </data>
+  <data name="MissingEpisodeCount" xml:space="preserve">
+    <value>Эпизоды пропавших без вести</value>
+  </data>
+  <data name="Dash_MiniCalendar" xml:space="preserve">
+    <value>Мини-календарь</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Логин</value>
+  </data>
+  <data name="ImageSize" xml:space="preserve">
+    <value>Размер изображения</value>
+  </data>
+  <data name="INFO_SettingsUserAdmin" xml:space="preserve">
+    <value>Добавление и редактирование пользователей здесь. Пользователи хранятся в базе данных и общими для различных клиентов. Вы всегда должны иметь по крайней мере один администратор.</value>
+  </data>
+  <data name="TAB_SettingsUsers" xml:space="preserve">
+    <value>Пользователи</value>
+  </data>
+  <data name="User_HideCategories" xml:space="preserve">
+    <value>Скрыть категории</value>
+  </data>
+  <data name="User_IsAdmin" xml:space="preserve">
+    <value>Администратор</value>
+  </data>
+  <data name="User_Password" xml:space="preserve">
+    <value>Пароль</value>
+  </data>
+  <data name="User_Username" xml:space="preserve">
+    <value>Имя пользователя</value>
+  </data>
+  <data name="Items" xml:space="preserve">
+    <value>Элементы</value>
+  </data>
+  <data name="Days" xml:space="preserve">
+    <value>Дней</value>
+  </data>
+  <data name="DashWatchNextStyle_Detailed" xml:space="preserve">
+    <value>Подробные</value>
+  </data>
+  <data name="DashWatchNextStyle_Simple" xml:space="preserve">
+    <value>Простой</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_Trakt" xml:space="preserve">
+    <value>Тракт ТВ</value>
+  </data>
+  <data name="Trakt_Password" xml:space="preserve">
+    <value>Пароль</value>
+  </data>
+  <data name="Trakt_Username" xml:space="preserve">
+    <value>Имя пользователя</value>
+  </data>
+  <data name="UpdateFrequency" xml:space="preserve">
+    <value>Автоматическое обновление данных</value>
+  </data>
+  <data name="UpdateFrequency_12Hours" xml:space="preserve">
+    <value>Каждые 12 часов</value>
+  </data>
+  <data name="UpdateFrequency_6Hours" xml:space="preserve">
+    <value>Каждые 6 часов</value>
+  </data>
+  <data name="UpdateFrequency_Daily" xml:space="preserve">
+    <value>Каждые 24 часа</value>
+  </data>
+  <data name="UpdateFrequency_Never" xml:space="preserve">
+    <value>Никогда не</value>
+  </data>
+  <data name="TraktSyncFrequency" xml:space="preserve">
+    <value>Автоматическая синхронизация коллекции</value>
+  </data>
+  <data name="TraktSearchPrompt" xml:space="preserve">
+    <value>Поиск на тракт или введите ID тракт (пули)</value>
+  </data>
+  <data name="TraktShow" xml:space="preserve">
+    <value>Перейти к тракт</value>
+  </data>
+  <data name="TAB_Pinned" xml:space="preserve">
+    <value>Удержал</value>
+  </data>
+  <data name="Tooltip_ViewSeries" xml:space="preserve">
+    <value>Открыть в новом окне этот аниме-сериал</value>
+  </data>
+  <data name="GroupFilterConditionType_UserVotedAny" xml:space="preserve">
+    <value>Пользователь, проголосовали (любой)</value>
+  </data>
+  <data name="Tooltip_User_IsAniDB" xml:space="preserve">
+    <value>Любой пользователь, помеченные как AniDB пользователя будет храниться в синхронизации с другими пользователями AniDB. Если пользователь не является пользователем AniDB наблюдали эпизоды не будут отражены на веб-сайте AniDB.</value>
+  </data>
+  <data name="User_IsAniDB" xml:space="preserve">
+    <value>Пользователь AniDB</value>
+  </data>
+  <data name="User_IsTrakt" xml:space="preserve">
+    <value>Trakt пользователя</value>
+  </data>
+  <data name="ERROR_SeriesExists" xml:space="preserve">
+    <value>Серия уже существует для этой аниме</value>
+  </data>
+  <data name="Tooltip_CreateSeries" xml:space="preserve">
+    <value>Создание серии для этого аниме</value>
+  </data>
+  <data name="SimilarAnime" xml:space="preserve">
+    <value>Подобные аниме</value>
+  </data>
+  <data name="RelatedAndSimilar" xml:space="preserve">
+    <value>Связанные и аналогичные</value>
+  </data>
+  <data name="GetMissingData" xml:space="preserve">
+    <value>Теперь получить недостающие данные</value>
+  </data>
+  <data name="NoSimilarAnime" xml:space="preserve">
+    <value>Без подобных аниме можно найти</value>
+  </data>
+  <data name="NoRelatedAnime" xml:space="preserve">
+    <value>Нет соответствующих аниме можно найти</value>
+  </data>
+  <data name="RelatedAnime" xml:space="preserve">
+    <value>Связанные аниме</value>
+  </data>
+  <data name="Dash_RecWatch" xml:space="preserve">
+    <value>Рекомендации для смотреть</value>
+  </data>
+  <data name="Dash_RecDownload" xml:space="preserve">
+    <value>Рекомендации для загрузки</value>
+  </data>
+  <data name="ImportSettings_AutoGroupSeries" xml:space="preserve">
+    <value>Автоматически поместить связанные серии в той же группе</value>
+  </data>
+  <data name="GroupFilterConditionType_HasWatchedEpisodes" xml:space="preserve">
+    <value>Наблюдал эпизодов</value>
+  </data>
+  <data name="MyList" xml:space="preserve">
+    <value>MyList</value>
+  </data>
+  <data name="Tooltip_MyList" xml:space="preserve">
+    <value>Принудительно добавьте этот файл в ваш список на AniDB</value>
+  </data>
+  <data name="TAB_MissingFiles" xml:space="preserve">
+    <value>Отсутствующие файлы MyList</value>
+  </data>
+  <data name="TAB_Utilities" xml:space="preserve">
+    <value>Утилиты</value>
+  </data>
+  <data name="TAB_SeriesWithoutFiles" xml:space="preserve">
+    <value>Серия без файлов</value>
+  </data>
+  <data name="DeleteSeriesConfirm_Groups" xml:space="preserve">
+    <value>Удаление любых родительских групп, если они пусты</value>
+  </data>
+  <data name="Export" xml:space="preserve">
+    <value>Экспорт</value>
+  </data>
+  <data name="TAB_MissingEpisodes" xml:space="preserve">
+    <value>Отсутствующие эпизодов</value>
+  </data>
+  <data name="MyGroupsOnly" xml:space="preserve">
+    <value>Только релиз групп, которые я собираю</value>
+  </data>
+  <data name="RegularEpisodesOnly" xml:space="preserve">
+    <value>Только регулярные эпизодов</value>
+  </data>
+  <data name="Dash_TraktFriends" xml:space="preserve">
+    <value>Друзья деятельности (Trakt ТВ)</value>
+  </data>
+  <data name="Tooltip_IgnoreAnimeDownload" xml:space="preserve">
+    <value>Игнорировать это аниме скачать рекомендации</value>
+  </data>
+  <data name="Tooltip_IgnoreAnimeWatch" xml:space="preserve">
+    <value>Игнорировать это аниме смотреть рекомендаций</value>
+  </data>
+  <data name="VisitWebsite" xml:space="preserve">
+    <value>Посетите веб-сайт</value>
+  </data>
+  <data name="AniDBSignup" xml:space="preserve">
+    <value>Зарегистрироваться сейчас AniDB</value>
+  </data>
+  <data name="AvdumpHeader" xml:space="preserve">
+    <value>AVDump2 (опционально)</value>
+  </data>
+  <data name="AvdumpInfoLink" xml:space="preserve">
+    <value>Более подробная информация о AVDump2</value>
+  </data>
+  <data name="AvdumpKey" xml:space="preserve">
+    <value>Ключ API</value>
+  </data>
+  <data name="AvdumpKeyEditLink" xml:space="preserve">
+    <value>Редактировать AVDump2 UDP API ключ здесь</value>
+  </data>
+  <data name="Avdump" xml:space="preserve">
+    <value>Avdump2</value>
+  </data>
+  <data name="AvdumpRequiredFilesLink" xml:space="preserve">
+    <value>Убедитесь, что у вас есть все необходимые файлы в той же папке, как модель памяти JMM Рабочий стол</value>
+  </data>
+  <data name="AvdumpSettingsError" xml:space="preserve">
+    <value>Не указан ваш ключ API и/или порт клиента</value>
+  </data>
+  <data name="AvdumpAddRelease" xml:space="preserve">
+    <value>Добавить новый релиз</value>
+  </data>
+  <data name="CopyED2KClipboard" xml:space="preserve">
+    <value>Скопировать ED2K дамп</value>
+  </data>
+  <data name="Tooltip_CopyED2KClipboard" xml:space="preserve">
+    <value>Скопировать в буфер обмена дамп ED2K</value>
+  </data>
+  <data name="TAB_IgnoredAnime" xml:space="preserve">
+    <value>Игнорируемые аниме</value>
+  </data>
+  <data name="Anime" xml:space="preserve">
+    <value>Аниме</value>
+  </data>
+  <data name="RemoveDefaultSeries" xml:space="preserve">
+    <value>Удалить по умолчанию серии</value>
+  </data>
+  <data name="SetDefaultSeries" xml:space="preserve">
+    <value>Добавление серии по умолчанию</value>
+  </data>
+  <data name="DefSeries1" xml:space="preserve">
+    <value>Выберите серии по умолчанию для</value>
+  </data>
+  <data name="DefSeries2" xml:space="preserve">
+    <value>Выбор серии по умолчанию означает, что будет использовать все изображения, которые являются dsiplayed для группы </value>
+  </data>
+  <data name="DefSeries3" xml:space="preserve">
+    <value>серии по умолчанию вместо случайных серии в группе</value>
+  </data>
+  <data name="ChangeLanguage" xml:space="preserve">
+    <value>Изменение языка</value>
+  </data>
+  <data name="EpisodeTitleSourceStyle" xml:space="preserve">
+    <value>Источник название эпизода</value>
+  </data>
+  <data name="SeriesNameSourceStyle" xml:space="preserve">
+    <value>Источник имя серии</value>
+  </data>
+  <data name="SeriesOverviewSourceStyle" xml:space="preserve">
+    <value>Обзор серии источник</value>
+  </data>
+  <data name="Tooltip_EpisodeTitleSourceStyle" xml:space="preserve">
+    <value>Предпочтительный источник информации при отображении название эпизода</value>
+  </data>
+  <data name="Tooltip_SeriesNameSourceStyle" xml:space="preserve">
+    <value>Предпочтительный источник информации при отображении имя серии аниме</value>
+  </data>
+  <data name="Tooltip_SeriesOverviewSourceStyle" xml:space="preserve">
+    <value>Предпочтительный источник информации при отображении обзор (описание) для аниме-сериал</value>
+  </data>
+  <data name="User_EditSettings" xml:space="preserve">
+    <value>Редактирование параметров сервера</value>
+  </data>
+  <data name="Tooltip_RemoveMissingFiles" xml:space="preserve">
+    <value>Это удалит все записи видео файлы из вашей базы данных, где физически не удается найти файл. Убедитесь, что все общие сетевые ресурсы доступны или накопители USB подключен перед запуском этого.</value>
+  </data>
+  <data name="Tooltip_UpdateMediaInfo" xml:space="preserve">
+    <value>СМИ информация-это информация о ваших файлов, такие как битрейт, резолюции кодеки и т.д., который считывается и сохраняется впервые вы импортировать файл</value>
+  </data>
+  <data name="UpdateMediaInfo" xml:space="preserve">
+    <value>Обновление всех СМИ информация</value>
+  </data>
+  <data name="Video_Hi10P" xml:space="preserve">
+    <value>10 бит</value>
+  </data>
+  <data name="Tooltip_TraktAnimeOnly" xml:space="preserve">
+    <value>Только показать активность связана с аниме (ie исключить другие сериалы)</value>
+  </data>
+  <data name="TraktAnimeOnly" xml:space="preserve">
+    <value>Аниме только</value>
+  </data>
+  <data name="ForceRefresh" xml:space="preserve">
+    <value>Принудительно обновить</value>
+  </data>
+  <data name="TraktFriendNotes" xml:space="preserve">
+    <value>Информация обновляется на сервере каждые 20 минут</value>
+  </data>
+  <data name="Dash_RecentEpisodes" xml:space="preserve">
+    <value>Недавно смотрел эпизодов</value>
+  </data>
+  <data name="PromptRateSeries" xml:space="preserve">
+    <value>Запрос на стоимость серии по завершении</value>
+  </data>
+  <data name="Tooltip_PromptRateSeries" xml:space="preserve">
+    <value>Всякий раз, когда вы смотреть последний эпизод в серии, чтобы попросить вас рейтинг появится запрос</value>
+  </data>
+  <data name="MALSearchPrompt" xml:space="preserve">
+    <value>Поиск по MyAnimelist или введите MAL ID</value>
+  </data>
+  <data name="MALShow" xml:space="preserve">
+    <value>Перейти к MyAnimeList</value>
+  </data>
+  <data name="Tooltip_WebCache_MALAssociations" xml:space="preserve">
+    <value>Используйте Web-кэша для искать связи между AniDB и MyAnimeList. Если не выбран вам будет нужно вручную выполнить поиск всех ссылок ТЗА.</value>
+  </data>
+  <data name="WebCache_MALAssociations" xml:space="preserve">
+    <value>MyAnimeList ссылки</value>
+  </data>
+  <data name="Tooltip_MAL_UpdateFrequency" xml:space="preserve">
+    <value>Как часто обновляются данные, и как часто выполняется автоматический поиск искать аниме в вашей коллекции, которая не имеет ссылку MAL</value>
+  </data>
+  <data name="GroupFilterConditionType_AssignedMALInfo" xml:space="preserve">
+    <value>MAL ссылка</value>
+  </data>
+  <data name="Tooltip_UseFanartOnSeries" xml:space="preserve">
+    <value>Фанарт пользователя вместо плакаты (где доступно) на дисплее серии</value>
+  </data>
+  <data name="UseFanartOnSeries" xml:space="preserve">
+    <value>Пользователь фанарт на дисплее серии</value>
+  </data>
+  <data name="MAL_NeverDecrease" xml:space="preserve">
+    <value>Никогда не уменьшение смотрел графов</value>
+  </data>
+  <data name="Tooltip_MAL_NeverDecrease" xml:space="preserve">
+    <value>Убедитесь, что смотрел, что счетчики всегда находятся. Это требует загрузки ваш полный список каждый раз, когда вы смотреть эпизод, так что может занять много времени</value>
+  </data>
+  <data name="GroupFilterConditionType_EpisodeCount" xml:space="preserve">
+    <value>Количество эпизод</value>
+  </data>
+  <data name="SyncMalDown" xml:space="preserve">
+    <value>Скачать смотрел государства от MAL</value>
+  </data>
+  <data name="SyncMalUp" xml:space="preserve">
+    <value>Загрузить смотрел государства MAL</value>
+  </data>
+  <data name="Tooltip_SyncMalDown" xml:space="preserve">
+    <value>Скачать смотрели государств от мал и обновить локальную коллекцию и AniDB.</value>
+  </data>
+  <data name="Tooltip_SyncMalUp" xml:space="preserve">
+    <value>Обновление с использованием смотрел статистику из вашей локальной коллекции</value>
+  </data>
+  <data name="Tooltip_WebCache_AniDB_File" xml:space="preserve">
+    <value>Это данные, связанные с каждым отдельным файлом. Рекомендуется для больших коллекций</value>
+  </data>
+  <data name="WebCache_AniDB_File" xml:space="preserve">
+    <value>Данные файла AniDB</value>
+  </data>
+  <data name="PlaylistPlayOrderRandom" xml:space="preserve">
+    <value>Случайный</value>
+  </data>
+  <data name="PlaylistPlayOrderSeq" xml:space="preserve">
+    <value>Последовательный</value>
+  </data>
+  <data name="AniDBScheduleMyListStats" xml:space="preserve">
+    <value>Автоматически получить статистику MyList от AniDB</value>
+  </data>
+  <data name="GroupFilter_Predefined" xml:space="preserve">
+    <value>Встроенные фильтры</value>
+  </data>
+  <data name="BakaBTResetBody" xml:space="preserve">
+    <value>Сбросьте cookie, если вы не получаете никаких результатов от BakaBT когда вы должны быть. Это заставит входа к BakaBT снова.</value>
+  </data>
+  <data name="BakaBTResetTitle" xml:space="preserve">
+    <value>Сбросить Cookie</value>
+  </data>
+  <data name="BakaBTSeriesBody" xml:space="preserve">
+    <value>При поиске для серии, BakaBT (и AnimeBytes) будет только торрент источник, используемый в первоначальный Поиск</value>
+  </data>
+  <data name="BakaBTSeriesTitle" xml:space="preserve">
+    <value>BakaBT (и AnimeBytes) только</value>
+  </data>
+  <data name="AnimeBytesResetBody" xml:space="preserve">
+    <value>Сбросьте cookie, если вы не получаете никаких результатов от AnimeBytes когда вы должны быть. Это заставит входа к AnimeBytes снова.</value>
+  </data>
+  <data name="AnimeBytesResetTitle" xml:space="preserve">
+    <value>Сбросить cookie</value>
+  </data>
+  <data name="AnimeBytesSeriesBody" xml:space="preserve">
+    <value>При поиске для серии, AnimeBytes (и BakaBT) будет только торрент источник, используемый в первоначальный Поиск</value>
+  </data>
+  <data name="AnimeBytesSeriesTitle" xml:space="preserve">
+    <value>AnimeBytes (и BakaBT) только</value>
+  </data>
+  <data name="IsVariation" xml:space="preserve">
+    <value>Это вариация</value>
+  </data>
+  <data name="Tooltip_IsVariation" xml:space="preserve">
+    <value>Используйте это, когда вы не хотите файл, чтобы показать в элементе нескольких файлов. Это может быть случай, когда у вас есть несколько версий OP/ED для чистой/нет чистой, cut директора и другие виды вариаций</value>
+  </data>
+  <data name="AniDBDownloadCharacters" xml:space="preserve">
+    <value>Скачать образы символов</value>
+  </data>
+  <data name="AniDBDownloadCreators" xml:space="preserve">
+    <value>Скачать создатель изображения</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadCharacters" xml:space="preserve">
+    <value>Эти изображения показаны в MyAnime 3 и Бадди аниме</value>
+  </data>
+  <data name="Tooltip_AniDBDownloadCreators" xml:space="preserve">
+    <value>Эти изображения показаны в MyAnime 3 и аниме Бадди (актеры)</value>
+  </data>
+  <data name="AniDBMyListDeleteAction" xml:space="preserve">
+    <value>Удаление действия</value>
+  </data>
+  <data name="Tooltip_AniDBMyListDeleteAction" xml:space="preserve">
+    <value>Какие меры следует принять для файла, когда вы удалите его из вас локальной коллекции.
+Удалите файл (AniDB) - удаляет файл из вашего AniDB MyList.
+Удалите файл (местные дБ) - удалить файл из вашего местного DB только.
+Марк удалений - оставляет файл на вашем списке, но изменяет состояние удален.
+Марк внешние (CD/DVD) - оставляет файл на вашем списке, но изменяет состояние во внешнее хранилище.
+Марк неизвестный - оставляет файл на вашем списке, но изменяет состояние на неизвестный.</value>
+  </data>
+  <data name="GroupFilterConditionType_CustomTag" xml:space="preserve">
+    <value>Пользовательский тег</value>
+  </data>
+  <data name="Tooltip_WebCache_UserInfo" xml:space="preserve">
+    <value>Посылает анонимное использование информации в веб кэш как тип базы данных, версия Windows и т.д. В справке ссылка для всех данных, которая отправляется</value>
+  </data>
+  <data name="WebCache_UserInfo" xml:space="preserve">
+    <value>Отправить анонимное использование информация</value>
+  </data>
+  <data name="NewSeries_Search" xml:space="preserve">
+    <value>Поиск по названию или ID</value>
+  </data>
+  <data name="Tooltip_NewSeries_Search" xml:space="preserve">
+    <value>Введите часть имени аниме, или если вы знаете AniDB ID просто, прямо</value>
+  </data>
+  <data name="Link_CommunityRecommendation" xml:space="preserve">
+    <value>http://JMediaManager.org/FAQ/#What-are-Community-Recommendations</value>
+  </data>
+  <data name="WhatsThis" xml:space="preserve">
+    <value>Что это?</value>
+  </data>
+  <data name="Override" xml:space="preserve">
+    <value>Переопределение</value>
+  </data>
+  <data name="Tooltip_NameOverride" xml:space="preserve">
+    <value>Можно вручную ввести предпочтительное имя или использовать зеленые стрелки вправо для выбора имени из AniDB.</value>
+  </data>
+  <data name="Tooltip_NameOverride2" xml:space="preserve">
+    <value>Выберите имя из списка названий AniDB.</value>
+  </data>
+  <data name="AdminMessageTitle" xml:space="preserve">
+    <value>Admin сообщение</value>
+  </data>
+  <data name="CheckForUpdate" xml:space="preserve">
+    <value>Проверить наличие обновлений</value>
+  </data>
+  <data name="Link_Blog" xml:space="preserve">
+    <value>http://JMediaManager.org/blog</value>
+  </data>
+  <data name="Link_AniDBBanned" xml:space="preserve">
+    <value>http://JMediaManager.org/FAQ/#Banned-from-AniDB</value>
+  </data>
+  <data name="Link_AniDBSettings" xml:space="preserve">
+    <value>http://JMediaManager.org/JMM-Desktop/Settings/#AniDB</value>
+  </data>
+  <data name="Link_FileRenaming" xml:space="preserve">
+    <value>http://JMediaManager.org/JMM-Desktop/Utilities/File-renaming/</value>
+  </data>
+  <data name="Link_GroupFilters" xml:space="preserve">
+    <value>http://JMediaManager.org/JMM-Desktop/Collection/#What-are-Filters</value>
+  </data>
+  <data name="Link_ImportFolders" xml:space="preserve">
+    <value>http://JMediaManager.org/JMM-Server/Configuring-JMM-Server/#Import-Folders</value>
+  </data>
+  <data name="Link_MAL" xml:space="preserve">
+    <value>http://JMediaManager.org/JMM-Desktop/Settings/#Community-Sites</value>
+  </data>
+  <data name="Link_MPC" xml:space="preserve">
+    <value>http://JMediaManager.org/JMM-Desktop/Settings/#MPC</value>
+  </data>
+  <data name="Link_PotPlayer" xml:space="preserve">
+    <value>http://JMediaManager.org/JMM-Desktop/Settings/#Pot-Player</value>
+  </data>
+  <data name="Link_TMDb" xml:space="preserve">
+    <value>http://JMediaManager.org/JMM-Desktop/Settings/#Community-Sites</value>
+  </data>
+  <data name="Link_Trakt" xml:space="preserve">
+    <value>http://JMediaManager.org/JMM-Desktop/Settings/#Community-Sites</value>
+  </data>
+  <data name="Link_TvDB" xml:space="preserve">
+    <value>http://JMediaManager.org/JMM-Desktop/Settings/#Community-Sites</value>
+  </data>
+  <data name="Link_uTorrent" xml:space="preserve">
+    <value>http://JMediaManager.org/JMM-Desktop/downloads/#uTorrent</value>
+  </data>
+  <data name="Link_VLC" xml:space="preserve">
+    <value>http://JMediaManager.org/JMM-Desktop/Settings/#VLC</value>
+  </data>
+  <data name="Link_WebCache" xml:space="preserve">
+    <value>http://JMediaManager.org/JMM-Desktop/Settings/#Web-Cache</value>
+  </data>
+  <data name="UpdateFrequency_OneMonth" xml:space="preserve">
+    <value>Один раз в месяц</value>
+  </data>
+  <data name="UpdateFrequency_OneWeek" xml:space="preserve">
+    <value>Раз в неделю</value>
+  </data>
+  <data name="SettingAlwaysAniDBPoster" xml:space="preserve">
+    <value>Всегда используйте AniDB плакат</value>
+  </data>
+  <data name="Tooltip_SettingAlwaysAniDBPoster" xml:space="preserve">
+    <value>Этот параметр будет отвергнуть любые другие параметры плакат, так, что только AniDB плакат используется. Это обычно быстрее, чем при использовании Случайные плакаты</value>
+  </data>
+  <data name="MoreInfo" xml:space="preserve">
+    <value>Более подробная информация</value>
+  </data>
+  <data name="Link_Changelog" xml:space="preserve">
+    <value>http://JMediaManager.org/changelog/</value>
+  </data>
+  <data name="Link_Download" xml:space="preserve">
+    <value>http://JMediaManager.org/downloads/</value>
+  </data>
+  <data name="Link_Site" xml:space="preserve">
+    <value>http://JMediaManager.org/</value>
+  </data>
+  <data name="ReenterPassword" xml:space="preserve">
+    <value>Введите пароль повторно</value>
+  </data>
+  <data name="ChangePassword" xml:space="preserve">
+    <value>Смена пароля</value>
+  </data>
+  <data name="ChangingPassword" xml:space="preserve">
+    <value>Изменение пароля для: </value>
+  </data>
+  <data name="WhatDoesThisMean" xml:space="preserve">
+    <value>Что это значит?</value>
+  </data>
+  <data name="DetailedExplanation" xml:space="preserve">
+    <value>Нажмите для подробное объяснение параметров</value>
+  </data>
+  <data name="CustomTag_Name" xml:space="preserve">
+    <value>Имя тега</value>
+  </data>
+  <data name="CustomTag_Description" xml:space="preserve">
+    <value>Описание тега</value>
+  </data>
+  <data name="Add" xml:space="preserve">
+    <value>Добавить</value>
+  </data>
+  <data name="MissingEpisodes_AnimeName" xml:space="preserve">
+    <value>Название аниме</value>
+  </data>
+  <data name="MissingEpisodes_AnimeID" xml:space="preserve">
+    <value>Аниме ID</value>
+  </data>
+  <data name="MissingEpisodes_EpisodeNumber" xml:space="preserve">
+    <value>Номер эпизода</value>
+  </data>
+  <data name="MissingEpisodes_EpisodeID" xml:space="preserve">
+    <value>Код эпизода</value>
+  </data>
+  <data name="MissingEpisodes_GroupSummary" xml:space="preserve">
+    <value>Группа резюме</value>
+  </data>
+  <data name="MissingEpisodes_AnimeLink" xml:space="preserve">
+    <value>Ссылка на аниме</value>
+  </data>
+  <data name="MissingEpisodes_EpisodeLink" xml:space="preserve">
+    <value>Ссылка на эпизод</value>
+  </data>
+  <data name="MissingEpisodes_FileSummary" xml:space="preserve">
+    <value>Файл резюме</value>
+  </data>
+  <data name="NewSeries_AlreadyAttached" xml:space="preserve">
+    <value>Серия уже прилагается к этой аниме</value>
+  </data>
+  <data name="NewSeries_Step1" xml:space="preserve">
+    <value>Шаг 1 - выбор аниме</value>
+  </data>
+  <data name="NewSeries_SearchBy" xml:space="preserve">
+    <value>Поиск по названию или ID</value>
+  </data>
+  <data name="NewSeries_Step2" xml:space="preserve">
+    <value>Выберите локальную группу</value>
+  </data>
+  <data name="NewSeries_BackToStep1" xml:space="preserve">
+    <value>Возвращается к шагу 1</value>
+  </data>
+  <data name="TryAgain" xml:space="preserve">
+    <value>Повторить!</value>
+  </data>
+  <data name="Random_Tags" xml:space="preserve">
+    <value>Теги</value>
+  </data>
+  <data name="Finish" xml:space="preserve">
+    <value>Отделка</value>
+  </data>
+  <data name="Clear" xml:space="preserve">
+    <value>Ясно</value>
+  </data>
+  <data name="Matches" xml:space="preserve">
+    <value>Матчи</value>
+  </data>
+  <data name="Random_Watched" xml:space="preserve">
+    <value>Смотрел</value>
+  </data>
+  <data name="Random_Unwatched" xml:space="preserve">
+    <value>Непросмотренные</value>
+  </data>
+  <data name="Random_PartiallyWatched" xml:space="preserve">
+    <value>Частично смотрел</value>
+  </data>
+  <data name="Random_CompleteOnly" xml:space="preserve">
+    <value>ТОЛЬКО полное</value>
+  </data>
+  <data name="Random_View" xml:space="preserve">
+    <value>Просмотр этой серии</value>
+  </data>
+  <data name="RateSeries_Rate" xml:space="preserve">
+    <value>Стоимость серии:</value>
+  </data>
+  <data name="RateSeries_TraktShout" xml:space="preserve">
+    <value>Сказать свое слово на тракт</value>
+  </data>
+  <data name="Search_Episodes" xml:space="preserve">
+    <value>Эпизоды:</value>
+  </data>
+  <data name="Search_StartingAt" xml:space="preserve">
+    <value>Начиная с</value>
+  </data>
+  <data name="Search_ID" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="Search_Title" xml:space="preserve">
+    <value>Название</value>
+  </data>
+  <data name="Search_AniDBStart" xml:space="preserve">
+    <value>AniDB начало:</value>
+  </data>
+  <data name="Search_Trakt" xml:space="preserve">
+    <value>Тракт: </value>
+  </data>
+  <data name="Search_Approved" xml:space="preserve">
+    <value>Администратор утвердил</value>
+  </data>
+  <data name="Search_TvDB" xml:space="preserve">
+    <value>TvDB: </value>
+  </data>
+  <data name="Search_MAL" xml:space="preserve">
+    <value>МАЛ: </value>
+  </data>
+  <data name="SelectAniDBTitle_SelectName" xml:space="preserve">
+    <value>Выберите имя переопределения</value>
+  </data>
+  <data name="SelectGroupSeries_Select" xml:space="preserve">
+    <value>Выберите </value>
+  </data>
+  <data name="Select_MyAnimeList" xml:space="preserve">
+    <value>MyAnimeList</value>
+  </data>
+  <data name="Select_StartingEpisode" xml:space="preserve">
+    <value>Начиная эпизод #</value>
+  </data>
+  <data name="Select_EpisodeType" xml:space="preserve">
+    <value>Тип эпизод:</value>
+  </data>
+  <data name="Select_TraktTV" xml:space="preserve">
+    <value>Тракт ТВ</value>
+  </data>
+  <data name="Select_TvDBDetails" xml:space="preserve">
+    <value>Выберите детали TvDB</value>
+  </data>
+  <data name="Select_Season" xml:space="preserve">
+    <value>Сезон</value>
+  </data>
+  <data name="Select_DefaultLanguage" xml:space="preserve">
+    <value>Выберите язык по умолчанию</value>
+  </data>
+  <data name="Update_Update" xml:space="preserve">
+    <value>Доступно обновление рабочего стола JMM!</value>
+  </data>
+  <data name="Update_UpdatePage" xml:space="preserve">
+    <value>Обновление страницы</value>
+  </data>
+  <data name="Update_Changelog" xml:space="preserve">
+    <value>История изменений</value>
+  </data>
+  <data name="Update_AvailableVersion" xml:space="preserve">
+    <value>Доступные версии</value>
+  </data>
+  <data name="Update_YourVersion" xml:space="preserve">
+    <value>Ваша версия</value>
+  </data>
+  <data name="ViewComments_FromTrakt" xml:space="preserve">
+    <value>От тракт</value>
+  </data>
+  <data name="ViewComments_Username" xml:space="preserve">
+    <value>Имя пользователя</value>
+  </data>
+  <data name="ViewComments_CommentDate" xml:space="preserve">
+    <value>Дата комментария</value>
+  </data>
+  <data name="ViewComments_Comments" xml:space="preserve">
+    <value>Комментарии</value>
+  </data>
+  <data name="ViewComments_Website" xml:space="preserve">
+    <value>Вид на веб-сайте</value>
+  </data>
+  <data name="JMMDesktop" xml:space="preserve">
+    <value>Модель памяти JMM рабочего стола</value>
+  </data>
+  <data name="MoreInformation" xml:space="preserve">
+    <value>Дополнительная информация</value>
+  </data>
+  <data name="Metro_Continue" xml:space="preserve">
+    <value>Продолжить просмотр</value>
+  </data>
+  <data name="Metro_New" xml:space="preserve">
+    <value>Новые эпизоды</value>
+  </data>
+  <data name="Metro_Random" xml:space="preserve">
+    <value>Случайная серия</value>
+  </data>
+  <data name="Metro_Trakt" xml:space="preserve">
+    <value>Тракт активность</value>
+  </data>
+  <data name="MarkedFavorite" xml:space="preserve">
+    <value>Эта группа помечается как избранное</value>
+  </data>
+  <data name="Community_TraktValid" xml:space="preserve">
+    <value>Проверьте мои ссылки являются действительными на тракт</value>
+  </data>
+  <data name="Community_TraktRemoveBad" xml:space="preserve">
+    <value>Автоматически удалите неверную информацию из базы данных (рекомендуется)</value>
+  </data>
+  <data name="Community_CommunityCheck" xml:space="preserve">
+    <value>Проверить, если мои ссылки отличаются от рекомендаций сообщества</value>
+  </data>
+  <data name="Community_ProblemStop" xml:space="preserve">
+    <value>Остановка после нахождения этого многие проблемы</value>
+  </data>
+  <data name="Trakt" xml:space="preserve">
+    <value>Тракт</value>
+  </data>
+  <data name="Start" xml:space="preserve">
+    <value>Начало</value>
+  </data>
+  <data name="Stop" xml:space="preserve">
+    <value>Остановить</value>
+  </data>
+  <data name="Community_Filter" xml:space="preserve">
+    <value>Фильтр:</value>
+  </data>
+  <data name="Community_Refresh" xml:space="preserve">
+    <value>Обновить данные для этой серии</value>
+  </data>
+  <data name="Community_SeriesName" xml:space="preserve">
+    <value>Название серии</value>
+  </data>
+  <data name="Community_Status" xml:space="preserve">
+    <value>Статус</value>
+  </data>
+  <data name="Community_ValidTraktLink" xml:space="preserve">
+    <value>Действительный Trakt ссылка</value>
+  </data>
+  <data name="Community_HasTraktLink" xml:space="preserve">
+    <value>Trakt ссылка</value>
+  </data>
+  <data name="Community_CommunityLink" xml:space="preserve">
+    <value>Сообщество ссылки</value>
+  </data>
+  <data name="Community_Match" xml:space="preserve">
+    <value>Ссылки матч?</value>
+  </data>
+  <data name="Download_Bookmark" xml:space="preserve">
+    <value>Закладка это аниме скачать позже</value>
+  </data>
+  <data name="Download_SeriesSearch" xml:space="preserve">
+    <value>Поиск для загрузки для этой серии</value>
+  </data>
+  <data name="Download_Approval" xml:space="preserve">
+    <value>Утверждение</value>
+  </data>
+  <data name="Download_YourVote" xml:space="preserve">
+    <value>Ваш голос</value>
+  </data>
+  <data name="Download_RecommendPrompt" xml:space="preserve">
+    <value>Эта утилита показывает вам список рекомендуемых аниме, которые не в вашей коллекции, основанные на собственные рейтинги и отзывы от пользователей AniDB</value>
+  </data>
+  <data name="Torrent" xml:space="preserve">
+    <value>Торрент</value>
+  </data>
+  <data name="Torrents" xml:space="preserve">
+    <value>Торренты</value>
+  </data>
+  <data name="Download_Name" xml:space="preserve">
+    <value>Имя</value>
+  </data>
+  <data name="Download_Size" xml:space="preserve">
+    <value>Размер</value>
+  </data>
+  <data name="Download_Seeders" xml:space="preserve">
+    <value>Сеялки</value>
+  </data>
+  <data name="Download_Leechers" xml:space="preserve">
+    <value>Лекарь</value>
+  </data>
+  <data name="Download_ExtraInfo" xml:space="preserve">
+    <value>Дополнительная информация</value>
+  </data>
+  <data name="Download_WrongSeries" xml:space="preserve">
+    <value>Неправильные серии?</value>
+  </data>
+  <data name="Tooltip_WrongSeries" xml:space="preserve">
+    <value>Это JMMs попытка угадать какой серии, вы смотрите на, так что вы можете сравнить ваши местные коллекции. Если вы не имеете серии в вашей коллекции будет неверным.</value>
+  </data>
+  <data name="Download_ResetCookie" xml:space="preserve">
+    <value>Сбросить Cookie</value>
+  </data>
+  <data name="Download_AnimeBytesOnly" xml:space="preserve">
+    <value>AnimeBytes только для серии</value>
+  </data>
+  <data name="Download_BakaBTOnly" xml:space="preserve">
+    <value>BakaBT только для серии</value>
+  </data>
+  <data name="Available" xml:space="preserve">
+    <value>Доступно</value>
+  </data>
+  <data name="Selected" xml:space="preserve">
+    <value>Выбранные</value>
+  </data>
+  <data name="Download_Source" xml:space="preserve">
+    <value>Источник</value>
+  </data>
+  <data name="Download_Server" xml:space="preserve">
+    <value>Сервера</value>
+  </data>
+  <data name="Download_RefreshInterval" xml:space="preserve">
+    <value>Интервал (в секундах) обновления</value>
+  </data>
+  <data name="Download_AutoRefresh" xml:space="preserve">
+    <value>Автоматическое обновление</value>
+  </data>
+  <data name="Download_UseBlackHole" xml:space="preserve">
+    <value>Использование торрент черная дыра</value>
+  </data>
+  <data name="Download_FolderLocation" xml:space="preserve">
+    <value>Местоположение папки</value>
+  </data>
+  <data name="Download_Hash" xml:space="preserve">
+    <value>Хэш</value>
+  </data>
+  <data name="Download_Queue" xml:space="preserve">
+    <value>#</value>
+  </data>
+  <data name="Download_Done" xml:space="preserve">
+    <value>Договорились</value>
+  </data>
+  <data name="Download_Peers" xml:space="preserve">
+    <value>Сверстников</value>
+  </data>
+  <data name="Download_DownSpeed" xml:space="preserve">
+    <value>Вниз скорость</value>
+  </data>
+  <data name="Download_UpSpeed" xml:space="preserve">
+    <value>Скорость загрузки</value>
+  </data>
+  <data name="Download_Ratio" xml:space="preserve">
+    <value>Коэффициент</value>
+  </data>
+  <data name="Download_InvalidCred" xml:space="preserve">
+    <value>Вы не указаны учетные данные действительны uTorrent</value>
+  </data>
+  <data name="Download_EnterCred" xml:space="preserve">
+    <value>Пожалуйста, введите ваши учетные данные на вкладке Настройка, а затем вернуться</value>
+  </data>
+  <data name="Download_Priority" xml:space="preserve">
+    <value>Приоритет</value>
+  </data>
+  <data name="Download_Downloaded" xml:space="preserve">
+    <value>Загрузить</value>
+  </data>
+  <data name="Settings_DeleteAction" xml:space="preserve">
+    <value>Удаление действия</value>
+  </data>
+  <data name="Settings_AutoUpdateInfo" xml:space="preserve">
+    <value>Автоматически обновлять файлы с отсутствует информация</value>
+  </data>
+  <data name="Settings_HideDownloadButton" xml:space="preserve">
+    <value>Скрыть кнопку Загрузить эпизод, когда у вас уже есть файлы</value>
+  </data>
+  <data name="Settings_RecreateGroups" xml:space="preserve">
+    <value>Воссоздать все группы</value>
+  </data>
+  <data name="Settings_ScanOnStart" xml:space="preserve">
+    <value>Сканировать папки падение на старте</value>
+  </data>
+  <data name="Settings_ImagePath" xml:space="preserve">
+    <value>Путь к изображению</value>
+  </data>
+  <data name="Settings_SelectFolder" xml:space="preserve">
+    <value>Выберите папку</value>
+  </data>
+  <data name="Settings_FilePort" xml:space="preserve">
+    <value>Файл порт</value>
+  </data>
+  <data name="WebCache_TraktLinks" xml:space="preserve">
+    <value>Trakt ссылки</value>
+  </data>
+  <data name="VideoPlayer_MPC" xml:space="preserve">
+    <value>Media Player Classic</value>
+  </data>
+  <data name="VideoPlayer_MPCNote" xml:space="preserve">
+    <value>Для интеграции MPC, которую вы должны включить два варианта (1) хранить параметры INI-файла и истории (2) хранить недавно смотрел файлов. Смотрите скриншот ниже для более подробной информации. MPC расположен обычно что-то вроде C:\Program Files (x 86) \Combined Community Codec Pack\MPC</value>
+  </data>
+  <data name="VideoPlayer_MPCOptions" xml:space="preserve">
+    <value>MPC опции</value>
+  </data>
+  <data name="VideoPlayer_VLC" xml:space="preserve">
+    <value>VLC</value>
+  </data>
+  <data name="VideoPlayer_VLCNote" xml:space="preserve">
+    <value>VLC 2.2 + записей последних файлов и временные метки по умолчанию (и отключение «Дополнительно» вариант). Более старые версии не поддерживают функциональность «Резюме из последней позиции». Расположение файла .ini VLC является обычно что-то вроде C:\Users\username\AppData\Roaming\vlc\vlc-qt-interface.ini</value>
+  </data>
+  <data name="VideoPlayer_VLCOptions" xml:space="preserve">
+    <value>VLC опции</value>
+  </data>
+  <data name="VideoPlayer_PotPlayer" xml:space="preserve">
+    <value>PotPlayer</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerNote" xml:space="preserve">
+    <value>Для интеграции PotPlayer, необходимо включить следующие параметры (1) предпочтения &gt; общего &gt; хранилища параметров .ini файла (2) предпочтения &gt; воспроизведение &gt; играть от последней точки. Смотрите скриншот ниже для более подробной информации. Расположение файла .ini PlotPlayer обычно это что-то вроде C:\Users\username\AppData\Roaming\PotPlayer64\PotPlayer64.ini</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerOptions" xml:space="preserve">
+    <value>PotPlayer опции</value>
+  </data>
+  <data name="VideoPlayer_MPCINI" xml:space="preserve">
+    <value>Выберите папку MPC INI</value>
+  </data>
+  <data name="VideoPlayer_VLCINI" xml:space="preserve">
+    <value>Выберите папку VLC INI</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerINI" xml:space="preserve">
+    <value>Выберите папку PotPlayer INI</value>
+  </data>
+  <data name="VideoPlayer_MPCTest" xml:space="preserve">
+    <value>MPC файлов теста</value>
+  </data>
+  <data name="VideoPlayer_VLCTest" xml:space="preserve">
+    <value>Тестовый файл VLC</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerTest" xml:space="preserve">
+    <value>Тестовый файл PotPlayer</value>
+  </data>
+  <data name="VideoPlayer_AutoMark" xml:space="preserve">
+    <value>Автоматическая пометка файлов как смотрел, когда смотрел следующих процент</value>
+  </data>
+  <data name="VideoPlayer_MPCFolder" xml:space="preserve">
+    <value>MPC INI папки</value>
+  </data>
+  <data name="VideoPlayer_VLCFolder" xml:space="preserve">
+    <value>VLC INI папки</value>
+  </data>
+  <data name="VideoPlayer_PotPlayerFolder" xml:space="preserve">
+    <value>PotPlayer INI папки</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote1" xml:space="preserve">
+    <value>Автоматический файл выбора предпочтения - это относится к, когда у вас есть больше, чем файл для эпизода</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote2" xml:space="preserve">
+    <value>Для воспроизведения необходимо выбрать один файл, который будет основываться на вас предпочтения ниже.</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote3" xml:space="preserve">
+    <value>За один эпизод можно включить автоматический выбор файла или JMM предложит вам выбрать файл всякий раз, когда у вас более чем один</value>
+  </data>
+  <data name="VideoPlayer_AutoFileFirstEpisode" xml:space="preserve">
+    <value>Автоматический выбор файлов - первый эпизод в серии</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNextEpisode" xml:space="preserve">
+    <value>Автоматический выбор файлов - последующие эпизоды в серии</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote4" xml:space="preserve">
+    <value>Если вы выберете «Релиз группы от ранее играл эпизод» в параметре выше вам также нужно сделать следующие</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote5" xml:space="preserve">
+    <value>Снимите флажок Параметры импорта под параметры «Установить файл как смотрел, если смотрел эпизод» - важная информация-</value>
+  </data>
+  <data name="VideoPlayer_AutoFileNote6" xml:space="preserve">
+    <value>Всегда Марк файл как смотрел и не эпизод</value>
+  </data>
+  <data name="VideoPlayer_AutoFileEnable" xml:space="preserve">
+    <value>Включить автоматический выбор файлов на одном эпизодов</value>
+  </data>
+  <data name="TvDB_WideBannerMax" xml:space="preserve">
+    <value>Максимально широкий баннеры</value>
+  </data>
+  <data name="TvDB_PostersMax" xml:space="preserve">
+    <value>Максимальная плакаты</value>
+  </data>
+  <data name="Trakt_Enable" xml:space="preserve">
+    <value>Включить тракт</value>
+  </data>
+  <data name="Trakt_PIN" xml:space="preserve">
+    <value>Тракт PIN</value>
+  </data>
+  <data name="Trakt_GetPIN" xml:space="preserve">
+    <value>Получить ПИН-код</value>
+  </data>
+  <data name="Trakt_Authorize" xml:space="preserve">
+    <value>Санкционировать JMM</value>
+  </data>
+  <data name="Trakt_CurrentToken" xml:space="preserve">
+    <value>Текущий маркер действителен до:</value>
+  </data>
+  <data name="Trakt_AutoFanart" xml:space="preserve">
+    <value>Автоматическая загрузка фанарт</value>
+  </data>
+  <data name="Trakt_AutoPosters" xml:space="preserve">
+    <value>Автоматическая загрузка плакаты</value>
+  </data>
+  <data name="Trakt_AutoEpisodeImages" xml:space="preserve">
+    <value>Автоматическая загрузка эпизод изображения</value>
+  </data>
+  <data name="MovieDB_MaxPosters" xml:space="preserve">
+    <value>Максимальная плакаты</value>
+  </data>
+  <data name="AnimeGroup_Random" xml:space="preserve">
+    <value>Случайный эпизод</value>
+  </data>
+  <data name="AnimeGroup_AllSeries" xml:space="preserve">
+    <value>Все серии</value>
+  </data>
+  <data name="AnimeGroup_DoubleClick" xml:space="preserve">
+    <value>Дважды щелкните на серию для просмотра непосредственно</value>
+  </data>
+  <data name="PinnedSeries_Simple" xml:space="preserve">
+    <value>Упрощенное представление</value>
+  </data>
+  <data name="Playlist_Add" xml:space="preserve">
+    <value>Добавить в плейлист</value>
+  </data>
+  <data name="Series_Overview" xml:space="preserve">
+    <value>Обзор</value>
+  </data>
+  <data name="Series_MoreInfo" xml:space="preserve">
+    <value>Дополнительная информация</value>
+  </data>
+  <data name="Series_CustomTags" xml:space="preserve">
+    <value>Пользовательские теги</value>
+  </data>
+  <data name="Series_ManageCustom" xml:space="preserve">
+    <value>Управление пользовательской метки</value>
+  </data>
+  <data name="Series_Tag" xml:space="preserve">
+    <value>Тег</value>
+  </data>
+  <data name="Series_Add" xml:space="preserve">
+    <value>Добавить</value>
+  </data>
+  <data name="Series_Files" xml:space="preserve">
+    <value>Файлы</value>
+  </data>
+  <data name="Series_Folder" xml:space="preserve">
+    <value>Папка</value>
+  </data>
+  <data name="SeriesSimple_TraktLink" xml:space="preserve">
+    <value>Перейти этот эпизод на Trakt.TV</value>
+  </data>
+  <data name="SeriesSimple_Comments" xml:space="preserve">
+    <value>Комментарии</value>
+  </data>
+  <data name="SeriesSimple_Play" xml:space="preserve">
+    <value>Играть</value>
+  </data>
+  <data name="SeriesSimple_Watched" xml:space="preserve">
+    <value>Посмотрели:</value>
+  </data>
+  <data name="SeriesSimple_From" xml:space="preserve">
+    <value>От:</value>
+  </data>
+  <data name="SeriesSimple_AlreadyHave" xml:space="preserve">
+    <value>У вас уже есть это аниме в вашей коллекции</value>
+  </data>
+  <data name="SeriesSimple_Details" xml:space="preserve">
+    <value>Детали:</value>
+  </data>
+  <data name="SeriesSimple_Voteup" xml:space="preserve">
+    <value>Голосовать</value>
+  </data>
+  <data name="SeriesSimple_VoteDown" xml:space="preserve">
+    <value>Проголосовать вниз</value>
+  </data>
+  <data name="SeriesSimple_FromTrakt" xml:space="preserve">
+    <value>От тракт</value>
+  </data>
+  <data name="SeriesSimple_View" xml:space="preserve">
+    <value>Вид</value>
+  </data>
+  <data name="SeriesSimple_FromAniDB" xml:space="preserve">
+    <value>От AniDB</value>
+  </data>
+  <data name="SeriesSimple_Aired" xml:space="preserve">
+    <value>Эфир</value>
+  </data>
+  <data name="SeriesSimple_Episodes" xml:space="preserve">
+    <value>Эпизоды</value>
+  </data>
+  <data name="SeriesSimple_MyVote" xml:space="preserve">
+    <value>Мой голос</value>
+  </data>
+  <data name="SeriesSimple_PlayNext" xml:space="preserve">
+    <value>Играть в следующем эпизоде</value>
+  </data>
+  <data name="SeriesSimple_PlayUnWatched" xml:space="preserve">
+    <value>Играть все непросмотренные)</value>
+  </data>
+  <data name="SeriesSimple_YourSay" xml:space="preserve">
+    <value>Сказать свое слово...</value>
+  </data>
+  <data name="SeriesSimple_Spoiler" xml:space="preserve">
+    <value>Спойлер</value>
+  </data>
+  <data name="SeriesSimple_CommentTrakt" xml:space="preserve">
+    <value>Комментарий на тракт</value>
+  </data>
+  <data name="SeriesSimple_Characters" xml:space="preserve">
+    <value>Персонажи</value>
+  </data>
+  <data name="SeriesSimple_AlsoLike" xml:space="preserve">
+    <value>Вам также может понравиться</value>
+  </data>
+  <data name="SeriesSimple_PeopleSaying" xml:space="preserve">
+    <value>Что люди говорят</value>
+  </data>
+  <data name="SeriesSimple_Loading" xml:space="preserve">
+    <value>Загрузка...</value>
+  </data>
+  <data name="AvDump_Remove" xml:space="preserve">
+    <value>Удалить из списка</value>
+  </data>
+  <data name="AvDump_Clear" xml:space="preserve">
+    <value>Очистить список</value>
+  </data>
+  <data name="AvDump_Dump" xml:space="preserve">
+    <value>Файлы дампов</value>
+  </data>
+  <data name="Bookmarks_Downloading" xml:space="preserve">
+    <value>Загрузка</value>
+  </data>
+  <data name="Bookmarks_NotDownloading" xml:space="preserve">
+    <value>Не скачивая</value>
+  </data>
+  <data name="Dashboard_YourVote" xml:space="preserve">
+    <value>Ваш голос</value>
+  </data>
+  <data name="Dashboard_Bookmark" xml:space="preserve">
+    <value>Закладка это аниме скачать позже</value>
+  </data>
+  <data name="Dashboard_Download" xml:space="preserve">
+    <value>Поиск для загрузки для этой серии</value>
+  </data>
+  <data name="Dashboard_NoRecommend" xml:space="preserve">
+    <value>Можно найти никаких рекомендаций.</value>
+  </data>
+  <data name="Dashboard_DownloadVotes" xml:space="preserve">
+    <value>Загрузите ваши голоса, или голосовать на аниме, чтобы начать получать рекомендации.</value>
+  </data>
+  <data name="Dashboard_SyncVotes" xml:space="preserve">
+    <value>Синхронизация голосов</value>
+  </data>
+  <data name="Dashboard_Added" xml:space="preserve">
+    <value>Добавлено</value>
+  </data>
+  <data name="Dashboard_Metro" xml:space="preserve">
+    <value>Станции мониторинга</value>
+  </data>
+  <data name="Dashboard_UpdateCalendar" xml:space="preserve">
+    <value>Обновление данных календаря</value>
+  </data>
+  <data name="Dashboard_Recent" xml:space="preserve">
+    <value>Последние добавления</value>
+  </data>
+  <data name="Metro_Options" xml:space="preserve">
+    <value>Параметры</value>
+  </data>
+  <data name="Metro_General" xml:space="preserve">
+    <value>Общие</value>
+  </data>
+  <data name="Metro_ImageType" xml:space="preserve">
+    <value>Тип изображения</value>
+  </data>
+  <data name="Metro_Sections" xml:space="preserve">
+    <value>Разделы</value>
+  </data>
+  <data name="Metro_Items" xml:space="preserve">
+    <value>Элементы</value>
+  </data>
+  <data name="Metro_Refresh" xml:space="preserve">
+    <value>Обновить</value>
+  </data>
+  <data name="PlayVideo" xml:space="preserve">
+    <value>Воспроизведение видео</value>
+  </data>
+  <data name="Episode_MoreInfo" xml:space="preserve">
+    <value>Подробнее...</value>
+  </data>
+  <data name="Episode_LessInfo" xml:space="preserve">
+    <value>Менее информация...</value>
+  </data>
+  <data name="Episode_Manual" xml:space="preserve">
+    <value>Механическая связь</value>
+  </data>
+  <data name="Episode_ForceAniDBUpdate" xml:space="preserve">
+    <value>Сведения об обновлении силы от AniDB</value>
+  </data>
+  <data name="Episode_RecalculateHash" xml:space="preserve">
+    <value>Повторно вычислить хэш</value>
+  </data>
+  <data name="Episode_Hash" xml:space="preserve">
+    <value>Хэш</value>
+  </data>
+  <data name="Episode_CRC32" xml:space="preserve">
+    <value>CRC32</value>
+  </data>
+  <data name="Episode_SHA1" xml:space="preserve">
+    <value>SHA1</value>
+  </data>
+  <data name="Episode_MD5" xml:space="preserve">
+    <value>MD5</value>
+  </data>
+  <data name="Episode_DownloadSearch" xml:space="preserve">
+    <value>Поиск загрузки для этого эпизода</value>
+  </data>
+  <data name="Episode_PlaylistAdd" xml:space="preserve">
+    <value>Добавить в плейлист</value>
+  </data>
+  <data name="Episode_TvDBOverride" xml:space="preserve">
+    <value>Переопределите TvDB ссылку для этого эпизода</value>
+  </data>
+  <data name="Episode_TvDBRemove" xml:space="preserve">
+    <value>Удалить ссылку TvDB для этого эпизода</value>
+  </data>
+  <data name="Episode_AniDBForceUpdate" xml:space="preserve">
+    <value>Сведения об обновлении силы от AniDB</value>
+  </data>
+  <data name="Episode_Type" xml:space="preserve">
+    <value>Тип</value>
+  </data>
+  <data name="Episode_Availability" xml:space="preserve">
+    <value>Доступность</value>
+  </data>
+  <data name="Episode_WatchedState" xml:space="preserve">
+    <value>Смотрел состояние</value>
+  </data>
+  <data name="Rename_Script" xml:space="preserve">
+    <value>Сценарий</value>
+  </data>
+  <data name="Rename_New" xml:space="preserve">
+    <value>Новые функции</value>
+  </data>
+  <data name="Rename_Save" xml:space="preserve">
+    <value>Сохранить</value>
+  </data>
+  <data name="Rename_Delete" xml:space="preserve">
+    <value>Удалить</value>
+  </data>
+  <data name="Rename_Tag" xml:space="preserve">
+    <value>Тег</value>
+  </data>
+  <data name="Rename_Add" xml:space="preserve">
+    <value>Добавить</value>
+  </data>
+  <data name="Rename_Test" xml:space="preserve">
+    <value>Тест</value>
+  </data>
+  <data name="Rename_ScriptingHelp" xml:space="preserve">
+    <value>Помощь с использованием сценариев</value>
+  </data>
+  <data name="Rename_ImportRun" xml:space="preserve">
+    <value>Запустите этот сценарий при импорте файлов в коллекцию</value>
+  </data>
+  <data name="Rename_Filter" xml:space="preserve">
+    <value>Фильтр:</value>
+  </data>
+  <data name="Rename_Clear" xml:space="preserve">
+    <value>Ясно</value>
+  </data>
+  <data name="Rename_AddFiles" xml:space="preserve">
+    <value>Добавление файлов</value>
+  </data>
+  <data name="Rename_Rename" xml:space="preserve">
+    <value>Переименование сейчас</value>
+  </data>
+  <data name="Rename_Preview" xml:space="preserve">
+    <value>Предварительный просмотр</value>
+  </data>
+  <data name="FileSearch_Rescan" xml:space="preserve">
+    <value>Проверка (Rescan)</value>
+  </data>
+  <data name="FileSearch_AniDBForceUpdate" xml:space="preserve">
+    <value>Сведения об обновлении силы от AniDB</value>
+  </data>
+  <data name="GroupFilter_RandomSeries" xml:space="preserve">
+    <value>Случайная серия</value>
+  </data>
+  <data name="GroupFilter_RandomEpisode" xml:space="preserve">
+    <value>Случайный эпизод</value>
+  </data>
+  <data name="IgnoredAnime_Delete" xml:space="preserve">
+    <value>Удалите эту запись</value>
+  </data>
+  <data name="IgnoredAnime_Note" xml:space="preserve">
+    <value>Эта программа покажет вам все аниме, которую вы решили игнорировать из рекомендаций. Удаление этих записей означает, что они могут показать в рекомендациях снова.</value>
+  </data>
+  <data name="ImportFolder_Watched" xml:space="preserve">
+    <value>В настоящее время смотрел эту папку для новых файлов</value>
+  </data>
+  <data name="MissingEpisodes_SelectColumns" xml:space="preserve">
+    <value>Выберите столбцы, которые будут использоваться в импорт</value>
+  </data>
+  <data name="MissingEpisodes_AiringState" xml:space="preserve">
+    <value>Проветривание состояние:</value>
+  </data>
+  <data name="RefreshWait" xml:space="preserve">
+    <value>Нажатие кнопки Обновить может занять несколько минут, так что будьте терпеливы</value>
+  </data>
+  <data name="MissingEpisodes_Note" xml:space="preserve">
+    <value>Эта программа покажет вам краткую информацию о всех пропавших без вести эпизодов.</value>
+  </data>
+  <data name="MissingMyList_Missing" xml:space="preserve">
+    <value>Просмотреть файл отсутствует</value>
+  </data>
+  <data name="MissingMyList_RemoveAll" xml:space="preserve">
+    <value>Удалить все записи из AniDB</value>
+  </data>
+  <data name="MissingMyList_Note" xml:space="preserve">
+    <value>Эта утилита будет скачать список файлов из AniDB и сравнить его с файлы локально. Затем будет иметь шанс, чтобы удалить эти файлы из AniDB, если они не существуют.</value>
+  </data>
+  <data name="Episode" xml:space="preserve">
+    <value>Эпизод</value>
+  </data>
+  <data name="Playlist_Random" xml:space="preserve">
+    <value>Случайный эпизод</value>
+  </data>
+  <data name="Playlist_Default" xml:space="preserve">
+    <value>По умолчанию порядок воспроизведения</value>
+  </data>
+  <data name="Playlist_Items" xml:space="preserve">
+    <value>Элементы списка воспроизведения</value>
+  </data>
+  <data name="PlayNext_Hidden" xml:space="preserve">
+    <value>Скрыты, чтобы предотвратить спойлеры</value>
+  </data>
+  <data name="Rankings_Overall" xml:space="preserve">
+    <value>Общий пользовательский рейтинг</value>
+  </data>
+  <data name="Rankings_GroupedByYear" xml:space="preserve">
+    <value>Сгруппированы по годам</value>
+  </data>
+  <data name="Rankings_CollectionState" xml:space="preserve">
+    <value>Коллекция государственного</value>
+  </data>
+  <data name="Rankings_Voted" xml:space="preserve">
+    <value>Проголосовали</value>
+  </data>
+  <data name="Rankings_Completed" xml:space="preserve">
+    <value>Завершено</value>
+  </data>
+  <data name="Rankings_Anime" xml:space="preserve">
+    <value> Аниме</value>
+  </data>
+  <data name="Rankings_AniDB" xml:space="preserve">
+    <value>Рейтинг AniDB</value>
+  </data>
+  <data name="Rankings_User" xml:space="preserve">
+    <value>Ваш рейтинг</value>
+  </data>
+  <data name="Rankings_Year" xml:space="preserve">
+    <value>Год</value>
+  </data>
+  <data name="Rankings_View" xml:space="preserve">
+    <value>Просмотр серии</value>
+  </data>
+  <data name="Rankings_MyVote" xml:space="preserve">
+    <value>Мой голос</value>
+  </data>
+  <data name="Related_Bookmark" xml:space="preserve">
+    <value>Закладка это аниме скачать позже</value>
+  </data>
+  <data name="Related_Search" xml:space="preserve">
+    <value>Поиск для загрузки для этой серии</value>
+  </data>
+  <data name="SeriesWithoutFiles_Delete" xml:space="preserve">
+    <value>Удаление этой серии из базы данных</value>
+  </data>
+  <data name="SeriesWithoutFiles_Note" xml:space="preserve">
+    <value>Эта программа покажет вам все серии, которые не имеют каких-либо файлов. Удаление серии также удалить группу, если нет других серий в этой группе файлов.</value>
+  </data>
+  <data name="TraktShouts_View" xml:space="preserve">
+    <value>Вид</value>
+  </data>
+  <data name="TraktShouts_FromAniDB" xml:space="preserve">
+    <value>От AniDB</value>
+  </data>
+  <data name="TraktShouts_Spoiler" xml:space="preserve">
+    <value>Спойлер</value>
+  </data>
+  <data name="TraktShouts_Loading" xml:space="preserve">
+    <value>Загрузка...</value>
+  </data>
+  <data name="TraktShouts_Comments" xml:space="preserve">
+    <value>Комментарии</value>
+  </data>
+  <data name="CommunityLinks_Start" xml:space="preserve">
+    <value>Начало:</value>
+  </data>
+  <data name="CommunityLinks_Edit" xml:space="preserve">
+    <value>Изменить детали</value>
+  </data>
+  <data name="CommunityLinks_AniDBStart" xml:space="preserve">
+    <value>AniDB начало:</value>
+  </data>
+  <data name="CommunityLinks_TvDB" xml:space="preserve">
+    <value>TvDB: </value>
+  </data>
+  <data name="CommunityLinks_Trakt" xml:space="preserve">
+    <value>Тракт: </value>
+  </data>
+  <data name="CommunityLinks_TMDb" xml:space="preserve">
+    <value>Фильм DB</value>
+  </data>
+  <data name="CommunityLinks_MAL" xml:space="preserve">
+    <value>MyAnimeList</value>
+  </data>
+  <data name="CommunityLinks_AutoLink" xml:space="preserve">
+    <value>Автоматическое соединение</value>
+  </data>
+  <data name="Tooltip_DeleteTitle" xml:space="preserve">
+    <value>Удалить</value>
+  </data>
+  <data name="Tooltip_DeleteInfo" xml:space="preserve">
+    <value>Удалить эту ссылку</value>
+  </data>
+  <data name="Tooltip_EditTitle" xml:space="preserve">
+    <value>Редактировать</value>
+  </data>
+  <data name="Tooltip_EditInfo" xml:space="preserve">
+    <value>Редактирование деталей этой ссылке</value>
+  </data>
+  <data name="Tooltip_UpdateTitle" xml:space="preserve">
+    <value>Обновление</value>
+  </data>
+  <data name="Tooltip_UpdateTvDB" xml:space="preserve">
+    <value>Скачать свежие данные из TvDB и обновить локальную базу данных</value>
+  </data>
+  <data name="Tooltip_ReportLinkTitle" xml:space="preserve">
+    <value>Отчет об ошибке ссылок</value>
+  </data>
+  <data name="Tooltip_ReportLinkInfo" xml:space="preserve">
+    <value>Если это связано с неправильным серии нажмите здесь, чтобы позволить разработчикам знать</value>
+  </data>
+  <data name="Tooltip_UpdateTrakt" xml:space="preserve">
+    <value>Скачать свежие данные из тракт и обновить локальную базу данных</value>
+  </data>
+  <data name="Tooltip_Sync" xml:space="preserve">
+    <value>Синхронизация</value>
+  </data>
+  <data name="Tooltip_SyncTrakt" xml:space="preserve">
+    <value>Синхронизировать данные коллекции и истории с тракт</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTitle" xml:space="preserve">
+    <value>Автоматическое связывание отключено</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTvDB" xml:space="preserve">
+    <value>В настоящее время отключено автоматическое связывание от этого аниме серии TvDB</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTitle" xml:space="preserve">
+    <value>Автоматическое связывание включено</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTvDB" xml:space="preserve">
+    <value>В настоящее время включено автоматическое связывание от этого аниме серии TvDB. Если модель памяти JMM сервер находит близко матча или сообщество рекомендацию он будет автоматически создавать ссылки</value>
+  </data>
+  <data name="CommunityLinks_TraktTV" xml:space="preserve">
+    <value>Тракт ТВ</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTrakt" xml:space="preserve">
+    <value>В настоящее время отключено автоматическое связывание от этого аниме серии тракт</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTrakt" xml:space="preserve">
+    <value>В настоящее время включено автоматическое связывание от этого аниме серии тракт. Если модель памяти JMM сервер находит близко матча или сообщество рекомендацию он будет автоматически создавать ссылки</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledMAL" xml:space="preserve">
+    <value>В настоящее время отключено автоматическое связывание от этого аниме серии MAL</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledMAL" xml:space="preserve">
+    <value>В настоящее время включено автоматическое связывание от этого аниме серии ТЗА. Если модель памяти JMM сервер находит близко матча или сообщество рекомендацию он будет автоматически создавать ссылки</value>
+  </data>
+  <data name="Tooltip_AutoLinkDisabledTMDb" xml:space="preserve">
+    <value>В настоящее время отключено автоматическое связывание от этого аниме серии MovieDB</value>
+  </data>
+  <data name="Tooltip_AutoLinkEnabledTMDb" xml:space="preserve">
+    <value>Автоматическое связывание от этого аниме MovieDB серии в настоящее время включен. Если модель памяти JMM сервер находит близко матча или сообщество рекомендацию он будет автоматически создавать ссылки</value>
+  </data>
+  <data name="Tooltip_CommunityAdminTitle" xml:space="preserve">
+    <value>Администратор сообщества</value>
+  </data>
+  <data name="Tooltip_CommunityAdminInfo" xml:space="preserve">
+    <value>Перейдите на вкладку Администратор сообщества и рекомендованные ссылки для этого аниме редактировать</value>
+  </data>
+  <data name="Unrecognized_Rescan" xml:space="preserve">
+    <value>Проверка (Rescan)</value>
+  </data>
+  <data name="Unrecognized_ForceAniDB" xml:space="preserve">
+    <value>Сведения об обновлении силы от AniDB</value>
+  </data>
+  <data name="Unrecognized_Hash" xml:space="preserve">
+    <value>Хэш</value>
+  </data>
+  <data name="Unrecognized_CRC32" xml:space="preserve">
+    <value>CRC32</value>
+  </data>
+  <data name="Unrecognized_Rehash" xml:space="preserve">
+    <value>Повторно хэш всех</value>
+  </data>
+  <data name="Unrecognized_Logs" xml:space="preserve">
+    <value>Журналы</value>
+  </data>
+  <data name="Unrecognized_NA" xml:space="preserve">
+    <value>NA</value>
+  </data>
+  <data name="Unrecognized_RefreshSeries" xml:space="preserve">
+    <value>Обновить список серии</value>
+  </data>
+  <data name="Unrecognized_To" xml:space="preserve">
+    <value>Кому</value>
+  </data>
+  <data name="UpdateAniDB_UpdateLocal" xml:space="preserve">
+    <value>Обновление данных локального файла AniDB</value>
+  </data>
+  <data name="UpdateAniDB_Info1" xml:space="preserve">
+    <value>Данные, касающиеся файлы загружаются из AniDB и затем сохраняются в локальной базе данных при импорте файла. В некоторых случаях эти данные не может быть полной, когда вы сначала загрузить его. Или дополнительных данных могут быть скачаны, но новые версии модели памяти JMM. Эта утилита позволит вам получить новую копию этой информации от AniDB</value>
+  </data>
+  <data name="UpdateAniDB_MissingInfo" xml:space="preserve">
+    <value>Обновление файлов с отсутствует информация</value>
+  </data>
+  <data name="UpdateAniDB_Info2" xml:space="preserve">
+    <value>Недостающие данные обычно относится к отсутствует кодек и резолюции информацию. Вы можете увидеть резолюции: 0x0 рядом с эти файлы</value>
+  </data>
+  <data name="UpdateAniDB_Version" xml:space="preserve">
+    <value>Обновление файлов на внутренние версии 2</value>
+  </data>
+  <data name="UpdateAniDB_Info3" xml:space="preserve">
+    <value>Внутренние версии 2 добавил следующую информацию - версия файла (v2, v3 и т.д.), это цензуре, является устаревшим</value>
+  </data>
+  <data name="UpdateAniDB_Info4" xml:space="preserve">
+    <value>Отправка команд слишком много AniDB, может вызвать временный запрет. Используйте на свой страх и риск</value>
+  </data>
+  <data name="UpdateAniDB_HowManyQueued" xml:space="preserve">
+    <value>Сколько команд будут помещаться в очередь?</value>
+  </data>
+  <data name="UpdateAniDB_Queued" xml:space="preserve">
+    <value>Очередь команд</value>
+  </data>
+  <data name="User_HideTags" xml:space="preserve">
+    <value>Скрыть Теги</value>
+  </data>
+  <data name="User_ChangePassword" xml:space="preserve">
+    <value>Смена пароля</value>
+  </data>
+  <data name="Sort_Error" xml:space="preserve">
+    <value>Ошибка при попытке отсортировать список </value>
+  </data>
+  <data name="Sort_Using" xml:space="preserve">
+    <value> Использование </value>
+  </data>
+  <data name="Sort_Property" xml:space="preserve">
+    <value>Недвижимость </value>
+  </data>
+  <data name="Sort_Field" xml:space="preserve">
+    <value>поле </value>
+  </data>
+  <data name="Sort_Exception" xml:space="preserve">
+    <value>Исключение в ТМЕ при сортировке списка </value>
+  </data>
+  <data name="Sort_PassedEmpty" xml:space="preserve">
+    <value>Имя пустого поля в rgSortBy [был принят multiSort параметр rgSortBy</value>
+  </data>
+  <data name="Selected_DoesNotExist" xml:space="preserve">
+    <value>Указанный файл или папка не существует: </value>
+  </data>
+  <data name="ValueCompare_PropertyName" xml:space="preserve">
+    <value>Имя свойства </value>
+  </data>
+  <data name="ValueCompare_NotFound" xml:space="preserve">
+    <value> не найден, при попытке сравнения объектов типа </value>
+  </data>
+  <data name="ValueCompare_FieldName" xml:space="preserve">
+    <value>Имя поля </value>
+  </data>
+  <data name="Video_VLCError1" xml:space="preserve">
+    <value>Не удается выполнить разбор URI в VLC ini-файла</value>
+  </data>
+  <data name="Video_VLCError2" xml:space="preserve">
+    <value>Количество последних файлов и временные метки в ini-файле VLC отличаются</value>
+  </data>
+  <data name="Video_Complete" xml:space="preserve">
+    <value>Завершить</value>
+  </data>
+  <data name="Video_Position" xml:space="preserve">
+    <value>Видео позиции для</value>
+  </data>
+  <data name="Video_HasChanged" xml:space="preserve">
+    <value>изменился</value>
+  </data>
+  <data name="Video_Updating" xml:space="preserve">
+    <value>Обновление до смотрел на медиа-проигрыватель: </value>
+  </data>
+  <data name="AniDB_DataMissing" xml:space="preserve">
+    <value>Отсутствуют данные</value>
+  </data>
+  <data name="AniDB_Votes" xml:space="preserve">
+    <value>Голоса</value>
+  </data>
+  <data name="AniDB_GotVids" xml:space="preserve">
+    <value>Получили vids для аниме от службы:</value>
+  </data>
+  <data name="AniDB_In" xml:space="preserve">
+    <value>в</value>
+  </data>
+  <data name="AniDB_ForFans" xml:space="preserve">
+    <value>Для фанатов</value>
+  </data>
+  <data name="AniDB_Recommended" xml:space="preserve">
+    <value>Рекомендуется</value>
+  </data>
+  <data name="AniDB_MustSee" xml:space="preserve">
+    <value>Должны видеть</value>
+  </data>
+  <data name="AniDB_Collecting" xml:space="preserve">
+    <value>Сбор:</value>
+  </data>
+  <data name="AniDB_Files" xml:space="preserve">
+    <value>Файлов:</value>
+  </data>
+  <data name="AnimeEpisode_Previous" xml:space="preserve">
+    <value>Предыдущий эпизод</value>
+  </data>
+  <data name="AnimeEpisode_Next" xml:space="preserve">
+    <value>Следующий эпизод</value>
+  </data>
+  <data name="AnimeEpisode_NoOverview" xml:space="preserve">
+    <value>Обзор эпизод не доступны</value>
+  </data>
+  <data name="Anime_Groups" xml:space="preserve">
+    <value>Группы</value>
+  </data>
+  <data name="Anime_Series" xml:space="preserve">
+    <value>Серия</value>
+  </data>
+  <data name="Anime_GroupName" xml:space="preserve">
+    <value>Имя группы должны быть заполнены</value>
+  </data>
+  <data name="Anime_SortName" xml:space="preserve">
+    <value>Имя сортировки должны быть заполнены</value>
+  </data>
+  <data name="Anime_GotVids" xml:space="preserve">
+    <value>Получили vids для аниме от службы:</value>
+  </data>
+  <data name="Anime_GotEpisodes" xml:space="preserve">
+    <value>Есть эпизод данных от службы:</value>
+  </data>
+  <data name="Anime_In" xml:space="preserve">
+    <value>в</value>
+  </data>
+  <data name="Anime_Contracts" xml:space="preserve">
+    <value>Получил эпизод контракты:</value>
+  </data>
+  <data name="Anime_Sorted" xml:space="preserve">
+    <value>Сортировка эпизод контракты:</value>
+  </data>
+  <data name="AVDump_ToBe" xml:space="preserve">
+    <value>Для обработки</value>
+  </data>
+  <data name="Group_Groups" xml:space="preserve">
+    <value>Группы</value>
+  </data>
+  <data name="Group_FilterName" xml:space="preserve">
+    <value>Имя фильтра должны быть заполнены</value>
+  </data>
+  <data name="Ignore_RecDown" xml:space="preserve">
+    <value>Рекомендации - скачать</value>
+  </data>
+  <data name="Ignore_RecWatch" xml:space="preserve">
+    <value>Рекомендации - часы</value>
+  </data>
+  <data name="Ignore_AnimeID" xml:space="preserve">
+    <value>Аниме ID:</value>
+  </data>
+  <data name="JMMServer_TraktAuth" xml:space="preserve">
+    <value>Trakt Auth</value>
+  </data>
+  <data name="JMMServer_Success" xml:space="preserve">
+    <value>Успех</value>
+  </data>
+  <data name="JMMServer_Error" xml:space="preserve">
+    <value>Ошибка</value>
+  </data>
+  <data name="Missing_Episode" xml:space="preserve">
+    <value>Эпизод</value>
+  </data>
+  <data name="Missing_File" xml:space="preserve">
+    <value>Файл</value>
+  </data>
+  <data name="Playlist_Name" xml:space="preserve">
+    <value>Введите имя списка воспроизведения: </value>
+  </data>
+  <data name="Playlist_NameBlank" xml:space="preserve">
+    <value>Пожалуйста, введите имя списка воспроизведения</value>
+  </data>
+  <data name="Recommendation_Missing" xml:space="preserve">
+    <value>Отсутствуют данные</value>
+  </data>
+  <data name="Recommendation_NoOverview" xml:space="preserve">
+    <value>Обзор не доступны</value>
+  </data>
+  <data name="uTorrent_NotConnected" xml:space="preserve">
+    <value>Не подключен</value>
+  </data>
+  <data name="uTorrent_Connecting" xml:space="preserve">
+    <value>Подключение...</value>
+  </data>
+  <data name="Constants_Continue" xml:space="preserve">
+    <value>Продолжить просмотр (система)</value>
+  </data>
+  <data name="Constants_MainCharacter" xml:space="preserve">
+    <value>Главный герой в</value>
+  </data>
+  <data name="Group_GroupCount" xml:space="preserve">
+    <value> Группы</value>
+  </data>
+  <data name="Tab_Playlists" xml:space="preserve">
+    <value>Списки воспроизведения</value>
+  </data>
+  <data name="Playlist_NewPlaylist" xml:space="preserve">
+    <value>Новый список воспроизведения</value>
+  </data>
+  <data name="Tab_Bookmarks" xml:space="preserve">
+    <value>Закладки</value>
+  </data>
+  <data name="JMMServer_ImportFolders" xml:space="preserve">
+    <value>Импорт папки</value>
+  </data>
+  <data name="JMMServer_ServerStatus" xml:space="preserve">
+    <value>Статус сервера</value>
+  </data>
+  <data name="Tooltip_ClearHash" xml:space="preserve">
+    <value>Очистить все очереди хэш команды</value>
+  </data>
+  <data name="JMMServer_Running" xml:space="preserve">
+    <value>Запуск</value>
+  </data>
+  <data name="JMMServer_Paused" xml:space="preserve">
+    <value>Приостановлено</value>
+  </data>
+  <data name="Tooltip_ClearGeneral" xml:space="preserve">
+    <value>Очистить все очереди общие команды</value>
+  </data>
+  <data name="Tooltip_ClearImages" xml:space="preserve">
+    <value>Очистить все очереди сервера образа загрузки команд</value>
+  </data>
+  <data name="JMMServer_ServerImage" xml:space="preserve">
+    <value>Очереди сервера изображений</value>
+  </data>
+  <data name="Tab_AniDBAVDump" xml:space="preserve">
+    <value>Дамп AV AniDB</value>
+  </data>
+  <data name="Tab_FileSearch" xml:space="preserve">
+    <value>Поиск файлов</value>
+  </data>
+  <data name="Tab_FileRename" xml:space="preserve">
+    <value>Переименование файлов</value>
+  </data>
+  <data name="Tab_UpdateAniDB" xml:space="preserve">
+    <value>Обновление данных AniDB</value>
+  </data>
+  <data name="Tab_CommunityData" xml:space="preserve">
+    <value>Данные сообщества</value>
+  </data>
+  <data name="Tab_MyVotes" xml:space="preserve">
+    <value>Мои голоса</value>
+  </data>
+  <data name="VideoPlayer_MPCI" xml:space="preserve">
+    <value>Media Player Классический интеграции</value>
+  </data>
+  <data name="VideoPlayer_AutoFile" xml:space="preserve">
+    <value>Выбор автоматического файла</value>
+  </data>
+  <data name="TAB_SettingsOnlineDB_MAL" xml:space="preserve">
+    <value>Мой список аниме</value>
+  </data>
+  <data name="Tab_Downloads" xml:space="preserve">
+    <value>Загрузки</value>
+  </data>
+  <data name="Downloads_uTorrentInfo" xml:space="preserve">
+    <value>Это использует uTorrent WebUI API, который необходимо включить в вашем клиенте uTorrent сначала</value>
+  </data>
+  <data name="Downloads_uTorrentWebUI" xml:space="preserve">
+    <value>uTorrent WebUI детали</value>
+  </data>
+  <data name="Downloads_TorrentBlackHole" xml:space="preserve">
+    <value>Параметры черная дыра торрент</value>
+  </data>
+  <data name="Downloads_TorrentDefault" xml:space="preserve">
+    <value>По умолчанию торрент источники для поиска</value>
+  </data>
+  <data name="Downloads_BakaBT" xml:space="preserve">
+    <value>BakaBT параметры</value>
+  </data>
+  <data name="Downloads_AnimeBytes" xml:space="preserve">
+    <value>AnimeBytes параметры</value>
+  </data>
+  <data name="Downloads_BakaBTInfo" xml:space="preserve">
+    <value>BakaBT это аниме торрент-сайт, который специализируется в неделю полная серия, однако это требует учетной записи первых</value>
+  </data>
+  <data name="Downloads_AnimeBytesInfo" xml:space="preserve">
+    <value>AnimeBytes это аниме торрент-сайт, который специализируется в неделю полная серия, однако это требует учетной записи первых</value>
+  </data>
+  <data name="Downloads_GoTo" xml:space="preserve">
+    <value>Перейти на сайт</value>
+  </data>
+  <data name="Tab_Search" xml:space="preserve">
+    <value>Поиск</value>
+  </data>
+  <data name="Tab_Community" xml:space="preserve">
+    <value>Сообщество</value>
+  </data>
+  <data name="Main_Messages" xml:space="preserve">
+    <value>Сообщения</value>
+  </data>
+  <data name="Main_Paused" xml:space="preserve">
+    <value>Приостановлено из-за ЗАПРЕТА от AniDB (</value>
+  </data>
+  <data name="Main_User" xml:space="preserve">
+    <value>Пользователь</value>
+  </data>
+  <data name="Main_Feed" xml:space="preserve">
+    <value>Кормить</value>
+  </data>
+  <data name="Main_About" xml:space="preserve">
+    <value>О</value>
+  </data>
+  <data name="Tab_uTorrent" xml:space="preserve">
+    <value>uTorrent</value>
+  </data>
+  <data name="Tab_BrowseTorrents" xml:space="preserve">
+    <value>Поиск Торренты</value>
+  </data>
+  <data name="Tab_SearchTorrents" xml:space="preserve">
+    <value>Поиск Торренты</value>
+  </data>
+  <data name="Tab_Recommendations" xml:space="preserve">
+    <value>Рекомендации</value>
+  </data>
+  <data name="Tab_Settings" xml:space="preserve">
+    <value>Параметры</value>
+  </data>
+  <data name="Tab_SeriesInfo" xml:space="preserve">
+    <value>Информация о серии</value>
+  </data>
+  <data name="Tab_Comments" xml:space="preserve">
+    <value>Комментарии от пользователей</value>
+  </data>
+  <data name="Tab_Files" xml:space="preserve">
+    <value>Файлы</value>
+  </data>
+  <data name="Download_TorrentFolder" xml:space="preserve">
+    <value>Расположение папки торрент</value>
+  </data>
+  <data name="Search_TitleOnly" xml:space="preserve">
+    <value>Только название</value>
+  </data>
+</root>

--- a/JMMClient/UserControls/AnimeGroupControl.xaml
+++ b/JMMClient/UserControls/AnimeGroupControl.xaml
@@ -70,7 +70,7 @@
                     <Button Name="btnRandomEpisode" Margin="10,2,2,2" Style="{DynamicResource FlatButtonStyle}" >
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                             <Image Height="16" Width="16" Source="/Images/32_dice.png" Margin="0,0,3,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Random Episode" Margin="0,0,0,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=AnimeGroup_Random}" Margin="0,0,0,0"/>
                         </StackPanel>
                     </Button>
 
@@ -292,7 +292,7 @@
 
                 <!-- Play Next Episode Header -->
                 <Border Style="{DynamicResource ToolbarBorderControlStyle}" Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="3" Padding="6" Margin="0,10,0,0" Background="#F1F1F1">
-                    <TextBlock Text="Play Next Episode" FontSize="16" Foreground="DarkGray"/>
+                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=PlayNextEpisode}" FontSize="16" Foreground="DarkGray"/>
                 </Border>
 
                 <!-- Play Next Episode -->
@@ -301,8 +301,8 @@
                 <!-- All Series Header -->
                 <Border Style="{DynamicResource ToolbarBorderControlStyle}" Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="3" Padding="6" Background="#F1F1F1" Margin="0,10,0,0">
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="All Series" FontSize="16" Foreground="DarkGray" VerticalAlignment="Bottom"/>
-                        <TextBlock Text="Double click on a series to view it directly" FontSize="10" Foreground="DarkGray" Margin="20,0,0,0" VerticalAlignment="Bottom"/>
+                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=AnimeGroup_AllSeries}" FontSize="16" Foreground="DarkGray" VerticalAlignment="Bottom"/>
+                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=AnimeGroup_DoubleClick}" FontSize="10" Foreground="DarkGray" Margin="20,0,0,0" VerticalAlignment="Bottom"/>
                     </StackPanel>
                 </Border>
 

--- a/JMMClient/UserControls/AnimeSeries.xaml
+++ b/JMMClient/UserControls/AnimeSeries.xaml
@@ -335,7 +335,7 @@
     </UserControl.CommandBindings>
 
     <TabControl Grid.Column="0" Grid.Row="1" x:Name="tabContainer" Padding="0" Margin="2,0,2,0" SelectedIndex="0">
-        <TabItem Header="Series Info" x:Name="tabSeries">
+        <TabItem Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Tab_SeriesInfo}" x:Name="tabSeries">
             <DockPanel LastChildFill="True">
                 <!-- Toolbar -->
                 <Border x:Name="panelGroupReadOnlyToolbar" Style="{DynamicResource ToolbarBorderControlStyle}" DockPanel.Dock="Top">
@@ -346,7 +346,7 @@
                         <Button x:Name="btnSwitchView" Margin="2,2,2,2" Style="{DynamicResource FlatButtonStyle}" VerticalAlignment="Center">
                             <Image Height="16" Width="16" Source="/Images/16_columns.png" Margin="2,0,2,0">
                                 <Image.ToolTip>
-                                    <TextBlock Text="Show Simplified View"/>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=PinnedSeries_Simple}"/>
                                 </Image.ToolTip>
                             </Image>
                         </Button>
@@ -366,7 +366,7 @@
                                 Command="{DynamicResource RefreshSeriesCommand}" CommandParameter="{Binding}">
                             <Image Height="16" Width="16" Source="/Images/16_refresh.png" Margin="2,0,2,0">
                                 <Image.ToolTip>
-                                    <TextBlock Text="Refresh"/>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Refresh}"/>
                                 </Image.ToolTip>
                             </Image>
                         </Button>
@@ -375,7 +375,7 @@
                         <Button Margin="0,2,2,2" Style="{DynamicResource FlatButtonStyle}" VerticalAlignment="Center" Name="btnPlaylistAdd" >
                             <Image Height="16" Width="16" Source="/Images/32_playlist_add.png" Margin="2,0,2,0">
                                 <Image.ToolTip>
-                                    <TextBlock Text="Add to Playlist"/>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Playlist_Add}"/>
                                 </Image.ToolTip>
                             </Image>
                         </Button>
@@ -438,7 +438,7 @@
                         <Button x:Name="btnRandomEpisode" Margin="2,2,2,2" Style="{DynamicResource FlatButtonStyle}" >
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                 <Image Height="16" Width="16" Source="/Images/32_dice.png" Margin="0,0,3,0"/>
-                                <TextBlock VerticalAlignment="Center" Text="Random Episode" Margin="0,0,0,0"/>
+                                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=AnimeGroup_Random}" Margin="0,0,0,0"/>
                             </StackPanel>
                         </Button>
                     </WrapPanel>
@@ -703,7 +703,7 @@
 
                             <!-- Overview Header -->
                             <Border Style="{DynamicResource ToolbarBorderControlStyle}" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Padding="6" Background="#F1F1F1">
-                                <TextBlock Text="Overview" FontSize="16" Foreground="DarkGray"/>
+                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Series_Overview}" FontSize="16" Foreground="DarkGray"/>
                             </Border>
 
                             <!-- Description -->
@@ -719,7 +719,7 @@
 
                             <!-- More Info Header -->
                             <Border Style="{DynamicResource ToolbarBorderControlStyle}" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Padding="6" Background="#F1F1F1">
-                                <TextBlock Text="More Information" FontSize="16" Foreground="DarkGray"/>
+                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Series_MoreInfo}" FontSize="16" Foreground="DarkGray"/>
                             </Border>
 
                             <!-- Tags -->
@@ -909,7 +909,7 @@
                                         </Button>
                                     </StackPanel>
 
-                                    <TextBlock VerticalAlignment="Center" Text="Custom Tags" FontWeight="Bold" Margin="8,0,0,0"/>
+                                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Series_CustomTags}" FontWeight="Bold" Margin="8,0,0,0"/>
 
                                     <ListBox ScrollViewer.HorizontalScrollBarVisibility="Disabled"  VerticalAlignment="Top"
                                              Visibility="{Binding Source={x:Static local:UserSettingsVM.Instance}, Path=CustomTagsCollapsed, Converter={StaticResource BooleanToVisibilityConverter}}"
@@ -938,13 +938,13 @@
                                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                                 <Image Height="16" Width="16" Source="/Images/32_settings2.png" Margin="0,0,5,0">
                                                     <Image.ToolTip>
-                                                        <TextBlock Margin="5,0,0,0" Text="Manage Custom Tags" VerticalAlignment="Center" />
+                                                        <TextBlock Margin="5,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Series_ManageCustom}" VerticalAlignment="Center" />
                                                     </Image.ToolTip>
                                                 </Image>
                                             </StackPanel>
                                         </Button>
 
-                                        <TextBlock VerticalAlignment="Center" Text="Tag" Margin="2,0,5,0"/>
+                                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Series_Tag}" Margin="2,0,5,0"/>
                                         <ComboBox Name="cboCustomTag" Margin="3,3,5,3" Height="Auto" VerticalAlignment="Center"
                                             ItemTemplate="{StaticResource SimpleTagTemplate}"
                                             ItemsSource="{Binding Source={x:Static local:JMMServerVM.Instance},Path=ViewCustomTagsAll}"/>
@@ -952,7 +952,7 @@
                                         <Button Name="btnAddCustomTag" Margin="2,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                                 <Image Height="16" Width="16" Source="/Images/16_plus.png" Margin="0,0,5,0"/>
-                                                <TextBlock VerticalAlignment="Center" Text="Add" Margin="0,0,5,0"/>
+                                                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Series_Add}" Margin="0,0,5,0"/>
                                             </StackPanel>
                                         </Button>
 
@@ -1095,11 +1095,11 @@
             </ScrollViewer>
         </TabItem>
 
-        <TabItem x:Name="tabTraktShouts" Header="Comments From Users">
+        <TabItem x:Name="tabTraktShouts" Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Tab_Comments}">
             <usercontrols:TraktCommentsShowControl x:Name="ucTraktShouts"  />
         </TabItem>
 
-        <TabItem x:Name="tabFiles" Header="Files">
+        <TabItem x:Name="tabFiles" Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Tab_Files}">
 
             <Grid>
                 <Grid.RowDefinitions>
@@ -1124,7 +1124,7 @@
 
                 <!-- Files -->
                 <Border BorderBrush="LightGray" BorderThickness="1" Background="#FFE9ECEF" Margin="0,0,0,5" Grid.Row="0" Grid.ColumnSpan="2">
-                    <TextBlock Text="Files" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
+                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Series_Files}" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
                 </Border>
 
                 <Border Background="FloralWhite" BorderBrush="DarkGray" BorderThickness="1" Padding="5" Margin="5" Grid.Row="1" Grid.ColumnSpan="2">
@@ -1133,7 +1133,7 @@
 
                 <!-- Folders -->
                 <Border BorderBrush="LightGray" BorderThickness="1" Background="#FFE9ECEF" Margin="0,0,0,5" Grid.Row="2" Grid.ColumnSpan="2">
-                    <TextBlock Text="Folders" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
+                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Series_Folders}" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
                 </Border>
 
                 <Border Background="FloralWhite" BorderBrush="DarkGray" BorderThickness="1" Padding="5" Margin="5" Grid.Row="3" Grid.ColumnSpan="2">

--- a/JMMClient/UserControls/AnimeSeriesSimplifiedControl.xaml
+++ b/JMMClient/UserControls/AnimeSeriesSimplifiedControl.xaml
@@ -90,7 +90,7 @@
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                     <Image Height="16" Width="16" Source="/Images/trakttv.ico" Margin="2,0,2,0" ToolTipService.ShowDuration="60000">
                                         <Image.ToolTip>
-                                            <TextBlock Text="Go this episode on Trakt.TV"/>
+                                            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_TraktLink}"/>
                                         </Image.ToolTip>
                                     </Image>
 
@@ -102,7 +102,7 @@
                                     Visibility="{Binding Path=TraktLinkExists, Converter={StaticResource BooleanToVisibilityConverter}}">
                                 <StackPanel Orientation="Horizontal">
                                     <TextBlock Text="3" Foreground="DarkGray" FontWeight="Bold" FontSize="14" VerticalAlignment="Center" Margin="5,0,0,0"/>
-                                    <TextBlock Text="Comments" Foreground="DarkGray" FontWeight="Normal" FontSize="14" VerticalAlignment="Center" Margin="5,0,0,0" />
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_Comments}" Foreground="DarkGray" FontWeight="Normal" FontSize="14" VerticalAlignment="Center" Margin="5,0,0,0" />
                                 </StackPanel>
 
                             </Border>
@@ -147,7 +147,7 @@
                                     <Image Height="24" Width="24" Source="/Images/32_play2.png" Margin="0,0,0,0"/>
                                 </StackPanel>
                                 <Button.ToolTip>
-                                    <TextBlock Text="Play"/>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_Play}"/>
                                 </Button.ToolTip>
                             </Button>
                         </StackPanel>
@@ -159,7 +159,7 @@
                                    Foreground="Black" VerticalAlignment="Center">
                             </TextBlock>
 
-                            <TextBlock Margin="15,5,5,5" Text="Watched:" FontSize="12" FontWeight="Normal"
+                            <TextBlock Margin="15,5,5,5" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_Watched}" FontSize="12" FontWeight="Normal"
                                    Foreground="Black" VerticalAlignment="Center">
                             </TextBlock>
 
@@ -251,7 +251,7 @@
                                     <Image Height="24" Width="24" Source="/Images/32_play2.png" Margin="0,0,0,0"/>
                                 </StackPanel>
                                 <Button.ToolTip>
-                                    <TextBlock Text="Play"/>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_Play}"/>
                                 </Button.ToolTip>
                             </Button>
                         </StackPanel>
@@ -343,7 +343,7 @@
                                     <Image Height="24" Width="24" Source="/Images/32_play2.png" Margin="0,0,0,0"/>
                                 </StackPanel>
                                 <Button.ToolTip>
-                                    <TextBlock Text="Play"/>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_Play}"/>
                                 </Button.ToolTip>
                             </Button>
                         </StackPanel>
@@ -430,7 +430,7 @@
                                     <Image Height="24" Width="24" Source="/Images/32_play2.png" Margin="0,0,0,0"/>
                                 </StackPanel>
                                 <Button.ToolTip>
-                                    <TextBlock Text="Play"/>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_Play}"/>
                                 </Button.ToolTip>
                             </Button>
                         </StackPanel>
@@ -498,12 +498,12 @@
                         </TextBlock>
 
                         <StackPanel Orientation="Horizontal" Grid.Column="0" Grid.Row="2" Margin="5,2,5,5" Grid.ColumnSpan="2" HorizontalAlignment="Left">
-                            <TextBlock Text="From " FontSize="12" Foreground="DarkGray" VerticalAlignment="Center" />
+                            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_From}" FontSize="12" Foreground="DarkGray" VerticalAlignment="Center" />
                             <TextBlock Text="{Binding Path=Source}" FontSize="14" Foreground="DarkGray" VerticalAlignment="Center" Margin="3,0,0,0" FontWeight="Bold"/>
                             <Image Height="16" Width="16" Source="/Images/16_tick.png" Margin="5,0,0,0" VerticalAlignment="Center"
                                    Visibility="{Binding Path=HasSeries, Converter={StaticResource BooleanToVisibilityConverter}}">
                                 <Image.ToolTip>
-                                    <TextBlock Text="You Have this Anime in your collection"/>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_AlreadyHave}"/>
                                 </Image.ToolTip>
                             </Image>
                         </StackPanel>
@@ -513,7 +513,7 @@
                             <!-- Details -->
                             <Button Margin="0,0,0,0" VerticalAlignment="Center" Command="{StaticResource RecDetailsCommand}" CommandParameter="{Binding}">
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
-                                    <TextBlock Text="Details" VerticalAlignment="Center" FontSize="12" FontWeight="Normal"/>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_Details}" VerticalAlignment="Center" FontSize="12" FontWeight="Normal"/>
                                 </StackPanel>
                             </Button>
 
@@ -522,7 +522,7 @@
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                     <Image Height="24" Width="24" Source="/Images/vote_up2.png" Margin="2,0,2,0" VerticalAlignment="Center">
                                         <Image.ToolTip>
-                                            <TextBlock Text="Vote Up"/>
+                                            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_VoteUp}"/>
                                         </Image.ToolTip>
                                     </Image>
                                 </StackPanel>
@@ -533,7 +533,7 @@
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center"  >
                                     <Image Height="24" Width="24" Source="/Images/vote_down2.png" Margin="2,0,2,0" VerticalAlignment="Center">
                                         <Image.ToolTip>
-                                            <TextBlock Text="Vote Down"/>
+                                            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_VoteDown}"/>
                                         </Image.ToolTip>
                                     </Image>
                                 </StackPanel>
@@ -563,7 +563,7 @@
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
 
-                        <TextBlock Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2"  Margin="5,0,0,0" Text="From Trakt" FontSize="14" Foreground="DarkGreen" 
+                        <TextBlock Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2"  Margin="5,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_FromTrakt}" FontSize="14" Foreground="DarkGreen" 
                                    VerticalAlignment="Center" FontWeight="Bold"/>
 
                         <TextBlock Grid.Column="1" Grid.Row="1" Margin="15,0,0,0" Text="{Binding Path=Comment.CommentDateString}" FontSize="12" HorizontalAlignment="Left"
@@ -581,7 +581,7 @@
                             <Button Style="{StaticResource RoundButtonStyle}" VerticalAlignment="Center"
                             Command="{StaticResource ViewCommentCommand}" CommandParameter="{Binding}">
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
-                                    <TextBlock Text="View"/>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_View}"/>
 
                                 </StackPanel>
                             </Button>
@@ -608,7 +608,7 @@
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
 
-                        <TextBlock Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Margin="5,0,0,0" Text="From AniDB" FontSize="14" Foreground="DarkBlue" VerticalAlignment="Center" FontWeight="Bold"/>
+                        <TextBlock Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Margin="5,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_FromAniDB}" FontSize="14" Foreground="DarkBlue" VerticalAlignment="Center" FontWeight="Bold"/>
 
                         <TextBlock Grid.Column="0" Grid.Row="1" Margin="5,0,0,0" Text="{Binding Path=UserID}" VerticalAlignment="Center" FontSize="14" FontWeight="Bold"
                                    Foreground="Black" ToolTipService.ShowDuration="60000">
@@ -627,7 +627,7 @@
                             <Button Style="{StaticResource RoundButtonStyle}" VerticalAlignment="Center"
                             Command="{StaticResource ViewCommentCommand}" CommandParameter="{Binding}">
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
-                                    <TextBlock Text="View"/>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_View}"/>
 
                                 </StackPanel>
                             </Button>
@@ -867,7 +867,7 @@
                         </Rectangle.Fill>
                     </Rectangle>
 
-                    <TextBlock Grid.Row="1" Grid.Column="2" Grid.ColumnSpan="1" Text="Aired" FontWeight="Bold"  HorizontalAlignment="Stretch" Margin="10,5,5,5" 
+                    <TextBlock Grid.Row="1" Grid.Column="2" Grid.ColumnSpan="1" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_Aired}" FontWeight="Bold"  HorizontalAlignment="Stretch" Margin="10,5,5,5" 
                             VerticalAlignment="Top" TextWrapping="Wrap" Foreground="Black" FontSize="16" >
                     </TextBlock>
 
@@ -875,7 +875,7 @@
                             VerticalAlignment="Top" TextWrapping="Wrap" Foreground="Black" FontSize="16" >
                     </TextBlock>
 
-                    <TextBlock Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="1" Text="Episodes" FontWeight="Bold"  HorizontalAlignment="Stretch" Margin="10,5,5,5" 
+                    <TextBlock Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="1" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_Episodes}" FontWeight="Bold"  HorizontalAlignment="Stretch" Margin="10,5,5,5" 
                             VerticalAlignment="Top" TextWrapping="Wrap" Foreground="Black" FontSize="16" >
                     </TextBlock>
 
@@ -907,7 +907,7 @@
                             <!-- User rating if the user has NOT voted -->
                             <StackPanel Orientation="Horizontal">
 
-                                <TextBlock Margin="5,0,5,0"  FontWeight="Heavy" Foreground="DarkGray"  Text="My Vote" VerticalAlignment="Center"/>
+                                <TextBlock Margin="5,0,5,0"  FontWeight="Heavy" Foreground="DarkGray"  Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_MyVote}" VerticalAlignment="Center"/>
 
                                 <usercontrols:RatingControl x:Name="cRating" Width="280" Height="24" RatingValue="{Binding Path=AniDB_Anime.Detail.UserRating}" />
 
@@ -921,7 +921,7 @@
                             <Button Name="btnPlayNextEp" Margin="0" VerticalAlignment="Top" >
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                     <Image Height="24" Width="24" Source="/Images/32_play2.png" Margin="2,0,2,0" VerticalAlignment="Center"/>
-                                    <TextBlock Text="Play Next Episode" FontSize="14" VerticalAlignment="Center" Margin="2,0,8,0"/>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_PlayNext}" FontSize="14" VerticalAlignment="Center" Margin="2,0,8,0"/>
                                 </StackPanel>
 
                             </Button>
@@ -929,7 +929,7 @@
                             <Button Name="btnPlayAllEps" VerticalAlignment="Top" Margin="12,0,2,0">
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                     <Image Height="24" Width="24" Source="/Images/32_play2.png" Margin="2,0,2,0" VerticalAlignment="Center"/>
-                                    <TextBlock Text="Play All UnWatched (" FontSize="14" VerticalAlignment="Center" Margin="2,0,0,0"/>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_PlayUnWatched}" FontSize="14" VerticalAlignment="Center" Margin="2,0,0,0"/>
                                     <TextBlock Text="{Binding Path=UnwatchedEpisodeCount, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:AnimeSeriesSimplifiedControl}}}" FontSize="14" VerticalAlignment="Center" Margin="0,0,0,0"/>
                                     <TextBlock Text=")" FontSize="14" VerticalAlignment="Center" Margin="0,0,8,0"/>
                                 </StackPanel>
@@ -940,7 +940,7 @@
 
 
                                 <TextBox Name="txtCommentNew" Height="30" Width="300" HorizontalAlignment="Stretch" DockPanel.Dock="Left" TextWrapping="Wrap" 
-                         VerticalScrollBarVisibility="Visible" AcceptsReturn="True" Foreground="DarkGray" Text="Have Your Say..." FontSize="14" />
+                         VerticalScrollBarVisibility="Visible" AcceptsReturn="True" Foreground="DarkGray" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_YourSay}" FontSize="14" />
 
                                 <StackPanel  Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Top" Margin="10,0,0,0">
 
@@ -948,7 +948,7 @@
 
                                         <Border BorderThickness="0" BorderBrush="Navy" Background="{StaticResource GreenGradientBrush}" Padding="6,3,3,3" CornerRadius="4">
                                             <StackPanel Orientation="Horizontal">
-                                                <TextBlock Text="Comment on Trakt" Foreground="White" FontWeight="Bold" FontSize="12" VerticalAlignment="Center"/>
+                                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_TraktComment}" Foreground="White" FontWeight="Bold" FontSize="12" VerticalAlignment="Center"/>
                                                 <Image Height="16" Width="16" Source="/Images/trakt-icon-shouts.png" Margin="10,0,4,0" VerticalAlignment="Center"/>
                                             </StackPanel>
 
@@ -958,7 +958,7 @@
 
                                     <StackPanel Orientation="Horizontal" Margin="5" VerticalAlignment="Center">
                                         <CheckBox Name="chkSpoiler" VerticalAlignment="Center"/>
-                                        <TextBlock Text="Spoiler" Foreground="Black" FontSize="12" VerticalAlignment="Center" Margin="5,0,0,0"/>
+                                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_Spoiler}" Foreground="Black" FontSize="12" VerticalAlignment="Center" Margin="5,0,0,0"/>
 
                                     </StackPanel>
 
@@ -979,7 +979,7 @@
 
                 <!-- Play Next Episode -->
 
-                <TextBlock VerticalAlignment="Top" Text="Episodes" Foreground="DarkBlue" FontFamily="Segoe UI"  FontSize="20" Margin="5,10,0,0"  Grid.Row="3" Grid.Column="0"/>
+                <TextBlock VerticalAlignment="Top" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_Episodes}" Foreground="DarkBlue" FontFamily="Segoe UI"  FontSize="20" Margin="5,10,0,0"  Grid.Row="3" Grid.Column="0"/>
 
 
                 <ListBox x:Name="lbEpisodes" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="3" BorderThickness="0"   HorizontalAlignment="Stretch" ScrollViewer.HorizontalScrollBarVisibility="Disabled" Margin="5,5,0,5"
@@ -1001,7 +1001,7 @@
 
 
                 <!-- Characters -->
-                <TextBlock VerticalAlignment="Top" Text="Characters" Foreground="DarkBlue" FontFamily="Segoe UI"  FontSize="20" Margin="5,10,0,0"  Grid.Row="5" Grid.Column="0"/>
+                <TextBlock VerticalAlignment="Top" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_Characters}" Foreground="DarkBlue" FontFamily="Segoe UI"  FontSize="20" Margin="5,10,0,0"  Grid.Row="5" Grid.Column="0"/>
 
                 <ListBox x:Name="lbChars" Grid.Row="6" Grid.Column="0" BorderThickness="0" Grid.ColumnSpan="3"  HorizontalAlignment="Stretch" ScrollViewer.HorizontalScrollBarVisibility="Disabled" Margin="5,5,0,5"
                  VirtualizingStackPanel.IsVirtualizing="True" ScrollViewer.CanContentScroll="True"
@@ -1021,7 +1021,7 @@
                 </ListBox>
 
                 <!-- Recommendations -->
-                <TextBlock VerticalAlignment="Top" Text="You May Also Like" Foreground="DarkBlue" FontFamily="Segoe UI"  FontSize="20" Margin="5,10,0,0"  Grid.Row="7" Grid.Column="0"/>
+                <TextBlock VerticalAlignment="Top" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_AlsoLike}" Foreground="DarkBlue" FontFamily="Segoe UI"  FontSize="20" Margin="5,10,0,0"  Grid.Row="7" Grid.Column="0"/>
 
                 <ListBox x:Name="lbRecommendations" Grid.Row="8" Grid.Column="0" BorderThickness="0" Grid.ColumnSpan="3"  HorizontalAlignment="Stretch" ScrollViewer.HorizontalScrollBarVisibility="Disabled" Margin="5,5,0,5"
                  VirtualizingStackPanel.IsVirtualizing="True" ScrollViewer.CanContentScroll="True"
@@ -1045,7 +1045,7 @@
                 <!-- Comments -->
                 <StackPanel Orientation="Horizontal" Margin="5,10,0,0"  Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="3">
 
-                    <TextBlock VerticalAlignment="Top" Text="What People Are Saying" Foreground="DarkBlue" FontFamily="Segoe UI"  FontSize="20" Margin="0,0,10,0" />
+                    <TextBlock VerticalAlignment="Top" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_PeopleSaying}" Foreground="DarkBlue" FontFamily="Segoe UI"  FontSize="20" Margin="0,0,10,0" />
 
                     <!-- refresh comments button -->
                     <Button x:Name="btnRefreshComments"  Margin="0,0,2,2" Style="{StaticResource FlatButtonStyle}" VerticalAlignment="Center" ToolTip="Update Info from AniDB and Refresh"
@@ -1055,7 +1055,7 @@
                         </StackPanel>
                     </Button>
 
-                    <TextBlock VerticalAlignment="Top" Text="Loading..." Foreground="Green" FontFamily="Segoe UI"  FontSize="20" Margin="0,0,0,0"
+                    <TextBlock VerticalAlignment="Top" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_Loading}" Foreground="Green" FontFamily="Segoe UI"  FontSize="20" Margin="0,0,0,0"
                            Visibility="{Binding Path=IsLoadingComments, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:AnimeSeriesSimplifiedControl}}, Converter={StaticResource BooleanToVisibilityConverter}}"/>
 
                 </StackPanel>

--- a/JMMClient/UserControls/AvdumpBatchControl.xaml
+++ b/JMMClient/UserControls/AvdumpBatchControl.xaml
@@ -39,7 +39,7 @@
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                                 <Image Height="16" Width="16" Source="/Images/32_delete.png" Margin="0,0,5,0">
                                     <Image.ToolTip>
-                                        <TextBlock VerticalAlignment="Center" Text="Remove from list" Margin="0,0,5,0"/>
+                                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=AvDump_Remove}" Margin="0,0,5,0"/>
                                     </Image.ToolTip>
                                 </Image>
                                 
@@ -107,7 +107,7 @@
                     <Button Name="btnClearList" Margin="2,2,2,2" Style="{DynamicResource FlatButtonStyle}" VerticalAlignment="Center">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                             <Image Height="16" Width="16" Source="/Images/32_delete.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Clear List" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=AvDump_Clear}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
 
@@ -117,7 +117,7 @@
                     <Button Name="btnDumpFiles" Margin="10,2,2,2" Style="{DynamicResource FlatButtonStyle}" VerticalAlignment="Center">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                             <Image Height="16" Width="16" Source="/Images/32_sync.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Dump Files" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=AvDump_Dump}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
 
@@ -126,7 +126,7 @@
                             Visibility="{Binding Path=IsDumpRunning, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:AvdumpBatchControl}}, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                             <Image Height="16" Width="16" Source="/Images/32_cancel.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Cancel" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Cancel}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
 

--- a/JMMClient/UserControls/BookmarksControl.xaml
+++ b/JMMClient/UserControls/BookmarksControl.xaml
@@ -180,10 +180,10 @@
                 </StackPanel>
             </Button>
 
-            <CheckBox Name="chkDownloading" Content="Downloading" VerticalAlignment="Center" Margin="10,5,0,5"
+            <CheckBox Name="chkDownloading" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=Bookmarks_Downloading}" VerticalAlignment="Center" Margin="10,5,0,5"
                                   IsChecked="True"/>
 
-            <CheckBox Name="chkNotDownloading" Content="Not Downloading" VerticalAlignment="Center" Margin="10,5,0,5"
+            <CheckBox Name="chkNotDownloading" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=Bookmarks_NotDownloading}" VerticalAlignment="Center" Margin="10,5,0,5"
                                   IsChecked="True"/>
         </StackPanel>
         <ListBox DockPanel.Dock="Top" Name="lbBookmarks" BorderThickness="0" Background="Transparent" Grid.Row="1"

--- a/JMMClient/UserControls/Community/CommunityMaint.xaml
+++ b/JMMClient/UserControls/Community/CommunityMaint.xaml
@@ -36,7 +36,7 @@
         <TabControl Grid.Row="0" Grid.Column="0" Margin="5" Name="tabCommMaint" TabStripPlacement="Top" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" >
 
 
-            <TabItem Header="Trakt">
+            <TabItem Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Trakt}">
 
                 <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
                     <Grid>
@@ -55,13 +55,13 @@
                         <Border DockPanel.Dock="Top" Background="FloralWhite" BorderBrush="DarkGray" BorderThickness="1" Grid.Column="0" Grid.Row="0" Padding="2"  Grid.ColumnSpan="3">
                             <StackPanel Orientation="Vertical">
 
-                                <CheckBox Name="chkTraktValid" Margin="5" Content="Check my links are still valid on Trakt" IsChecked="True"/>
-                                <CheckBox Name="chkTraktValidCleanup" Margin="25,5,5,5" Content="Automatically remove bad information from the database (highly recommended)" IsChecked="True"/>
-                                <CheckBox Name="chkCommRec" Margin="5" Content="Check if my links are different from the community recommendations" IsChecked="True"/>
+                                <CheckBox Name="chkTraktValid" Margin="5" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=Community_TraktValid}" IsChecked="True"/>
+                                <CheckBox Name="chkTraktValidCleanup" Margin="25,5,5,5" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=Community_TraktRemoveBad}" IsChecked="True"/>
+                                <CheckBox Name="chkCommRec" Margin="5" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=Community_CommunityCheck}" IsChecked="True"/>
 
                                 <StackPanel Orientation="Horizontal"  HorizontalAlignment="Left" Margin="0">
 
-                                    <CheckBox Name="chkLimitSeries" Margin="5" Content="Stop after finding this many problems " IsChecked="True"/>
+                                    <CheckBox Name="chkLimitSeries" Margin="5" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=Community_ProblemStop}" IsChecked="True"/>
                                     <extToolkit:IntegerUpDown Name="udLimitSeries" Minimum="1" Maximum="99999" DefaultValue="50" Value="50" VerticalAlignment="Center"/>
 
 
@@ -79,7 +79,7 @@
                                             AncestorType={x:Type usercontrols:CommunityMaint}}, Converter={StaticResource BooleanToVisibilityConverter}}">
                                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                             <Image Height="16" Width="16" Source="/Images/32_play2.png" Margin="0,0,5,0"/>
-                                            <TextBlock VerticalAlignment="Center" Text="Start" Margin="0,0,5,0"/>
+                                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Start}" Margin="0,0,5,0"/>
                                         </StackPanel>
                                     </Button>
 
@@ -89,7 +89,7 @@
                                             AncestorType={x:Type usercontrols:CommunityMaint}}, Converter={StaticResource BooleanToVisibilityConverter}}">
                                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                             <Image Height="16" Width="16" Source="/Images/Pause.png" Margin="0,0,5,0"/>
-                                            <TextBlock VerticalAlignment="Center" Text="Pause" Margin="0,0,5,0"/>
+                                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Pause}" Margin="0,0,5,0"/>
                                         </StackPanel>
                                     </Button>
 
@@ -99,7 +99,7 @@
                                             AncestorType={x:Type usercontrols:CommunityMaint}}, Converter={StaticResource BooleanToVisibilityConverter}}">
                                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                             <Image Height="16" Width="16" Source="/Images/32_cancel.png" Margin="0,0,5,0"/>
-                                            <TextBlock VerticalAlignment="Center" Text="Stop" Margin="0,0,5,0"/>
+                                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Stop}" Margin="0,0,5,0"/>
                                         </StackPanel>
                                     </Button>
 
@@ -127,7 +127,7 @@
             <Border DockPanel.Dock="Top" Background="#F1F1F1" BorderBrush="DarkGray" BorderThickness="1" Padding="5">
                 <StackPanel Orientation="Horizontal">
 
-                    <TextBlock VerticalAlignment="Center" Text="Filter:" Margin="10,0,0,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Community_Filter}" Margin="10,0,0,0"/>
 
                     <ComboBox Name="cboFilterType" Margin="3,3,5,3" Height="24" VerticalAlignment="Center"/>
 
@@ -160,11 +160,11 @@
                     </Style>
                 </DataGrid.CellStyle>
                 <DataGrid.Columns>
-                    
-                    <DataGridTextColumn Header="Series Name" Binding="{Binding SeriesName}" IsReadOnly="True" />
-                    <DataGridTextColumn Header="Status" Binding="{Binding Status}" IsReadOnly="True" />
 
-                    <DataGridTemplateColumn Header="Valid Trakt Link" IsReadOnly="True">
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Community_SeriesName}" Binding="{Binding SeriesName}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Community_Status}" Binding="{Binding Status}" IsReadOnly="True" />
+
+                    <DataGridTemplateColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Community_ValidTraktLink}" IsReadOnly="True">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <Image Source="{Binding IsTraktLinkValidImage}" Width="16" Height="16" />
@@ -172,7 +172,7 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTemplateColumn Header="Has Trakt Link" IsReadOnly="True">
+                    <DataGridTemplateColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Community_HasTraktLink}" IsReadOnly="True">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <Image Source="{Binding HasTraktLinkImage}" Width="16" Height="16" />
@@ -180,7 +180,7 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTemplateColumn Header="Community Link" IsReadOnly="True">
+                    <DataGridTemplateColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Community_CommunityLink}" IsReadOnly="True">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <Image Source="{Binding HasTraktCommLinkImage}" Width="16" Height="16" />
@@ -188,7 +188,7 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTemplateColumn Header="Links Match?" IsReadOnly="True">
+                    <DataGridTemplateColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Community_Match}" IsReadOnly="True">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <Image Source="{Binding UserTraktLinkMatchImage}" Width="16" Height="16" />
@@ -220,7 +220,7 @@
                                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                             <Image Height="16" Width="16" Source="/Images/16_refresh.png" Margin="2,0,2,0">
                                                 <Image.ToolTip>
-                                                    <TextBlock Text="Refresh data for this series"/>
+                                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Community_Refresh}"/>
                                                 </Image.ToolTip>
                                             </Image>
 

--- a/JMMClient/UserControls/DashboardControl.xaml
+++ b/JMMClient/UserControls/DashboardControl.xaml
@@ -394,7 +394,7 @@
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,0">
-                                <TextBlock Text="Approval" Foreground="DarkGreen" FontWeight="Medium" VerticalAlignment="Center"/>
+                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Approval}" Foreground="DarkGreen" FontWeight="Medium" VerticalAlignment="Center"/>
                                 <TextBlock Text="{Binding Path=Recommended_ApprovalRating}" Foreground="Black" VerticalAlignment="Center" Margin="5,0,0,0"/>
                             </StackPanel>
                         </StackPanel>
@@ -452,7 +452,7 @@
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,0">
-                                <TextBlock Text="Your Vote" Foreground="DarkGreen" FontWeight="Medium" VerticalAlignment="Center"/>
+                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Dashboard_YourVote}" Foreground="DarkGreen" FontWeight="Medium" VerticalAlignment="Center"/>
                                 <TextBlock Text="{Binding Path=BasedOnVoteValueFormatted}" Foreground="Black" VerticalAlignment="Center" Margin="5,0,0,0"/>
                             </StackPanel>
                         </StackPanel>
@@ -529,7 +529,7 @@
                                         Command="{DynamicResource BookmarkAnimeCommand}" CommandParameter="{Binding}">
                                     <Image Height="16" Width="16" Source="/Images/32_bookmark.png" Margin="1,0,1,0" ToolTipService.ShowDuration="60000">
                                         <Image.ToolTip>
-                                            <TextBlock Text="Bookmark this anime to download later"/>
+                                            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Dashboard_Bookmark}"/>
                                         </Image.ToolTip>
                                     </Image>
                                 </Button>
@@ -539,14 +539,14 @@
                                         Command="{DynamicResource ShowTorrentSearchCommand}" CommandParameter="{Binding}">
                                     <Image Height="16" Width="16" Source="/Images/24_download3.png" Margin="2,0,2,0">
                                         <Image.ToolTip>
-                                            <TextBlock Text="Search for downloads for this series"/>
+                                            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Dashboard_Download}"/>
                                         </Image.ToolTip>
                                     </Image>
                                 </Button>
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,0">
-                                <TextBlock Text="Approval" Foreground="DarkGreen" FontWeight="Medium" VerticalAlignment="Center"/>
+                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Approval}" Foreground="DarkGreen" FontWeight="Medium" VerticalAlignment="Center"/>
                                 <TextBlock Text="{Binding Path=Recommended_ApprovalRating}" Foreground="Black" VerticalAlignment="Center" Margin="5,0,0,0"/>
                             </StackPanel>
                         </StackPanel>
@@ -604,7 +604,7 @@
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,0">
-                                <TextBlock Text="Your Vote" Foreground="DarkGreen" FontWeight="Medium" VerticalAlignment="Center"/>
+                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Dashboard_YourVote}" Foreground="DarkGreen" FontWeight="Medium" VerticalAlignment="Center"/>
                                 <TextBlock Text="{Binding Path=BasedOnVoteValueFormatted}" Foreground="Black" VerticalAlignment="Center" Margin="5,0,0,0"/>
                             </StackPanel>
                         </StackPanel>
@@ -660,7 +660,7 @@
                             Background="FloralWhite">
                         <StackPanel Orientation="Horizontal" Margin="10,10,10,5">
                             <Image Height="16" Width="16" Source="/Images/32_Info.png" Margin="0,0,5,0"/>
-                            <TextBlock Text="No recommendations could be found." FontWeight="Bold" VerticalAlignment="Center" Foreground="Black"/>
+                            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Dashboard_NoRecommend}" FontWeight="Bold" VerticalAlignment="Center" Foreground="Black"/>
                         </StackPanel>
                     </Border>
 
@@ -668,7 +668,7 @@
                             Background="FloralWhite">
 
                         <StackPanel Orientation="Horizontal" Margin="10,10,10,5">
-                            <TextBlock Text="Download your votes now, or vote on an anime to start getting recommendations." VerticalAlignment="Center" Foreground="Black"/>
+                            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Dashboard_DownloadVotes}" VerticalAlignment="Center" Foreground="Black"/>
                         </StackPanel>
                     </Border>
 
@@ -679,7 +679,7 @@
                                 Command="{DynamicResource SyncVotesCommand}" CommandParameter="{Binding}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                 <Image Height="16" Width="16" Source="/Images/32_sync.png" Margin="0,0,5,0"/>
-                                <TextBlock VerticalAlignment="Center" Text="Sync Votes" Foreground="Black"  Margin="0,0,5,0"/>
+                                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Dashboard_SyncVotes}" Foreground="Black"  Margin="0,0,5,0"/>
                             </StackPanel>
                         </Button>
                     </Border>
@@ -776,7 +776,7 @@
                         </Grid.RowDefinitions>
 
                         <StackPanel Orientation="Horizontal" Margin="0,0,0,5" Grid.Row="1" Grid.Column="0">
-                            <TextBlock Text="Added" Foreground="Black" FontWeight="Bold" VerticalAlignment="Center"/>
+                            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Dashboard_Added}" Foreground="Black" FontWeight="Bold" VerticalAlignment="Center"/>
                             <TextBlock Text="{Binding Path=DateTimeCreatedAsString}" Foreground="Black" VerticalAlignment="Center" Margin="5,0,0,0"/>
                         </StackPanel>
 
@@ -874,7 +874,7 @@
                 <Button Name="btnToggleDash" Margin="12,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                         <Image Height="16" Width="16" Source="/Images/Metro/MetroDash2_16.png" Margin="0,0,3,0"/>
-                        <TextBlock VerticalAlignment="Center" Text="Metro Dash" Margin="0,0,5,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Dashboard_Metro}" Margin="0,0,5,0"/>
                     </StackPanel>
                 </Button>
 
@@ -1110,7 +1110,7 @@
                             <Button Name="btnForceCalendarRefresh" Margin="10,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                     <Image Height="16" Width="16" Source="/Images/32_sync.png" Margin="0,0,3,0"/>
-                                    <TextBlock VerticalAlignment="Center" Text="Update Calendar Data" Margin="0,0,0,0"/>
+                                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Dashboard_UpdateCalendar}" Margin="0,0,0,0"/>
                                 </StackPanel>
                             </Button>
                             <StackPanel />
@@ -1410,7 +1410,7 @@
                                     </Image>
                                     <Image Height="16" Width="16" Source="/Images/64_navup.png" Margin="2,0,2,0"
                                            Visibility="{Binding Source={x:Static local:UserSettingsVM.Instance}, Path=DashRecentAdditionsExpanded, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                                    <TextBlock VerticalAlignment="Center" Text="Recent Additions" 
+                                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Dashboard_Recent}" 
                                                FontWeight="Bold" Margin="0,0,0,0"/>
                                 </StackPanel>
                             </Button>

--- a/JMMClient/UserControls/DashboardMetroDXControl.xaml
+++ b/JMMClient/UserControls/DashboardMetroDXControl.xaml
@@ -313,9 +313,9 @@
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
 
-                <TextBlock Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="4" IsHitTestVisible="False" Text="Options" Foreground="Black" FontSize="24" FontWeight="Bold" />
+                <TextBlock Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="4" IsHitTestVisible="False" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Metro_Options}" Foreground="Black" FontSize="24" FontWeight="Bold" />
 
-                <TextBlock Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="4" IsHitTestVisible="False" Text="General" Foreground="DarkBlue" FontSize="16" FontWeight="Bold" Margin="0,10,0,0"/>
+                <TextBlock Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="4" IsHitTestVisible="False" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Metro_General}" Foreground="DarkBlue" FontSize="16" FontWeight="Bold" Margin="0,10,0,0"/>
 
                 <!-- Height Buttons -->
                 <StackPanel Grid.Column="1" Grid.Row="1" Grid.ColumnSpan="4" Orientation="Horizontal" Margin="10,2,2,2" >
@@ -336,7 +336,7 @@
 
                 <!-- Posters or fanart -->
                 <StackPanel Grid.Column="1" Grid.Row="2" Grid.ColumnSpan="4" Orientation="Horizontal" Margin="10,2,2,2" >
-                    <TextBlock VerticalAlignment="Center" Text="Image Type" Margin="0,0,3,0" Foreground="Black"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Metro_ImageType}" Margin="0,0,3,0" Foreground="Black"/>
 
                     <ComboBox Name="cboImageType" VerticalAlignment="Center">
                     </ComboBox>
@@ -344,7 +344,7 @@
 
 
                 <!-- Number of Items - Continue Watching -->
-                <TextBlock Grid.Column="0" Grid.Row="4" Grid.ColumnSpan="1" IsHitTestVisible="False" Text="Continue Watching" Foreground="DarkBlue" FontSize="16" FontWeight="Bold" Margin="0,10,0,0"/>
+                <TextBlock Grid.Column="0" Grid.Row="4" Grid.ColumnSpan="1" IsHitTestVisible="False" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Metro_Continue}" Foreground="DarkBlue" FontSize="16" FontWeight="Bold" Margin="0,10,0,0"/>
 
                 
                 <StackPanel Grid.Column="1" Grid.Row="4" Grid.ColumnSpan="4" Orientation="Horizontal" Margin="10,10,2,2" >
@@ -354,7 +354,7 @@
                 </StackPanel>
 
                 <!-- Number of Items - Random Series -->
-                <TextBlock Grid.Column="0" Grid.Row="5" Grid.ColumnSpan="1" IsHitTestVisible="False" Text="Random Series" Foreground="DarkBlue" FontSize="16" FontWeight="Bold" Margin="0,10,0,0"/>
+                <TextBlock Grid.Column="0" Grid.Row="5" Grid.ColumnSpan="1" IsHitTestVisible="False" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Metro_Random}" Foreground="DarkBlue" FontSize="16" FontWeight="Bold" Margin="0,10,0,0"/>
 
                
                 <StackPanel Grid.Column="1" Grid.Row="5" Grid.ColumnSpan="4" Orientation="Horizontal" Margin="10,10,2,2" >
@@ -364,17 +364,17 @@
                 </StackPanel>
 
                 <!-- Number of Items - New Episodes -->
-                <TextBlock Grid.Column="0" Grid.Row="6" Grid.ColumnSpan="1" IsHitTestVisible="False" Text="New Episodes" Foreground="DarkBlue" FontSize="16" FontWeight="Bold" Margin="0,10,0,0"/>
+                <TextBlock Grid.Column="0" Grid.Row="6" Grid.ColumnSpan="1" IsHitTestVisible="False" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Metro_New}" Foreground="DarkBlue" FontSize="16" FontWeight="Bold" Margin="0,10,0,0"/>
 
                 
                 <StackPanel Grid.Column="1" Grid.Row="6" Grid.ColumnSpan="4" Orientation="Horizontal" Margin="10,10,2,2" >
-                    <TextBlock VerticalAlignment="Center" Text="Items" Margin="0,0,5,0" Foreground="Black"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Metro_Items}" Margin="0,0,5,0" Foreground="Black"/>
                     <extToolkit:IntegerUpDown Name="udItemsNewEpisodes" Minimum="1" Maximum="100" DefaultValue="5" VerticalAlignment="Center" 
                                       Value="{Binding Source={x:Static local:UserSettingsVM.Instance},Path=DashMetro_NewEpisodes_Items}" />
                 </StackPanel>
 
                 <!-- Sections -->
-                <TextBlock Grid.Column="0" Grid.Row="7" Grid.ColumnSpan="6" IsHitTestVisible="False" Text="Sections" Foreground="DarkBlue" FontSize="16" FontWeight="Bold" Margin="0,10,0,0"/>
+                <TextBlock Grid.Column="0" Grid.Row="7" Grid.ColumnSpan="6" IsHitTestVisible="False" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Metro_Sections}" Foreground="DarkBlue" FontSize="16" FontWeight="Bold" Margin="0,10,0,0"/>
 
                 <ListBox Margin="10,10,0,10" BorderThickness="0" Background="Transparent" Grid.Column="0" Grid.Row="8" Grid.ColumnSpan="4"
                          HorizontalAlignment="Left" VerticalAlignment="Top" 
@@ -420,7 +420,7 @@
                         Grid.Column="{Binding Path=Dash_ContinueWatching_Column, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:DashboardMetroDXControl}}}" 
                         Visibility="{Binding Path=Dash_ContinueWatching_Visibility, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:DashboardMetroDXControl}}}"
                         Grid.Row="1" Margin="10,5,0,17">
-                <TextBlock IsHitTestVisible="False"  Text="Continue Watching" Foreground="Black" FontSize="24" FontFamily="Segoe UI" FontWeight="Bold"  VerticalAlignment="Center"/>
+                <TextBlock IsHitTestVisible="False"  Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Metro_Continue}" Foreground="Black" FontSize="24" FontFamily="Segoe UI" FontWeight="Bold"  VerticalAlignment="Center"/>
 
                 <!-- Refresh -->
                 <Button Name="btnRefresh" Margin="12,2,2,2" Style="{DynamicResource FlatButtonStyle}">
@@ -428,7 +428,7 @@
                         <Image Height="24" Width="24" Source="/Images/Metro/refresh.png" Margin="0,0,0,0"/>
                     </StackPanel>
                     <Button.ToolTip>
-                        <TextBlock Text="Refresh"/>
+                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Metro_Refresh}"/>
                     </Button.ToolTip>
                 </Button>
 
@@ -477,7 +477,7 @@
                         Grid.Column="{Binding Path=Dash_RandomSeries_Column, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:DashboardMetroDXControl}}}" 
                         Visibility="{Binding Path=Dash_RandomSeries_Visibility, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:DashboardMetroDXControl}}}"
                         Grid.Row="1" Margin="10,5,0,17">
-                <TextBlock  IsHitTestVisible="False" Text="Random Series" 
+                <TextBlock  IsHitTestVisible="False" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Metro_Random}" 
                        Foreground="Black" FontSize="24" FontFamily="Segoe UI" FontWeight="Bold"   />
 
                 <!-- Refresh -->
@@ -486,7 +486,7 @@
                         <Image Height="24" Width="24" Source="/Images/Metro/refresh.png" Margin="0,0,0,0"/>
                     </StackPanel>
                     <Button.ToolTip>
-                        <TextBlock Text="Refresh"/>
+                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Metro_Refresh}"/>
                     </Button.ToolTip>
                 </Button>
             </StackPanel>
@@ -535,7 +535,7 @@
                         Grid.Column="{Binding Path=Dash_NewEpisodes_Column, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:DashboardMetroDXControl}}}" 
                         Visibility="{Binding Path=Dash_NewEpisodes_Visibility, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:DashboardMetroDXControl}}}"
                         Grid.Row="1" Margin="10,5,0,17">
-                <TextBlock  IsHitTestVisible="False" Text="New Episodes" 
+                <TextBlock  IsHitTestVisible="False" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Metro_New}" 
                        Foreground="Black" FontSize="24" FontFamily="Segoe UI" FontWeight="Bold"   />
 
                 <!-- Refresh -->
@@ -544,7 +544,7 @@
                         <Image Height="24" Width="24" Source="/Images/Metro/refresh.png" Margin="0,0,0,0"/>
                     </StackPanel>
                     <Button.ToolTip>
-                        <TextBlock Text="Refresh"/>
+                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Metro_Refresh}"/>
                     </Button.ToolTip>
                 </Button>
             </StackPanel>

--- a/JMMClient/UserControls/Downloads/DownloadRecommendationsControl.xaml
+++ b/JMMClient/UserControls/Downloads/DownloadRecommendationsControl.xaml
@@ -66,7 +66,7 @@
                                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                         <Image Height="16" Width="16" Source="/Images/32_bookmark.png" Margin="1,0,1,0" ToolTipService.ShowDuration="60000">
                                             <Image.ToolTip>
-                                                <TextBlock Text="Bookmark this anime to download later"/>
+                                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Bookmark}"/>
                                             </Image.ToolTip>
                                         </Image>
 
@@ -79,7 +79,7 @@
                                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                         <Image Height="16" Width="16" Source="/Images/24_download3.png" Margin="2,0,2,0">
                                             <Image.ToolTip>
-                                                <TextBlock Text="Search for downloads for this series"/>
+                                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_SeriesSearch}"/>
                                             </Image.ToolTip>
                                         </Image>
 
@@ -89,7 +89,7 @@
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,0">
-                                <TextBlock Text="Approval" Foreground="DarkGreen" FontWeight="Medium" VerticalAlignment="Center"/>
+                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Approval}" Foreground="DarkGreen" FontWeight="Medium" VerticalAlignment="Center"/>
                                 <TextBlock Text="{Binding Path=Recommended_ApprovalRating}" Foreground="Black" VerticalAlignment="Center" Margin="5,0,0,0"/>
                             </StackPanel>
 
@@ -152,7 +152,7 @@
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,0">
-                                <TextBlock Text="Your Vote" Foreground="DarkGreen" FontWeight="Medium" VerticalAlignment="Center"/>
+                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_YourVote}" Foreground="DarkGreen" FontWeight="Medium" VerticalAlignment="Center"/>
                                 <TextBlock Text="{Binding Path=BasedOnVoteValueFormatted}" Foreground="Black" VerticalAlignment="Center" Margin="5,0,0,0"/>
                             </StackPanel>
 
@@ -265,7 +265,7 @@
                                 </Grid.ColumnDefinitions>
 
                                 <Image Height="16" Width="16" Source="/Images/32_info.png" Margin="5,2,5,0" Grid.Column="0" VerticalAlignment="Top"/>
-                                <TextBlock VerticalAlignment="Center" Text="This utility shows you a list of recommended anime which are not in your collection based on your own ratings and feedback from AniDB users" Margin="0,0,5,5" TextWrapping="Wrap" Grid.Column="1"/>
+                                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_RecommendPrompt}" Margin="0,0,5,5" TextWrapping="Wrap" Grid.Column="1"/>
 
                             </Grid>
                         </Border>

--- a/JMMClient/UserControls/Downloads/DownloadSettingsAnimeBytes.xaml
+++ b/JMMClient/UserControls/Downloads/DownloadSettingsAnimeBytes.xaml
@@ -61,7 +61,7 @@
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="0" Grid.Row="5" Margin="0,5,15,0">
-            <TextBlock Text="Anime Byt.es ONLY for Series" VerticalAlignment="Center"></TextBlock>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_AnimeBytesOnly}" VerticalAlignment="Center"></TextBlock>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="5" Margin="0,5,5,0">
@@ -83,7 +83,7 @@
                                                 Body={Resx ResxName=JMMClient.Properties.Resources, Key=AnimeBytesResetBody}}">
             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                 <Image Height="16" Width="16" Source="/Images/32_redo.png" Margin="0,0,5,0"/>
-                <TextBlock VerticalAlignment="Center" Text="Reset Cookie" Margin="0,0,5,0"/>
+                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_ResetCookie}" Margin="0,0,5,0"/>
             </StackPanel>
         </Button>
 

--- a/JMMClient/UserControls/Downloads/DownloadSettingsBakaBT.xaml
+++ b/JMMClient/UserControls/Downloads/DownloadSettingsBakaBT.xaml
@@ -62,7 +62,7 @@
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="0" Grid.Row="5" Margin="0,5,15,0">
-            <TextBlock Text="BakaBT ONLY for Series" VerticalAlignment="Center"></TextBlock>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_BakaBTOnly}" VerticalAlignment="Center"></TextBlock>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="5" Margin="0,5,5,0">
@@ -84,7 +84,7 @@
                                                 Body={Resx ResxName=JMMClient.Properties.Resources, Key=BakaBTResetBody}}">
             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                 <Image Height="16" Width="16" Source="/Images/32_redo.png" Margin="0,0,5,0"/>
-                <TextBlock VerticalAlignment="Center" Text="Reset Cookie" Margin="0,0,5,0"/>
+                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_ResetCookie}" Margin="0,0,5,0"/>
             </StackPanel>
         </Button>
 

--- a/JMMClient/UserControls/Downloads/DownloadSettingsTorSources.xaml
+++ b/JMMClient/UserControls/Downloads/DownloadSettingsTorSources.xaml
@@ -41,9 +41,9 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <TextBlock Text="Available" FontWeight="Bold" Grid.Column="0" Grid.Row="0" Margin="0,0,0,5" />
+        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Available}" FontWeight="Bold" Grid.Column="0" Grid.Row="0" Margin="0,0,0,5" />
 
-        <TextBlock Text="Selected" FontWeight="Bold" Grid.Column="2" Grid.Row="0" Margin="0,0,0,5" />
+        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Selected}" FontWeight="Bold" Grid.Column="2" Grid.Row="0" Margin="0,0,0,5" />
 
         <ListBox Grid.Column="0" Grid.Row="1" BorderThickness="1" Background="Transparent" MaxHeight="300" Width="250" Name="lbUnselectedTorrentSources"
                  Margin="0,0,10,0"

--- a/JMMClient/UserControls/Downloads/DownloadsBrowseTorrentsControl.xaml
+++ b/JMMClient/UserControls/Downloads/DownloadsBrowseTorrentsControl.xaml
@@ -76,7 +76,7 @@
 
                         <!-- filter box -->
                         <StackPanel Orientation="Horizontal" >
-                            <TextBlock VerticalAlignment="Center" Text="Filter" Margin="5,0,0,0" Foreground="DarkGray"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Filter}" Margin="5,0,0,0" Foreground="DarkGray"/>
                             <Image Source="/Images/MagnifyingGlass7.png" Width="16" Height="16" Margin="5,0,0,0" ></Image>
 
                             <TextBox Name="txtFileSearch" Width="180" Margin="10,3,0,3" BorderThickness="1">
@@ -88,7 +88,7 @@
                         </StackPanel>
 
                         <TextBlock VerticalAlignment="Center" Text="{Binding Path=TorrentCount, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:DownloadsBrowseTorrentsControl}}}" Margin="10,0,0,0" Foreground="DarkGray" />
-                        <TextBlock VerticalAlignment="Center" Text="Torrents" Margin="5,0,0,0" Foreground="DarkGray"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Torrents}" Margin="5,0,0,0" Foreground="DarkGray"/>
 
                     </StackPanel>
 
@@ -118,11 +118,11 @@
                     </Style>
                 </DataGrid.CellStyle>
                 <DataGrid.Columns>
-                    <DataGridTextColumn Header="Name" Binding="{Binding TorrentName}" IsReadOnly="True" />
-                    <DataGridTextColumn Header="Size" Binding="{Binding Size}" IsReadOnly="True" />
-                    <DataGridTextColumn Header="Seeders" Binding="{Binding Seeders}" IsReadOnly="True" />
-                    <DataGridTextColumn Header="Leechers" Binding="{Binding Leechers}" IsReadOnly="True" />
-                    <DataGridTextColumn Header="Extra Info" Binding="{Binding ExtraInfo}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Name}" Binding="{Binding TorrentName}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Size}" Binding="{Binding Size}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Seeders}" Binding="{Binding Seeders}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Leechers}" Binding="{Binding Leechers}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_ExtraInfo}" Binding="{Binding ExtraInfo}" IsReadOnly="True" />
                 </DataGrid.Columns>
             </DataGrid>
         </DockPanel >
@@ -181,10 +181,10 @@
                                 </Button>
 
                                 <Image Height="16" Width="16" Source="/Images/32_info.png" Margin="15,0,5,0" ToolTipService.ShowDuration="60000"/>
-                                <TextBlock Text="Wrong Series?" Foreground="Black" FontWeight="DemiBold" 
+                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_WrongSeries}" Foreground="Black" FontWeight="DemiBold" 
                                         VerticalAlignment="Center" ToolTipService.ShowDuration="60000"
                                         ToolTip="{usercontrols:Info Title=Wrong Series, 
-                                                Body=This is JMMs attempt to guess which series you are looking at so you can compare to your local collection. If you do not have the series in your collection it will be incorrect.}">
+                                                Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_WrongSeries}}">
 
                                 </TextBlock>
 

--- a/JMMClient/UserControls/Downloads/DownloadsSearchTorrentsControl.xaml
+++ b/JMMClient/UserControls/Downloads/DownloadsSearchTorrentsControl.xaml
@@ -118,7 +118,7 @@
                         <Button Margin="2,2,2,2" Style="{DynamicResource RoundButtonStyle}" Name="btnSearch" IsDefault="True">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                 <Image Height="16" Width="16" Source="/Images/MagnifyingGlass7.png" Margin="0,0,5,0"/>
-                                <TextBlock VerticalAlignment="Center" Text="Search" Margin="0,0,5,0"/>
+                                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Search}" Margin="0,0,5,0"/>
                             </StackPanel>
                         </Button>
 
@@ -144,7 +144,7 @@
                         
                         <StackPanel Orientation="Horizontal" >
 
-                            <TextBlock VerticalAlignment="Center" Text="Filter" Margin="5,0,0,0" Foreground="DarkGray"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Filter}" Margin="5,0,0,0" Foreground="DarkGray"/>
                             
 
                             <TextBox Name="txtFileSearch" Width="180" Margin="10,3,0,3" BorderThickness="1">
@@ -203,12 +203,12 @@
                     </Style>
                 </DataGrid.CellStyle>
                 <DataGrid.Columns>
-                    <DataGridTextColumn Header="Source" Binding="{Binding Source.TorrentSourceName}" IsReadOnly="True" />
-                    <DataGridTextColumn Header="Name" Binding="{Binding TorrentName}" IsReadOnly="True" />
-                    <DataGridTextColumn Header="Size" Binding="{Binding Size}" IsReadOnly="True" />
-                    <DataGridTextColumn Header="Seeders" Binding="{Binding Seeders}" IsReadOnly="True" />
-                    <DataGridTextColumn Header="Leechers" Binding="{Binding Leechers}" IsReadOnly="True" />
-                    <DataGridTextColumn Header="Extra Info" Binding="{Binding ExtraInfo}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Source}" Binding="{Binding Source.TorrentSourceName}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Name}" Binding="{Binding TorrentName}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Size}" Binding="{Binding Size}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Seeders}" Binding="{Binding Seeders}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Leechers}" Binding="{Binding Leechers}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_ExtraInfo}" Binding="{Binding ExtraInfo}" IsReadOnly="True" />
                 </DataGrid.Columns>
             </DataGrid>
         </DockPanel >
@@ -267,10 +267,10 @@
                                 </Button>
 
                                 <Image Height="16" Width="16" Source="/Images/32_info.png" Margin="15,0,5,0" ToolTipService.ShowDuration="60000"/>
-                                <TextBlock Text="Wrong Series?" Foreground="Black" FontWeight="DemiBold" 
+                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_WrongSeries}" Foreground="Black" FontWeight="DemiBold" 
                                         VerticalAlignment="Center" ToolTipService.ShowDuration="60000"
                                         ToolTip="{usercontrols:Info Title=Wrong Series, 
-                                                Body=This is JMMs attempt to guess which series you are looking at so you can compare to your local collection. If you do not have the series in your collection it will be incorrect.}">
+                                                Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_WrongSeries}}">
 
                                 </TextBlock>
 

--- a/JMMClient/UserControls/Downloads/DownloadsSettingsControl.xaml
+++ b/JMMClient/UserControls/Downloads/DownloadsSettingsControl.xaml
@@ -25,7 +25,7 @@
         </Grid.RowDefinitions>
 
         <StackPanel Orientation="Horizontal" Grid.Column="0" Grid.Row="1">
-            <TextBlock Text="Server" Margin="0,5,5,0" VerticalAlignment="Center"></TextBlock>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Server}" Margin="0,5,5,0" VerticalAlignment="Center"></TextBlock>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="1">
@@ -53,7 +53,7 @@
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="0" Grid.Row="4" Margin="0,5,15,0">
-            <TextBlock Text="Refresh Interval (secs)" VerticalAlignment="Center"></TextBlock>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_RefreshInterval}" VerticalAlignment="Center"></TextBlock>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="4" Margin="0,5,5,0">
@@ -62,7 +62,7 @@
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="0" Grid.Row="5" Margin="0,5,15,0">
-            <TextBlock Text="Auto Refresh" VerticalAlignment="Center"></TextBlock>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_AutoRefresh}" VerticalAlignment="Center"></TextBlock>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="5" Margin="0,5,5,0">

--- a/JMMClient/UserControls/Downloads/DownloadsTorrentBlackHole.xaml
+++ b/JMMClient/UserControls/Downloads/DownloadsTorrentBlackHole.xaml
@@ -20,7 +20,7 @@
         </Grid.RowDefinitions>
 
         <StackPanel Orientation="Horizontal" Grid.Column="0" Grid.Row="0" Margin="0,5,15,0">
-            <TextBlock Text="Use Torrent Black Hole" VerticalAlignment="Center"></TextBlock>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_UseBlackHole}" VerticalAlignment="Center"></TextBlock>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="0" Margin="0,5,5,0">
@@ -28,7 +28,7 @@
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="0" Grid.Row="1">
-            <TextBlock Text="Torrent Folder Location" Margin="0,5,5,0" VerticalAlignment="Center"></TextBlock>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_TorrentFolder}" Margin="0,5,5,0" VerticalAlignment="Center"></TextBlock>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="1">

--- a/JMMClient/UserControls/Downloads/DownloadsTorrentMonitorControl.xaml
+++ b/JMMClient/UserControls/Downloads/DownloadsTorrentMonitorControl.xaml
@@ -100,17 +100,17 @@
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
-                    <DataGridTextColumn Header="Name" Binding="{Binding Name}" IsReadOnly="True" />
-                    <DataGridTextColumn Header="Hash" Binding="{Binding Hash}" IsReadOnly="True" Visibility="Hidden" />
-                    <DataGridTextColumn Header="#" Binding="{Binding TorrentQueueOrder}" IsReadOnly="True" />
-                    <DataGridTextColumn Header="Size" Binding="{Binding SizeFormatted}" IsReadOnly="True" />
-                    <DataGridTextColumn Header="Done" Binding="{Binding PercentProgressFormatted}" IsReadOnly="True" />
-                    <DataGridTextColumn Header="Status" Binding="{Binding StatusFormatted}" IsReadOnly="True" />
-                    <DataGridTextColumn Header="Seeds" Binding="{Binding SeedsFormatted}" IsReadOnly="True" />
-                    <DataGridTextColumn Header="Peers" Binding="{Binding PeersFormatted}" IsReadOnly="True" />
-                    <DataGridTextColumn Header="Down Speed" Binding="{Binding DownloadSpeedFormatted}" IsReadOnly="True" />
-                    <DataGridTextColumn Header="Up Speed" Binding="{Binding UploadSpeedFormatted}" IsReadOnly="True" />
-                    <DataGridTextColumn Header="Ratio" Binding="{Binding RatioFormatted}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Name}" Binding="{Binding Name}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Hash}" Binding="{Binding Hash}" IsReadOnly="True" Visibility="Hidden" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Queue}" Binding="{Binding TorrentQueueOrder}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Size}" Binding="{Binding SizeFormatted}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Done}" Binding="{Binding PercentProgressFormatted}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Status}" Binding="{Binding StatusFormatted}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Seeds}" Binding="{Binding SeedsFormatted}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Peers}" Binding="{Binding PeersFormatted}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_DownSpeed}" Binding="{Binding DownloadSpeedFormatted}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_UpSpeed}" Binding="{Binding UploadSpeedFormatted}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Ratio}" Binding="{Binding RatioFormatted}" IsReadOnly="True" />
 
                 </DataGrid.Columns>
             </DataGrid>
@@ -138,7 +138,7 @@
 
                 <StackPanel Orientation="Horizontal" Margin="10,10,10,5">
                     <Image Height="16" Width="16" Source="/Images/32_Info.png" Margin="0,0,5,0"/>
-                    <TextBlock Text="You haven't specified valid uTorrent credentials" FontWeight="Bold" VerticalAlignment="Center" Foreground="Black"/>
+                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_InvalidCred}" FontWeight="Bold" VerticalAlignment="Center" Foreground="Black"/>
                 </StackPanel>
             </Border>
 
@@ -146,7 +146,7 @@
                             Background="FloralWhite">
 
                 <StackPanel Orientation="Horizontal" Margin="10,10,10,10">
-                    <TextBlock Text="Please enter your credentials on the setting tab and then return " VerticalAlignment="Center" Foreground="Black"/>
+                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_EnterCred}" VerticalAlignment="Center" Foreground="Black"/>
 
                 </StackPanel>
             </Border>
@@ -205,10 +205,10 @@
                                 </Button>
 
                                 <Image Height="16" Width="16" Source="/Images/32_info.png" Margin="15,0,5,0" ToolTipService.ShowDuration="60000"/>
-                                <TextBlock Text="Wrong Series?" Foreground="Black" FontWeight="DemiBold" 
+                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_WrongSeries}" Foreground="Black" FontWeight="DemiBold" 
                                         VerticalAlignment="Center" ToolTipService.ShowDuration="60000"
                                         ToolTip="{usercontrols:Info Title=Wrong Series, 
-                                                Body=This is JMMs attempt to guess which series you are looking at so you can compare to your local collection. If you do not have the series in your collection it will be incorrect.}">
+                                                Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_WrongSeries}}">
 
                                 </TextBlock>
 
@@ -277,10 +277,10 @@
                         </Style>
                     </DataGrid.CellStyle>
                     <DataGrid.Columns>
-                        <DataGridTextColumn Header="Name" Binding="{Binding FileName}" IsReadOnly="True" />
-                        <DataGridTextColumn Header="Size" Binding="{Binding FileSizeFormatted}" IsReadOnly="True" />
-                        <DataGridTextColumn Header="Downloaded" Binding="{Binding DownloadedFormatted}" IsReadOnly="True" />
-                        <DataGridTextColumn Header="Priority" Binding="{Binding PriorityFormatted}" IsReadOnly="True" />
+                        <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Name}" Binding="{Binding FileName}" IsReadOnly="True" />
+                        <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Size}" Binding="{Binding FileSizeFormatted}" IsReadOnly="True" />
+                        <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Downloaded}" Binding="{Binding DownloadedFormatted}" IsReadOnly="True" />
+                        <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Download_Priority}" Binding="{Binding PriorityFormatted}" IsReadOnly="True" />
 
                     </DataGrid.Columns>
                 </DataGrid>

--- a/JMMClient/UserControls/DuplicateFileDetailControl.xaml
+++ b/JMMClient/UserControls/DuplicateFileDetailControl.xaml
@@ -63,7 +63,7 @@
                     <Image Height="16" Width="16" Source="/Images/32_play2.png" Margin="2,0,2,0"/>
                 </StackPanel>
                 <Button.ToolTip>
-                    <TextBlock Text="Play Video"/>
+                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=PlayVideo}"/>
                 </Button.ToolTip>
             </Button>
             
@@ -101,7 +101,7 @@
                     <Image Height="16" Width="16" Source="/Images/32_play2.png" Margin="2,0,2,0"/>
                 </StackPanel>
                 <Button.ToolTip>
-                    <TextBlock Text="Play Video"/>
+                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=PlayVideo}"/>
                 </Button.ToolTip>
             </Button>
             

--- a/JMMClient/UserControls/EpisodeDetail.xaml
+++ b/JMMClient/UserControls/EpisodeDetail.xaml
@@ -117,7 +117,7 @@
                             <Button Margin="0,0,5,0" Style="{DynamicResource FlatButtonStyle}" VerticalAlignment="Center" Command="{DynamicResource ToggleFileDetailsCommand}" 
                                 CommandParameter="{Binding}" Visibility="{Binding Path=ShowLessDetails, Converter={StaticResource BooleanToVisibilityConverter}}" >
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
-                                    <TextBlock VerticalAlignment="Center" Text="More Info.." Margin="5,0,5,0" Foreground="Black"/>
+                                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Episode_MoreInfo}" Margin="5,0,5,0" Foreground="Black"/>
                                 </StackPanel>
                             </Button>
 
@@ -125,7 +125,7 @@
                             <Button Margin="0,0,5,0" Style="{DynamicResource FlatButtonStyle}" VerticalAlignment="Center" Command="{DynamicResource ToggleFileDetailsCommand}" 
                                 CommandParameter="{Binding}" Visibility="{Binding Path=ShowMoreDetails, Converter={StaticResource BooleanToVisibilityConverter}}" >
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
-                                    <TextBlock VerticalAlignment="Center" Text="Less Info.." Margin="5,0,5,0" Foreground="Black"/>
+                                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Episode_LessInfo}" Margin="5,0,5,0" Foreground="Black"/>
                                 </StackPanel>
                             </Button>
 
@@ -153,7 +153,7 @@
 
                         <TextBlock Text="{Binding Path=AniDB_Anime_GroupNameShort}" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,10,0"
                                    Visibility="{Binding Path=IsAutoAssociation, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                        <TextBlock Text="MANUAL LINK" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,10,0"
+                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Episode_Manual}" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,10,0"
                                    Visibility="{Binding Path=IsManualAssociation, Converter={StaticResource BooleanToVisibilityConverter}}"/>
 
                         <TextBlock Text="{Binding Path=FormattedFileSize}" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,10,0" />
@@ -228,7 +228,7 @@
                                         <TextBlock VerticalAlignment="Center" Text="Update Info" Margin="5,0,5,0" Foreground="Black"/>
                                     </StackPanel>
                                     <Button.ToolTip>
-                                        <TextBlock Text="Force update information from AniDB"/>
+                                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Episode_ForceAniDBUpdate}"/>
                                     </Button.ToolTip>
                                 </Button>
 
@@ -240,7 +240,7 @@
                                         <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Rehash}" Margin="0,0,5,0"/>
                                     </StackPanel>
                                     <Button.ToolTip>
-                                        <TextBlock Text="Re-calculate hashes"/>
+                                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Episode_RecalculateHash}"/>
                                     </Button.ToolTip>
                                 </Button>
 
@@ -249,13 +249,13 @@
                                          Visibility="{Binding Path=HasAniDBFile, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                             </StackPanel >
                         </Border>
-                            
-                        
 
-                        <TextBlock Text="Hash" FontWeight="Bold" VerticalAlignment="Center" Margin="10,3,10,0" Grid.Column="0" Grid.Row="1"/>
-                        <TextBlock Text="CRC32" FontWeight="Bold" VerticalAlignment="Center" Margin="10,3,10,0" Grid.Column="0" Grid.Row="2"/>
-                        <TextBlock Text="SHA1" FontWeight="Bold" VerticalAlignment="Center" Margin="10,3,10,0" Grid.Column="0" Grid.Row="3"/>
-                        <TextBlock Text="MD5" FontWeight="Bold" VerticalAlignment="Center" Margin="10,3,10,0" Grid.Column="0" Grid.Row="4"/>
+
+
+                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Episode_Hash}" FontWeight="Bold" VerticalAlignment="Center" Margin="10,3,10,0" Grid.Column="0" Grid.Row="1"/>
+                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Episode_CRC32}" FontWeight="Bold" VerticalAlignment="Center" Margin="10,3,10,0" Grid.Column="0" Grid.Row="2"/>
+                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Episode_SHA1}" FontWeight="Bold" VerticalAlignment="Center" Margin="10,3,10,0" Grid.Column="0" Grid.Row="3"/>
+                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Episode_MD5}" FontWeight="Bold" VerticalAlignment="Center" Margin="10,3,10,0" Grid.Column="0" Grid.Row="4"/>
 
                         <TextBox Text="{Binding Path=VideoLocal_Hash}" VerticalAlignment="Center" Margin="10,3,10,0" Grid.Column="1" Grid.Row="1"/>
                         <TextBox Text="{Binding Path=VideoLocal_CRC32}" VerticalAlignment="Center" Margin="10,3,10,0" Grid.Column="1" Grid.Row="2"/>
@@ -352,7 +352,7 @@
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                     <Image Height="16" Width="16" Source="/Images/24_download3.png" Margin="2,0,2,0">
                         <Image.ToolTip>
-                            <TextBlock Text="Search downloads for this episode"/>
+                            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Episode_DownloadSearch}"/>
                         </Image.ToolTip>
                     </Image>
 
@@ -364,7 +364,7 @@
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                     <Image Height="16" Width="16" Source="/Images/32_playlist_add.png" Margin="2,0,2,0">
                         <Image.ToolTip>
-                            <TextBlock Text="Add to Playlist"/>
+                            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Episode_PlaylistAdd}"/>
                         </Image.ToolTip>
                     </Image>
 
@@ -378,7 +378,7 @@
                     <Image Height="16" Width="16" Source="/Images/16_switch.png" Margin="2,0,2,0"/>
                 </StackPanel>
                 <Button.ToolTip>
-                    <TextBlock Text="Override the TvDB link for this episode"/>
+                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Episode_TvDBOverride}"/>
                 </Button.ToolTip>
             </Button>
 
@@ -389,7 +389,7 @@
                     <Image Height="16" Width="16" Source="/Images/32_delete.png" Margin="2,0,2,0"/>
                 </StackPanel>
                 <Button.ToolTip>
-                    <TextBlock Text="Remove the TvDB link for this episode"/>
+                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Episode_TvDBRemove}"/>
                 </Button.ToolTip>
             </Button>
 
@@ -399,7 +399,7 @@
                     <Image Height="16" Width="16" Source="/Images/32_sync.png" Margin="2,0,2,0"/>
                 </StackPanel>
                 <Button.ToolTip>
-                    <TextBlock Text="Force update information from AniDB"/>
+                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Episode_AniDBForceUpdate}"/>
                 </Button.ToolTip>
             </Button>
 

--- a/JMMClient/UserControls/EpisodeList.xaml
+++ b/JMMClient/UserControls/EpisodeList.xaml
@@ -56,16 +56,16 @@
 
         <Border Style="{DynamicResource ToolbarBorderControlStyle}" Margin="0,0,0,0" Background="#F1F1F1" Padding="3" BorderThickness="0" Grid.Row="0">
             <StackPanel Orientation="Horizontal" >
-                <TextBlock Text="Type" VerticalAlignment="Center" Margin="10,0,0,0"/>
+                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Episode_Type}" VerticalAlignment="Center" Margin="10,0,0,0"/>
                 <ComboBox Margin="5,5,5,5" Name="cboEpisodeTypeFilter" VerticalAlignment="Center"
                       ItemsSource="{Binding Path=CurrentEpisodeTypes, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:EpisodeList}}}"
                       ItemTemplate="{StaticResource animeEpisodeTypeComboTemplate}" />
 
-                <TextBlock Text="Availability" VerticalAlignment="Center" Margin="10,0,0,0"/>
+                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Episode_Availability}" VerticalAlignment="Center" Margin="10,0,0,0"/>
                 <ComboBox Margin="5,5,5,5" Name="cboAvailableEpisodes" VerticalAlignment="Center"
                           ItemTemplate="{StaticResource episodeAvTemplate}"/>
 
-                <TextBlock Text="Watched State" VerticalAlignment="Center" Margin="10,0,0,0"/>
+                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Episode_WatchedState}" VerticalAlignment="Center" Margin="10,0,0,0"/>
                 <ComboBox Margin="5,5,5,5" Name="cboWatched" VerticalAlignment="Center"
                           ItemTemplate="{StaticResource episodeWatchedTemplate}"/>
 

--- a/JMMClient/UserControls/FileRenameControl.xaml
+++ b/JMMClient/UserControls/FileRenameControl.xaml
@@ -74,7 +74,7 @@
                                 
                                 <StackPanel Orientation="Horizontal"  HorizontalAlignment="Left" Margin="5">
 
-                                    <TextBlock VerticalAlignment="Center" Text="Script" Margin="0,0,5,0"/>
+                                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Rename_Script}" Margin="0,0,5,0"/>
                                     <ComboBox Name="cboScript" Margin="3,3,5,3" Height="24" VerticalAlignment="Center"
                                       ItemTemplate="{StaticResource SimpleScriptTemplate}"
                                       ItemsSource="{Binding Path=RenameScripts, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:FileRenameControl}}}"/>
@@ -83,7 +83,7 @@
                                     <Button Name="btnSaveScript" Margin="2,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                             <Image Height="16" Width="16" Source="/Images/32_save.png" Margin="0,0,5,0"/>
-                                            <TextBlock VerticalAlignment="Center" Text="Save" Margin="0,0,5,0"/>
+                                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Rename_Save}" Margin="0,0,5,0"/>
                                         </StackPanel>
                                     </Button>
                                     
@@ -91,7 +91,7 @@
                                     <Button Name="btnNewScript" Margin="2,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                             <Image Height="16" Width="16" Source="/Images/16_plus.png" Margin="0,0,5,0"/>
-                                            <TextBlock VerticalAlignment="Center" Text="New" Margin="0,0,5,0"/>
+                                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Rename_New}" Margin="0,0,5,0"/>
                                         </StackPanel>
                                     </Button>
 
@@ -99,7 +99,7 @@
                                     <Button Name="btnDeleteScript" Margin="2,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                             <Image Height="16" Width="16" Source="/Images/32_trash.png" Margin="0,0,5,0"/>
-                                            <TextBlock VerticalAlignment="Center" Text="Delete" Margin="0,0,5,0"/>
+                                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Rename_Delete}" Margin="0,0,5,0"/>
                                         </StackPanel>
                                     </Button>
                                 </StackPanel>
@@ -109,7 +109,7 @@
 
                         <StackPanel Orientation="Horizontal"  HorizontalAlignment="Left" Margin="5" Grid.Column="0" Grid.Row="1" >
 
-                            <TextBlock VerticalAlignment="Center" Text="Tag" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Rename_Tag}" Margin="0,0,5,0"/>
                             <ComboBox Name="cboTagType" Margin="3,3,5,3" Height="24" VerticalAlignment="Center"
                                       ItemTemplate="{StaticResource SimpleTagTemplate}"
                                       ItemsSource="{Binding Path=ViewTags, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:FileRenameControl}}}"/>
@@ -117,11 +117,11 @@
                             <Button Name="btnAddTag" Margin="2,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                     <Image Height="16" Width="16" Source="/Images/16_plus.png" Margin="0,0,5,0"/>
-                                    <TextBlock VerticalAlignment="Center" Text="Add" Margin="0,0,5,0"/>
+                                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Rename_Add}" Margin="0,0,5,0"/>
                                 </StackPanel>
                             </Button>
 
-                            <TextBlock VerticalAlignment="Center" Text="Test" Margin="15,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Rename_Test}" Margin="15,0,5,0"/>
                             <ComboBox Name="cboTestType" Margin="3,3,5,3" Height="24" VerticalAlignment="Center"
                                       ItemTemplate="{StaticResource SimpleTagTemplate}"
                                       ItemsSource="{Binding Path=ViewTests, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:FileRenameControl}}}"/>
@@ -129,15 +129,15 @@
                             <Button Name="btnAddTest" Margin="2,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                     <Image Height="16" Width="16" Source="/Images/16_plus.png" Margin="0,0,5,0"/>
-                                    <TextBlock VerticalAlignment="Center" Text="Add" Margin="0,0,5,0"/>
+                                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Rename_Add}" Margin="0,0,5,0"/>
                                 </StackPanel>
                             </Button>
 
                             <Image Height="16" Width="16" Source="/Images/32_info.png" Margin="15,2,5,0" Grid.Column="2" VerticalAlignment="Center"/>
-                            <usercontrols:HyperLinkStandard Margin="0,0,20,0" VerticalAlignment="Center" DisplayText="Help with scripting"
+                            <usercontrols:HyperLinkStandard Margin="0,0,20,0" VerticalAlignment="Center" DisplayText="{Resx ResxName=JMMClient.Properties.Resources, Key=Rename_ScriptingHelp}"
                                                                         URL="{Resx ResxName=JMMClient.Properties.Resources, Key=Link_FileRenaming}"/>
                         </StackPanel>
-                        <CheckBox Name="chkIsUsedForImports" Margin="5" Content="Run this script when importing files into collection" Grid.Column="0" Grid.Row="2"/>
+                        <CheckBox Name="chkIsUsedForImports" Margin="5" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=Rename_ImportRun}" Grid.Column="0" Grid.Row="2"/>
                         <TextBox Name="txtRenameScript" MinWidth="400" VerticalAlignment="Stretch" Grid.Column="0" Grid.Row="3" Margin="5" Grid.RowSpan="3" AcceptsReturn="True" FontFamily="Courier New" />
                         
 
@@ -161,7 +161,7 @@
             <Border DockPanel.Dock="Top" Background="#F1F1F1" BorderBrush="DarkGray" BorderThickness="1" Padding="5">
                 <StackPanel Orientation="Horizontal">
 
-                    <TextBlock VerticalAlignment="Center" Text="Filter:" Margin="0,0,0,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Rename_Filter}" Margin="0,0,0,0"/>
 
                     <ComboBox Name="cboFilterType" Margin="3,3,5,3" Height="24" VerticalAlignment="Center"/>
 
@@ -169,7 +169,7 @@
                     <Button Name="btnClearList" Margin="2,2,2,2" Style="{DynamicResource FlatButtonStyle}" VerticalAlignment="Center">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                             <Image Height="16" Width="16" Source="/Images/32_delete.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Clear" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Rename_Clear}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
 
@@ -184,7 +184,7 @@
                     <Button Name="btnLoadFiles" Margin="2,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                             <Image Height="16" Width="16" Source="/Images/16_plus.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Add Files" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Rename_AddFiles}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
 
@@ -192,7 +192,7 @@
                     <Button Name="btnPreviewFiles" Margin="0,2,5,2" Style="{DynamicResource FlatButtonStyle}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                             <Image Height="16" Width="16" Source="/Images/16_preview.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Preview" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Rename_Preview}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
 
@@ -200,7 +200,7 @@
                     <Button Name="btnRenameFiles" Margin="0,2,5,2" Style="{DynamicResource FlatButtonStyle}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                             <Image Height="16" Width="16" Source="/Images/32_save.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Rename Now" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Rename_Rename}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
 
@@ -212,7 +212,7 @@
                             Visibility="{Binding Path=WorkerRunning, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:FileRenameControl}}, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                             <Image Height="16" Width="16" Source="/Images/32_cancel.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Cancel" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Cancel}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
 

--- a/JMMClient/UserControls/FileSearchControl.xaml
+++ b/JMMClient/UserControls/FileSearchControl.xaml
@@ -60,10 +60,10 @@
                                 Command="{DynamicResource RescanFileCommand}" CommandParameter="{Binding}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                                 <Image Height="16" Width="16" Source="/Images/32_sync.png" Margin="0,0,5,0"/>
-                                <TextBlock VerticalAlignment="Center" Text="Rescan" Margin="0,0,5,0"/>
+                                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=FileSearch_Rescan}" Margin="0,0,5,0"/>
                             </StackPanel>
                             <Button.ToolTip>
-                                <TextBlock Text="Force update information from AniDB"/>
+                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=FileSearch_AniDBForceUpdate}"/>
                             </Button.ToolTip>
                         </Button>
 
@@ -89,10 +89,10 @@
                     <TextBlock Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="3" Text="{Binding Path=FileDirectory}" Margin="3" />
                     <TextBlock Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3" Text="{Binding Path=FormattedFileSize}" Margin="3" />
 
-                    <TextBlock Grid.Row="4" Grid.Column="0" Text="Hash" Margin="3" FontWeight="DemiBold" VerticalAlignment="Center" HorizontalAlignment="Left" />
+                    <TextBlock Grid.Row="4" Grid.Column="0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Episode_Hash}" Margin="3" FontWeight="DemiBold" VerticalAlignment="Center" HorizontalAlignment="Left" />
                     <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding Path=Hash}" MinWidth="150" Margin="10,3,3,3" VerticalAlignment="Center" HorizontalAlignment="Left"/>
 
-                    <TextBlock Grid.Row="5" Grid.Column="0" Text="CRC32" Margin="3" FontWeight="DemiBold" VerticalAlignment="Center" HorizontalAlignment="Left"/>
+                    <TextBlock Grid.Row="5" Grid.Column="0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Episode_CRC32}" Margin="3" FontWeight="DemiBold" VerticalAlignment="Center" HorizontalAlignment="Left"/>
                     <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding Path=CRC32}" MinWidth="150" Margin="10,3,3,3" VerticalAlignment="Center" HorizontalAlignment="Left"/>
 
                 </Grid>
@@ -187,7 +187,7 @@
                     <Button Name="btnSearch" Margin="2,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                             <Image Height="16" Width="16" Source="/Images/MagnifyingGlass7.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Search" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Search}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
                     

--- a/JMMClient/UserControls/GroupFilterAdmin.xaml
+++ b/JMMClient/UserControls/GroupFilterAdmin.xaml
@@ -138,7 +138,7 @@
                 <Button Name="btnRandomSeries" Margin="10,2,2,2" Style="{DynamicResource FlatButtonStyle}" >
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                         <Image Height="16" Width="16" Source="/Images/32_dice.png" Margin="0,0,3,0"/>
-                        <TextBlock VerticalAlignment="Center" Text="Random Series" Margin="0,0,0,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=GroupFilter_RandomSeries}" Margin="0,0,0,0"/>
                     </StackPanel>
                 </Button>
 
@@ -146,7 +146,7 @@
                 <Button Name="btnRandomEpisode" Margin="10,2,2,2" Style="{DynamicResource FlatButtonStyle}" >
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                         <Image Height="16" Width="16" Source="/Images/32_dice.png" Margin="0,0,3,0"/>
-                        <TextBlock VerticalAlignment="Center" Text="Random Episode" Margin="0,0,0,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=GroupFilter_RandomEpisode}" Margin="0,0,0,0"/>
                     </StackPanel>
                 </Button>
 

--- a/JMMClient/UserControls/IgnoredAnimeControl.xaml
+++ b/JMMClient/UserControls/IgnoredAnimeControl.xaml
@@ -37,7 +37,7 @@
                             <Image Height="16" Width="16" Source="/Images/32_Delete.png" Margin="0,0,0,0"/>
                         </StackPanel>
                         <Button.ToolTip>
-                            <TextBlock Text="Delete this entry"/>
+                            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=IgnoredAnime_Delete}"/>
                         </Button.ToolTip>
                     </Button>
 
@@ -110,7 +110,7 @@
                         </Grid.ColumnDefinitions>
 
                         <Image Height="16" Width="16" Source="/Images/32_info.png" Margin="5,2,5,0" Grid.Column="0" VerticalAlignment="Top"/>
-                        <TextBlock VerticalAlignment="Center" Text="This utility will show you all the anime you have chosen to ignore from the recommendations. Deleting these records means they may show in recommendations again." Margin="0,0,5,5" TextWrapping="Wrap" Grid.Column="1"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=IgnoredAnime_Note}" Margin="0,0,5,5" TextWrapping="Wrap" Grid.Column="1"/>
                     </Grid>
                 </Border>
 

--- a/JMMClient/UserControls/IgnoredFiles.xaml
+++ b/JMMClient/UserControls/IgnoredFiles.xaml
@@ -89,7 +89,7 @@
                                 <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Play}" Margin="5,0,5,0"/>
                             </StackPanel>
                             <Button.ToolTip>
-                                <TextBlock Text="Play Video"/>
+                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=PlayVideo}"/>
                             </Button.ToolTip>
                         </Button>
                         

--- a/JMMClient/UserControls/ImportFolderAdmin.xaml
+++ b/JMMClient/UserControls/ImportFolderAdmin.xaml
@@ -51,7 +51,7 @@
                         <Image Height="16" Width="16" Source="/Images/16_folder_find.png" VerticalAlignment="Center" Margin="0,0,5,0"
                                Visibility="{Binding Path=FolderIsWatched, Converter={StaticResource BooleanToVisibilityConverter}}">
                             <Image.ToolTip>
-                                <TextBlock Text="This folder is being watched for new files"/>
+                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=ImportFolder_Watched}"/>
                             </Image.ToolTip>
                         </Image>
                     </StackPanel>

--- a/JMMClient/UserControls/ManuallyLinkedFilesDetailControl.xaml
+++ b/JMMClient/UserControls/ManuallyLinkedFilesDetailControl.xaml
@@ -39,7 +39,7 @@
                                 <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Play}" Margin="5,0,5,0"/>
                             </StackPanel>
                             <Button.ToolTip>
-                                <TextBlock Text="Play Video"/>
+                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=PlayVideo}"/>
                             </Button.ToolTip>
                         </Button>
 
@@ -48,10 +48,10 @@
                                 Command="{StaticResource RescanFileCommand}" CommandParameter="{Binding}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                                 <Image Height="16" Width="16" Source="/Images/32_sync.png" Margin="0,0,5,0"/>
-                                <TextBlock VerticalAlignment="Center" Text="Rescan" Margin="0,0,5,0"/>
+                                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=FileSearch_Rescan}" Margin="0,0,5,0"/>
                             </StackPanel>
                             <Button.ToolTip>
-                                <TextBlock Text="Force update information from AniDB"/>
+                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Episode_AniDBForceUpdate}"/>
                             </Button.ToolTip>
                         </Button>
 

--- a/JMMClient/UserControls/MissingEpisodesControl.xaml
+++ b/JMMClient/UserControls/MissingEpisodesControl.xaml
@@ -52,7 +52,7 @@
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                             <Image Height="16" Width="16" Source="/Images/32_bookmark.png" Margin="1,0,1,0" ToolTipService.ShowDuration="60000">
                                 <Image.ToolTip>
-                                    <TextBlock Text="Bookmark this anime to download later"/>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Dashboard_Bookmark}"/>
                                 </Image.ToolTip>
                             </Image>
 
@@ -65,7 +65,7 @@
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                             <Image Height="16" Width="16" Source="/Images/24_download3.png" Margin="2,0,2,0">
                                 <Image.ToolTip>
-                                    <TextBlock Text="Search for downloads for this episode"/>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Episode_DownloadSearch}"/>
                                 </Image.ToolTip>
                             </Image>
 
@@ -135,7 +135,7 @@
                                 <Image Height="16" Width="16" Source="/Images/16_Columns.png" Margin="0,0,5,0"/>
                             </StackPanel>
                             <Button.ToolTip>
-                                <TextBlock Text="Select the columns to be used in the import"/>
+                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=MissingEpisodes_SelectColumns}"/>
                             </Button.ToolTip>
                         </Button>
                     </StackPanel>
@@ -148,7 +148,7 @@
                     <CheckBox Name="chkRegularEpisodesOnly" IsChecked="True" VerticalAlignment="Center" Margin="12,0,2,0"/>
                     <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=RegularEpisodesOnly}" VerticalAlignment="Center"></TextBlock>
 
-                    <TextBlock VerticalAlignment="Center" Text="Airing State:" Margin="10,0,0,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=MissingEpisodes_AiringState}" Margin="10,0,0,0"/>
 
                     <ComboBox Name="cboAiringFilter" Margin="3,3,5,3" Height="24" VerticalAlignment="Center"/>
 
@@ -169,8 +169,8 @@
                         </Grid.ColumnDefinitions>
 
                         <Image Height="16" Width="16" Source="/Images/32_info.png" Margin="5,2,5,0" Grid.Column="0" VerticalAlignment="Top"/>
-                        <TextBlock VerticalAlignment="Center" Text="Pressing the refresh button can take several minutes, so please be patient" Margin="0,0,5,5" TextWrapping="Wrap" Grid.Column="1"/>
-                        <TextBlock VerticalAlignment="Center" Text="This utility will show you a summary of all your missing episodes." Margin="0,0,5,0" TextWrapping="Wrap" Grid.Column="1" Grid.Row="1"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=RefreshWait}" Margin="0,0,5,5" TextWrapping="Wrap" Grid.Column="1"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=MissingEpisodes_Note}" Margin="0,0,5,0" TextWrapping="Wrap" Grid.Column="1" Grid.Row="1"/>
                     </Grid>
                 </Border>
 

--- a/JMMClient/UserControls/MissingMyListFilesControl.xaml
+++ b/JMMClient/UserControls/MissingMyListFilesControl.xaml
@@ -87,7 +87,7 @@
                             Visibility="{Binding Path=IsNotLoading, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:MissingMyListFilesControl}}, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                             <Image Height="16" Width="16" Source="/Images/16_Refresh.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="View Missing Files" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=MissingMyList_Missing}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
 
@@ -101,7 +101,7 @@
                             Visibility="{Binding Path=ReadyToRemoveFiles, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:MissingMyListFilesControl}}, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                             <Image Height="16" Width="16" Source="/Images/32_trash.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Remove All Entries From AniDB" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=MissingMyList_RemoveAll}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
 
@@ -122,8 +122,8 @@
                         </Grid.ColumnDefinitions>
 
                         <Image Height="16" Width="16" Source="/Images/32_info.png" Margin="5,2,5,0" Grid.Column="0" VerticalAlignment="Top"/>
-                        <TextBlock VerticalAlignment="Center" Text="Pressing the refresh button can take several minutes, so please be patient" Margin="0,0,5,5" TextWrapping="Wrap" Grid.Column="1"/>
-                        <TextBlock VerticalAlignment="Center" Text="This utility will download your list of files from AniDB, and compare it to the files locally. You will then have the chance to remove those files from AniDB if they don't exist." Margin="0,0,5,0" TextWrapping="Wrap" Grid.Column="1" Grid.Row="1"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=RefreshWait}" Margin="0,0,5,5" TextWrapping="Wrap" Grid.Column="1"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=MissingMyList_Note}" Margin="0,0,5,0" TextWrapping="Wrap" Grid.Column="1" Grid.Row="1"/>
                     </Grid>
                 </Border>
 

--- a/JMMClient/UserControls/MultipleFilesDetailControl.xaml
+++ b/JMMClient/UserControls/MultipleFilesDetailControl.xaml
@@ -41,7 +41,7 @@
                                     <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Play}" Margin="5,0,5,0"/>
                                 </StackPanel>
                                 <Button.ToolTip>
-                                    <TextBlock Text="Play Video"/>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=PlayVideo}"/>
                                 </Button.ToolTip>
                             </Button>
 
@@ -74,7 +74,7 @@
                             </CheckBox>
 
                             <!-- Link to AniDB -->
-                            <usercontrols:HyperLinkStandard VerticalAlignment="Center" DisplayText="AniDB" URL="{Binding Path=AniDB_SiteURL}" Margin="10,0,0,0"
+                            <usercontrols:HyperLinkStandard VerticalAlignment="Center" DisplayText="{Resx ResxName=JMMClient.Properties.Resources, Key=AniDB}" URL="{Binding Path=AniDB_SiteURL}" Margin="10,0,0,0"
                                          Visibility="{Binding Path=HasAniDBFile, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                             
                         </StackPanel>
@@ -102,7 +102,7 @@
 
                         <TextBlock Text="{Binding Path=AniDB_Anime_GroupNameShort}" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,10,0"
                                    Visibility="{Binding Path=IsAutoAssociation, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                        <TextBlock Text="MANUAL LINK" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,10,0"
+                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Episode_Manual}" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,10,0"
                                    Visibility="{Binding Path=IsManualAssociation, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                         <TextBlock Text="{Binding Path=FormattedFileSize}" FontWeight="DemiBold" VerticalAlignment="Center" Margin="0,0,10,0" />
                         

--- a/JMMClient/UserControls/PlayNextEpisodeControl.xaml
+++ b/JMMClient/UserControls/PlayNextEpisodeControl.xaml
@@ -78,7 +78,7 @@
 
                         <TextBlock Text="{Binding Path=AniDB_Anime_GroupNameShort}" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,10,0"
                                    Visibility="{Binding Path=IsAutoAssociation, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                        <TextBlock Text="MANUAL LINK" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,10,0"
+                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=ManualLink}" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,10,0"
                                    Visibility="{Binding Path=IsManualAssociation, Converter={StaticResource BooleanToVisibilityConverter}}"/>
 
                         <TextBlock Text="{Binding Path=FormattedFileSize}" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,10,0" />
@@ -212,7 +212,7 @@
                    Visibility="{Binding Path=FullOverview, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:PlayNextEpisodeControl}}, Converter={StaticResource BooleanToVisibilityConverter}}">
         </TextBlock>
 
-        <TextBlock Grid.Column="1" Grid.Row="1" Text="Hidden to prevent spoilers" HorizontalAlignment="Stretch" Margin="10,0,0,0" 
+        <TextBlock Grid.Column="1" Grid.Row="1" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=PlayNext_Hidden}" HorizontalAlignment="Stretch" Margin="10,0,0,0" 
                    VerticalAlignment="Top"  TextWrapping="Wrap"
                    Visibility="{Binding Path=HideOverview, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:PlayNextEpisodeControl}}, Converter={StaticResource BooleanToVisibilityConverter}}">
         </TextBlock>

--- a/JMMClient/UserControls/PlayNextEpisodeControlV2.xaml
+++ b/JMMClient/UserControls/PlayNextEpisodeControlV2.xaml
@@ -101,7 +101,7 @@
                         <Image Height="24" Width="24" Source="/Images/32_play2.png" Margin="0,0,0,0"/>
                     </StackPanel>
                     <Button.ToolTip>
-                        <TextBlock Text="Play"/>
+                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Play}"/>
                     </Button.ToolTip>
                 </Button>
             </StackPanel>

--- a/JMMClient/UserControls/PlaylistControl.xaml
+++ b/JMMClient/UserControls/PlaylistControl.xaml
@@ -50,7 +50,7 @@
 
                             </StackPanel>
                         </Button>
-                        <TextBlock Margin="0,0,10,0" Text="Series" FontSize="16" Foreground="DarkGray" VerticalAlignment="Center" />
+                        <TextBlock Margin="0,0,10,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Series}" FontSize="16" Foreground="DarkGray" VerticalAlignment="Center" />
                         <TextBlock Text="{Binding Path=Series.SeriesName}" FontWeight="Bold" FontSize="16" VerticalAlignment="Center" />
 
                         <!-- show pinned series button -->
@@ -103,7 +103,7 @@
 
                             </StackPanel>
                         </Button>
-                        <TextBlock Margin="0,0,10,0" Text="Episode" FontSize="16" Foreground="DarkGray" VerticalAlignment="Center" />
+                        <TextBlock Margin="0,0,10,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Episode}" FontSize="16" Foreground="DarkGray" VerticalAlignment="Center" />
                         <TextBlock Text="{Binding Path=Series.SeriesName}" FontWeight="Bold" FontSize="16" VerticalAlignment="Center" Margin="0,0,10,0" />
                         <TextBlock Text="{Binding Path=Episode.EpisodeNumberAndNameWithTypeTruncated}" FontWeight="Bold" FontSize="16" Foreground="DarkGreen" VerticalAlignment="Center" />
 
@@ -192,7 +192,7 @@
                                          Visibility="{Binding Path=IsReadOnly, Converter={StaticResource BooleanToVisibilityConverter}}">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                         <Image Height="16" Width="16" Source="/Images/32_play2_all.png" Margin="0,0,3,0"/>
-                        <TextBlock VerticalAlignment="Center" Text="Play All" Margin="0,0,0,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=PlayAll}" Margin="0,0,0,0"/>
                     </StackPanel>
                 </Button>
                     
@@ -218,7 +218,7 @@
                 <Button Name="btnRandomEpisode" Margin="10,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                         <Image Height="16" Width="16" Source="/Images/32_dice.png" Margin="0,0,3,0"/>
-                        <TextBlock VerticalAlignment="Center" Text="Random Episode" Margin="0,0,0,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Playlist_Random}" Margin="0,0,0,0"/>
                     </StackPanel>
                 </Button>
 
@@ -266,7 +266,7 @@
                         <CheckBox Name="chkPlayUnwatchedLocked" Content="Play Unwatched" VerticalAlignment="Center" Margin="10,0,0,0" IsEnabled="False"
                                   IsChecked="{Binding Path=PlayUnwatchedBool}"/>
 
-                        <TextBlock Margin="10,0,0,0" Text="Default Play Order" VerticalAlignment="Center" IsEnabled="False" Foreground="DarkGray"/>
+                    <TextBlock Margin="10,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Playlist_Default}" VerticalAlignment="Center" IsEnabled="False" Foreground="DarkGray"/>
 
                         <ComboBox Grid.Row="0" Name="cboPlayOrderLocked" VerticalAlignment="Center" Margin="5,0,0,0" IsEnabled="False"/>
                     </StackPanel>
@@ -285,7 +285,7 @@
                         <CheckBox Name="chkPlayUnwatchedEdit" Content="Play Unwatched" VerticalAlignment="Center" Margin="10,0,0,0"
                                   IsChecked="{Binding Path=PlayUnwatchedBool}"/>
 
-                        <TextBlock Margin="10,0,0,0" Text="Default Play Order" VerticalAlignment="Center" />
+                    <TextBlock Margin="10,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Playlist_Default}" VerticalAlignment="Center" />
 
                         <ComboBox Grid.Row="0" Name="cboPlayOrderEdit" VerticalAlignment="Center" Margin="5,0,0,0" />
                     </StackPanel>
@@ -350,7 +350,7 @@
             <Border Style="{DynamicResource ToolbarBorderControlStyle}" Grid.Row="2" Grid.Column="0" Padding="6" Background="#F1F1F1">
                 
                 <StackPanel Orientation="Horizontal">
-                    <TextBlock Text="Playlist Items" FontSize="16" Foreground="DarkGray" VerticalAlignment="Center"/>
+                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Playlist_Items}" FontSize="16" Foreground="DarkGray" VerticalAlignment="Center"/>
 
                    
                 </StackPanel>

--- a/JMMClient/UserControls/RankingsControl.xaml
+++ b/JMMClient/UserControls/RankingsControl.xaml
@@ -70,7 +70,7 @@
                         <Button Name="btnSortOverall" Margin="2,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                 <Image Height="16" Width="16" Source="/Images/32_sort.png" Margin="0,0,5,0"/>
-                                <TextBlock VerticalAlignment="Center" Text="By Overall User Rating" Margin="0,0,5,0"/>
+                                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Rankings_Overall}" Margin="0,0,5,0"/>
                             </StackPanel>
                         </Button>
 
@@ -78,7 +78,7 @@
                         <Button Name="btnSortYear" Margin="2,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                 <Image Height="16" Width="16" Source="/Images/32_sort.png" Margin="0,0,5,0"/>
-                                <TextBlock VerticalAlignment="Center" Text="Grouped By Year" Margin="0,0,5,0"/>
+                                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Rankings_GroupedByYear}" Margin="0,0,5,0"/>
                             </StackPanel>
                         </Button>
 
@@ -86,13 +86,13 @@
 
                     <StackPanel Orientation="Horizontal"  HorizontalAlignment="Left" Margin="5,0,5,5">
 
-                        <TextBlock VerticalAlignment="Center" Text="Collection State" Margin="10,0,0,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Rankings_CollectionState}" Margin="10,0,0,0"/>
                         <ComboBox Margin="7,0,0,0" Name="cboCollection" VerticalAlignment="Center"></ComboBox>
 
-                        <TextBlock VerticalAlignment="Center" Text="Completed" Margin="10,0,0,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Rankings_Completed}" Margin="10,0,0,0"/>
                         <ComboBox Margin="7,0,0,0" Name="cboWatched" VerticalAlignment="Center"></ComboBox>
 
-                        <TextBlock VerticalAlignment="Center" Text="Voted" Margin="10,0,0,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Rankings_Voted}" Margin="10,0,0,0"/>
                         <ComboBox Margin="7,0,0,0" Name="cboVoted" VerticalAlignment="Center"></ComboBox>
 
                     </StackPanel>
@@ -125,7 +125,7 @@
                                                     <StackPanel Orientation="Horizontal">
                                                         <TextBlock Text="{Binding Path=Name}" FontWeight="Bold" />
                                                         <TextBlock Text="{Binding Path=ItemCount}" Margin="10,0,0,0"/>
-                                                        <TextBlock Text=" Anime"/>
+                                                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Rankings_Anime}"/>
                                                     </StackPanel>
                                                 </Expander.Header>
                                                 <ItemsPresenter />
@@ -152,9 +152,9 @@
                     </Style>
                 </DataGrid.CellStyle>
                 <DataGrid.Columns>
-                    <DataGridTextColumn Header="Anime" Binding="{Binding AnimeName}" IsReadOnly="True" />
-                    <DataGridTextColumn Header="AniDB Rating" Binding="{Binding Rating}" IsReadOnly="True" />
-                    <DataGridTemplateColumn Header="Your Rating" IsReadOnly="False">
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Anime}" Binding="{Binding AnimeName}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Rankings_AniDB}" Binding="{Binding Rating}" IsReadOnly="True" />
+                    <DataGridTemplateColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Rankings_User}" IsReadOnly="False">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal">
@@ -166,7 +166,7 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
 
-                    <DataGridTextColumn Header="Year" Binding="{Binding Year}" IsReadOnly="True" />
+                    <DataGridTextColumn Header="{Resx ResxName=JMMClient.Properties.Resources, Key=Rankings_Year}" Binding="{Binding Year}" IsReadOnly="True" />
                 </DataGrid.Columns>
             </DataGrid>
 
@@ -197,7 +197,7 @@
                             Visibility="{Binding Path=IsNotLoading, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:RankingsControl}}, Converter={StaticResource BooleanToVisibilityConverter}}">
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                     <Image Height="16" Width="16" Source="/Images/16_windows.png" Margin="0,0,5,0"/>
-                                    <TextBlock VerticalAlignment="Center" Text="View Series"/>
+                                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Rankings_View}"/>
                                 </StackPanel>
                             </Button>
                         </StackPanel>
@@ -208,7 +208,7 @@
                 <StackPanel Orientation="Horizontal" Margin="5"
                             Visibility="{Binding Path=AnimeHasSeries, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:RankingsControl}}, Converter={StaticResource BooleanToVisibilityConverter}}">
 
-                    <TextBlock Margin="0,0,5,0"  FontWeight="Heavy" Foreground="DarkGray"  Text="My Vote" VerticalAlignment="Center"/>
+                    <TextBlock Margin="0,0,5,0"  FontWeight="Heavy" Foreground="DarkGray"  Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Rankings_MyVote}" VerticalAlignment="Center"/>
 
                     <usercontrols:RatingControl x:Name="cRating" Width="280" Height="24" RatingValue="{Binding Path=AnimeDetailed.AniDB_Anime.Detail.UserRating}" />
 

--- a/JMMClient/UserControls/RelatedAnimeControl.xaml
+++ b/JMMClient/UserControls/RelatedAnimeControl.xaml
@@ -83,7 +83,7 @@
                                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                         <Image Height="16" Width="16" Source="/Images/32_bookmark.png" Margin="1,0,1,0" ToolTipService.ShowDuration="60000">
                                             <Image.ToolTip>
-                                                <TextBlock Text="Bookmark this anime to download later"/>
+                                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Related_Bookmark}"/>
                                             </Image.ToolTip>
                                         </Image>
                                     </StackPanel>
@@ -96,7 +96,7 @@
                                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                         <Image Height="16" Width="16" Source="/Images/24_download3.png" Margin="2,0,2,0">
                                             <Image.ToolTip>
-                                                <TextBlock Text="Search for downloads for this series"/>
+                                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Related_Search}"/>
                                             </Image.ToolTip>
                                         </Image>
                                     </StackPanel>

--- a/JMMClient/UserControls/SeriesWithoutFilesControl.xaml
+++ b/JMMClient/UserControls/SeriesWithoutFilesControl.xaml
@@ -37,7 +37,7 @@
                             <Image Height="16" Width="16" Source="/Images/32_Delete.png" Margin="0,0,0,0"/>
                         </StackPanel>
                         <Button.ToolTip>
-                            <TextBlock Text="Delete this series from the database"/>
+                            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesWithoutFiles_Delete}"/>
                         </Button.ToolTip>
                     </Button>
                     
@@ -119,7 +119,7 @@
                         </Grid.ColumnDefinitions>
 
                         <Image Height="16" Width="16" Source="/Images/32_info.png" Margin="5,2,5,0" Grid.Column="0" VerticalAlignment="Top"/>
-                        <TextBlock VerticalAlignment="Center" Text="This utility will show you all the series which do not have any files. Deleting the series will also delete the group if no other series in that group have files." Margin="0,0,5,5" TextWrapping="Wrap" Grid.Column="1"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesWithoutFiles_Note}" Margin="0,0,5,5" TextWrapping="Wrap" Grid.Column="1"/>
                     </Grid>
                 </Border>
 

--- a/JMMClient/UserControls/Settings/AniDBMyListSettings.xaml
+++ b/JMMClient/UserControls/Settings/AniDBMyListSettings.xaml
@@ -48,7 +48,7 @@
 
         <!-- delete action -->
         <StackPanel Orientation="Horizontal" Grid.Column="0" Grid.Row="2" Margin="0,5,15,0">
-            <TextBlock Text="Delete Action" VerticalAlignment="Center"></TextBlock>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Settings_DeleteAction}" VerticalAlignment="Center"></TextBlock>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="2" Margin="0,5,5,0">

--- a/JMMClient/UserControls/Settings/AniDBScheduledUpdates.xaml
+++ b/JMMClient/UserControls/Settings/AniDBScheduledUpdates.xaml
@@ -58,7 +58,7 @@
 
         <!--AniDBScheduleMyListStats-->
         <StackPanel Orientation="Horizontal" Grid.Column="0" Grid.Row="4" Margin="0,5,15,0">
-            <TextBlock Text="Automatically Update Files With Missing Info" VerticalAlignment="Center"></TextBlock>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Settings_AutoUpdateInfo}" VerticalAlignment="Center"></TextBlock>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="4" Margin="0,5,5,0">

--- a/JMMClient/UserControls/Settings/DisplayStyleSettings.xaml
+++ b/JMMClient/UserControls/Settings/DisplayStyleSettings.xaml
@@ -62,7 +62,7 @@
 
         <!-- Episode Download button - hide -->
         <StackPanel Orientation="Horizontal" Grid.Column="0" Grid.Row="3" Margin="0,5,15,0">
-            <TextBlock Text="Hide Episode Download Button When You Already Have Files"  VerticalAlignment="Top"></TextBlock>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Settings_HideDownloadButton}"  VerticalAlignment="Top"></TextBlock>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="3" Margin="0,5,5,0">

--- a/JMMClient/UserControls/Settings/ImportSettings.xaml
+++ b/JMMClient/UserControls/Settings/ImportSettings.xaml
@@ -57,7 +57,7 @@
                 Body=This will delete all your current groups and then re-organize all your series into new groups based on your import settings}">
             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                 <Image Height="16" Width="16" Source="/Images/32_sync.png" Margin="0,0,5,0"/>
-                <TextBlock VerticalAlignment="Center" Text="Recreate All Groups" Margin="0,0,5,0"/>
+                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Settings_RecreateGroups}" Margin="0,0,5,0"/>
             </StackPanel>
         </Button>
 
@@ -81,7 +81,7 @@
 
         <!-- ScanDropFoldersOnStart -->
         <StackPanel Orientation="Horizontal" Grid.Column="0" Grid.Row="5" Margin="0,5,15,0">
-            <TextBlock Text="Scan Drop Folders On Start" VerticalAlignment="Center"></TextBlock>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Settings_ScanOnStart}" VerticalAlignment="Center"></TextBlock>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="5" Margin="0,5,5,0" Grid.ColumnSpan="1">
@@ -116,14 +116,14 @@
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" VerticalAlignment="Top" Margin="0,15,5,0" Grid.Column="0" Grid.Row="9" Grid.ColumnSpan="3">
-            <TextBlock Text="Images Path"  VerticalAlignment="Center"/>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Settings_ImagePath}"  VerticalAlignment="Center"/>
 
             <ComboBox Name="cboImagesPath" MinWidth="100" Margin="10,0,0,0" VerticalAlignment="Center"/>
 
             <Button Name="btnChooseImagesFolder" Style="{DynamicResource RoundButtonStyle}" Margin="10,0,0,0">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                     <Image Height="16" Width="16" Source="/Images/32_Folder.png" Margin="0,0,5,0"/>
-                    <TextBlock VerticalAlignment="Center" Text="Select Folder" Margin="0,0,5,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Settings_SelectFolder}" Margin="0,0,5,0"/>
                 </StackPanel>
             </Button>
         </StackPanel>

--- a/JMMClient/UserControls/Settings/JMMServerSettings.xaml
+++ b/JMMClient/UserControls/Settings/JMMServerSettings.xaml
@@ -28,7 +28,7 @@
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="1"  HorizontalAlignment="Right" Visibility="Collapsed">
-            <TextBlock Text="File Port" Margin="10,5,5,0" VerticalAlignment="Center"></TextBlock>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Settings_FilePort}" Margin="10,5,5,0" VerticalAlignment="Center"></TextBlock>
             <TextBox Name="txtFilePort" Width="50" Margin="0,5,5,0" VerticalAlignment="Center"/>
         </StackPanel>
 

--- a/JMMClient/UserControls/Settings/MovieDBSettings.xaml
+++ b/JMMClient/UserControls/Settings/MovieDBSettings.xaml
@@ -57,7 +57,7 @@
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="2" Grid.Row="2" Margin="0,5,15,0">
-            <TextBlock Text="Maximum Posters" VerticalAlignment="Center"></TextBlock>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=MovieDB_MaxPosters}" VerticalAlignment="Center"></TextBlock>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="3" Grid.Row="2" Margin="0,5,5,0">

--- a/JMMClient/UserControls/Settings/TraktSettings.xaml
+++ b/JMMClient/UserControls/Settings/TraktSettings.xaml
@@ -33,7 +33,7 @@
 
         <!-- Is Trakt enabled-->
         <StackPanel Orientation="Horizontal" Grid.Column="0" Grid.Row="0" Margin="0,5,15,0">
-            <TextBlock Text="Enable Trakt"  VerticalAlignment="Center"></TextBlock>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Trakt_Enable}"  VerticalAlignment="Center"></TextBlock>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" Margin="0,5,5,0">
@@ -42,7 +42,7 @@
 
         <!-- Trakt PIN-->
         <StackPanel Orientation="Horizontal" Grid.Column="0" Grid.Row="1" Margin="0,5,15,0" x:Name="spPINLabel">
-            <TextBlock Text="Trakt PIN"  VerticalAlignment="Center"></TextBlock>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Trakt_PIN}"  VerticalAlignment="Center"></TextBlock>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="1" x:Name="spPINData">
@@ -50,19 +50,19 @@
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="2" Grid.Row="1" x:Name="spPINLink">
-            <usercontrols:HyperLinkStandard VerticalAlignment="Center" DisplayText="Get PIN" URL="https://trakt.tv/pin/5309" Margin="0,0,0,0"/>
+            <usercontrols:HyperLinkStandard VerticalAlignment="Center" DisplayText="{Resx ResxName=JMMClient.Properties.Resources, Key=Trakt_GetPIN}" URL="https://trakt.tv/pin/5309" Margin="0,0,0,0"/>
         </StackPanel>
         
 
         <Button Name="btnTest" Margin="0,8,2,2" Grid.Column="1" Grid.Row="2"  HorizontalAlignment="Left" >
             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                 <Image Height="16" Width="16" Source="/Images/32_save.png" Margin="0,0,5,0"/>
-                <TextBlock VerticalAlignment="Center" Text="Authorize JMM" Margin="0,0,5,0"/>
+                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Trakt_Authorize}" Margin="0,0,5,0"/>
             </StackPanel>
         </Button>
 
         <StackPanel Orientation="Horizontal" Grid.Column="2" Grid.Row="2" Margin="0,5,15,0" x:Name="spValidity">
-            <TextBlock x:Name="tbValidity" Text="Current token is valid until:" VerticalAlignment="Center"></TextBlock>
+            <TextBlock x:Name="tbValidity" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Trakt_CurrentToken}" VerticalAlignment="Center"></TextBlock>
         </StackPanel>
 
         <!-- Schedule Updates-->
@@ -77,7 +77,7 @@
 
         <!-- Fanart Auto Download-->
         <StackPanel Orientation="Horizontal" Grid.Column="0" Grid.Row="5" Margin="0,5,15,0" x:Name="spFanartLabel">
-            <TextBlock Text="Auto Download Fanart"  VerticalAlignment="Center"></TextBlock>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Trakt_AutoFanart}"  VerticalAlignment="Center"></TextBlock>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="5" VerticalAlignment="Center" Margin="0,5,5,0" x:Name="spFanartData">
@@ -86,7 +86,7 @@
 
         <!-- Posters Auto Download-->
         <StackPanel Orientation="Horizontal" Grid.Column="0" Grid.Row="6" Margin="0,5,15,0" x:Name="spPostersLabel">
-            <TextBlock Text="Auto Download Posters"  VerticalAlignment="Center"></TextBlock>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Trakt_AutoPosters}"  VerticalAlignment="Center"></TextBlock>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="6" VerticalAlignment="Center" Margin="0,5,5,0" x:Name="spPostersData">
@@ -95,7 +95,7 @@
 
         <!-- Episode Auto Download-->
         <StackPanel Orientation="Horizontal" Grid.Column="0" Grid.Row="7" Margin="0,5,15,0" x:Name="spEpisodeLabel">
-            <TextBlock Text="Auto Download Episode Images"  VerticalAlignment="Center"></TextBlock>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Trakt_AutoEpisodeImages}"  VerticalAlignment="Center"></TextBlock>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="7" VerticalAlignment="Center" Margin="0,5,5,0" x:Name="spEpisodeData">

--- a/JMMClient/UserControls/Settings/TvDBSettings.xaml
+++ b/JMMClient/UserControls/Settings/TvDBSettings.xaml
@@ -59,7 +59,7 @@
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="2" Grid.Row="2" Margin="0,5,15,0">
-            <TextBlock Text="Maximum Wide Banners" VerticalAlignment="Center"></TextBlock>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=TvDB_WideBannerMax}" VerticalAlignment="Center"></TextBlock>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="3" Grid.Row="2" Margin="0,5,5,0">
@@ -79,7 +79,7 @@
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="2" Grid.Row="3" Margin="0,5,15,0">
-            <TextBlock Text="Maximum Posters" VerticalAlignment="Center"></TextBlock>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=TvDB_PostersMax}" VerticalAlignment="Center"></TextBlock>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="3" Grid.Row="3" Margin="0,5,5,0">

--- a/JMMClient/UserControls/Settings/VideoPlayerOptionsControl.xaml
+++ b/JMMClient/UserControls/Settings/VideoPlayerOptionsControl.xaml
@@ -45,9 +45,9 @@
                 </Grid.ColumnDefinitions>
 
                 <Image Height="16" Width="16" Source="/Images/32_info.png" Margin="5,2,5,0" Grid.Column="0" VerticalAlignment="Top"/>
-                <TextBlock Grid.Column="1" Grid.Row="0" Margin="0,0,5,0" VerticalAlignment="Center" Text="Automatic File Selection Preferences - this refers to when you have more than file for an episode"  TextWrapping="Wrap" />
-                <TextBlock Grid.Column="1" Grid.Row="1" Margin="0,5,5,0" VerticalAlignment="Center" Text="For a playlist it needs to choose one file, which will be based on you preferences below."  TextWrapping="Wrap" />
-                <TextBlock Grid.Column="1" Grid.Row="2" Margin="0,5,5,0" VerticalAlignment="Center" Text="For a single episode you can enable auto file selection or have JMM prompt you to select a file whenever you have more than one"  TextWrapping="Wrap" />
+                <TextBlock Grid.Column="1" Grid.Row="0" Margin="0,0,5,0" VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_AutoFileNote1}"  TextWrapping="Wrap" />
+                <TextBlock Grid.Column="1" Grid.Row="1" Margin="0,5,5,0" VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_AutoFileNote2}"  TextWrapping="Wrap" />
+                <TextBlock Grid.Column="1" Grid.Row="2" Margin="0,5,5,0" VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_AutoFileNote3}"  TextWrapping="Wrap" />
 
             </Grid>
         </Border>
@@ -72,10 +72,10 @@
             </Grid.RowDefinitions>
 
 
-            <TextBlock Grid.Column="0" VerticalAlignment="Center" Grid.Row="0" Text="Automatic File Selection - First episode in series" Margin="10,0,0,5"/>
+            <TextBlock Grid.Column="0" VerticalAlignment="Center" Grid.Row="0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_AutoFileFirstEpisode}" Margin="10,0,0,5"/>
             <ComboBox Name="cboAutoFileFirst" Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" Margin="10,0,0,5"/>
 
-            <TextBlock Grid.Column="0" VerticalAlignment="Center" Grid.Row="1" Text="Automatic File Selection - Subsequent episodes in series" Margin="10,0,0,5"/>
+            <TextBlock Grid.Column="0" VerticalAlignment="Center" Grid.Row="1" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_AutoFileNextEpisode}" Margin="10,0,0,5"/>
             <ComboBox Name="cboAutoFileSubsequent" Grid.Column="1" Grid.Row="1" VerticalAlignment="Center" Margin="10,0,0,5"/>
 
             <!-- Info 2 -->
@@ -93,14 +93,14 @@
                     </Grid.ColumnDefinitions>
 
                     <Image Height="16" Width="16" Source="/Images/16_exclamation.png" Margin="5,2,5,0" Grid.Column="0" VerticalAlignment="Top"/>
-                    <TextBlock Grid.Column="1" Grid.Row="0" Margin="0,0,5,0" VerticalAlignment="Center" Text="If you select 'Release Group From Previously Played Episode' in the above setting you also need to do the following "  TextWrapping="Wrap" />
-                    <TextBlock Grid.Column="1" Grid.Row="1" Margin="0,5,5,0" VerticalAlignment="Center" Text="Uncheck 'Set file as watched if episode is watched' Under Settings - Essential - Import Settings"  TextWrapping="Wrap" />
-                    <TextBlock Grid.Column="1" Grid.Row="2" Margin="0,5,5,0" VerticalAlignment="Center" Text="Always Mark a File as watched and not an episode"  TextWrapping="Wrap" />
+                    <TextBlock Grid.Column="1" Grid.Row="0" Margin="0,0,5,0" VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_AutoFileNote4}"  TextWrapping="Wrap" />
+                    <TextBlock Grid.Column="1" Grid.Row="1" Margin="0,5,5,0" VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_AutoFileNote5}"  TextWrapping="Wrap" />
+                    <TextBlock Grid.Column="1" Grid.Row="2" Margin="0,5,5,0" VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_AutoFileNote6}"  TextWrapping="Wrap" />
 
                 </Grid>
             </Border>
 
-            <CheckBox Name="chkAutoSelectFile" Grid.Column="0" VerticalAlignment="Center" Grid.Row="3" Grid.ColumnSpan="2" Content="Enable auto file selection on single episodes" Margin="10,0,0,5"/>
+            <CheckBox Name="chkAutoSelectFile" Grid.Column="0" VerticalAlignment="Center" Grid.Row="3" Grid.ColumnSpan="2" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_AutoFileEnable}" Margin="10,0,0,5"/>
 
 
 

--- a/JMMClient/UserControls/Settings/VideoPlayerSettingsControl.xaml
+++ b/JMMClient/UserControls/Settings/VideoPlayerSettingsControl.xaml
@@ -41,10 +41,10 @@
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
 
-                <TextBlock Grid.Column="0" Grid.Row="0" Margin="5,5,5,5" VerticalAlignment="Center" Text="Media Player Classic"  Grid.ColumnSpan="2" FontSize="14" FontWeight="Bold" />
+                <TextBlock Grid.Column="0" Grid.Row="0" Margin="5,5,5,5" VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_MPC}"  Grid.ColumnSpan="2" FontSize="14" FontWeight="Bold" />
                 <Image Height="16" Width="16" Source="/Images/32_info.png" Margin="5,2,5,0" Grid.Column="0" Grid.Row="1" VerticalAlignment="Top"/>
-                <TextBlock Grid.Column="1" Grid.Row="1" Margin="0,0,5,0" VerticalAlignment="Center" Text="For MPC Integration you must enable two options (1) Store settings to .ini file and (2) Keep history of recently watched files. See the following screenshot for more details. The location of MPC is usually something like C:\Program Files (x86)\Combined Community Codec Pack\MPC"  TextWrapping="Wrap" />
-                <usercontrols:HyperLinkStandard Grid.Column="1" Grid.Row="2" VerticalAlignment="Center" Margin="0,5,0,0" DisplayText="MPC Options"
+                <TextBlock Grid.Column="1" Grid.Row="1" Margin="0,0,5,0" VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_MPCNote}"  TextWrapping="Wrap" />
+                <usercontrols:HyperLinkStandard Grid.Column="1" Grid.Row="2" VerticalAlignment="Center" Margin="0,5,0,0" DisplayText="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_MPCOptions}"
                                                                         URL="{Resx ResxName=JMMClient.Properties.Resources, Key=Link_MPC}"/>
             </Grid>
         </Border>
@@ -65,20 +65,20 @@
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
-                <TextBlock Text="MPC INI Folder" VerticalAlignment="Center" Grid.Row="0" Grid.Column="0" Margin="10,10,0,0"/>
+                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_MPCFolder}" VerticalAlignment="Center" Grid.Row="0" Grid.Column="0" Margin="10,10,0,0"/>
                 <TextBlock Text="{Binding Source={x:Static local:UserSettingsVM.Instance},Path=MPCFolder}" Foreground="DarkGray" VerticalAlignment="Center" Margin="10,10,0,0" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="4"/>
 
                 <Button Name="btnChooseMPCLocation" Style="{DynamicResource RoundButtonStyle}" Margin="10,5,0,0" Grid.Row="2" Grid.Column="1">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                         <Image Height="16" Width="16" Source="/Images/32_Folder.png" Margin="0,0,5,0"/>
-                        <TextBlock VerticalAlignment="Center" Text="Select MPC INI Folder" Margin="0,0,5,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_MPCINI}" Margin="0,0,5,0"/>
                     </StackPanel>
                 </Button>
 
                 <Button Name="btnTestMPCLocation" Style="{DynamicResource RoundButtonStyle}" Margin="10,5,0,0" Grid.Row="2" Grid.Column="2">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                         <Image Height="16" Width="16" Source="/Images/16_Tick.png" Margin="0,0,5,0"/>
-                        <TextBlock VerticalAlignment="Center" Text="Test MPC File" Margin="0,0,5,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_MPCTest}" Margin="0,0,5,0"/>
                     </StackPanel>
                 </Button>
             </Grid>
@@ -99,10 +99,10 @@
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
 
-                <TextBlock Grid.Column="0" Grid.Row="0" Margin="5,5,5,5" VerticalAlignment="Center" Text="PotPlayer"  Grid.ColumnSpan="2" FontSize="14" FontWeight="Bold" />
+                <TextBlock Grid.Column="0" Grid.Row="0" Margin="5,5,5,5" VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_PotPlayer}"  Grid.ColumnSpan="2" FontSize="14" FontWeight="Bold" />
                 <Image Height="16" Width="16" Source="/Images/32_info.png" Margin="5,2,5,0" Grid.Column="0" Grid.Row="1" VerticalAlignment="Top"/>
-                <TextBlock Grid.Column="1" Grid.Row="1" Margin="0,0,5,0" VerticalAlignment="Center" Text="For PotPlayer Integration you must enable the following options (1) Preferences > General > Store Settings to .ini file (2) Preferences > Playback > Play from latest point. See the following screenshot for more details. The location of the PlotPlayer .ini file is usually something like C:\Users\username\AppData\Roaming\PotPlayer64\PotPlayer64.ini"  TextWrapping="Wrap" />
-                <usercontrols:HyperLinkStandard Grid.Column="1" Grid.Row="2" VerticalAlignment="Center" Margin="0,5,0,0" DisplayText="PotPlayer Options"
+                <TextBlock Grid.Column="1" Grid.Row="1" Margin="0,0,5,0" VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_PotPlayerNote}"  TextWrapping="Wrap" />
+                <usercontrols:HyperLinkStandard Grid.Column="1" Grid.Row="2" VerticalAlignment="Center" Margin="0,5,0,0" DisplayText="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_PotPlayerOptions}"
                                                                         URL="{Resx ResxName=JMMClient.Properties.Resources, Key=Link_PotPlayer}"/>
             </Grid>
         </Border>
@@ -123,20 +123,20 @@
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
-                <TextBlock Text="PotPlayer INI Folder" VerticalAlignment="Center" Grid.Row="0" Grid.Column="0" Margin="10,10,0,0"/>
+                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_PotPlayerFolder}" VerticalAlignment="Center" Grid.Row="0" Grid.Column="0" Margin="10,10,0,0"/>
                 <TextBlock Text="{Binding Source={x:Static local:UserSettingsVM.Instance},Path=PotPlayerFolder}" Foreground="DarkGray" VerticalAlignment="Center" Margin="10,10,0,0" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="4"/>
 
                 <Button Name="btnChoosePotLocation" Style="{DynamicResource RoundButtonStyle}" Margin="10,5,0,0" Grid.Row="2" Grid.Column="1">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                         <Image Height="16" Width="16" Source="/Images/32_Folder.png" Margin="0,0,5,0"/>
-                        <TextBlock VerticalAlignment="Center" Text="Select PotPlayer INI Folder" Margin="0,0,5,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_PotPlayerINI}" Margin="0,0,5,0"/>
                     </StackPanel>
                 </Button>
 
                 <Button Name="btnTestPotLocation" Style="{DynamicResource RoundButtonStyle}" Margin="10,5,0,0" Grid.Row="2" Grid.Column="2">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                         <Image Height="16" Width="16" Source="/Images/16_Tick.png" Margin="0,0,5,0"/>
-                        <TextBlock VerticalAlignment="Center" Text="Test PotPlayer INI File" Margin="0,0,5,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_PotPlayerTest}" Margin="0,0,5,0"/>
                     </StackPanel>
                 </Button>
             </Grid>
@@ -157,10 +157,10 @@
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
 
-                <TextBlock Grid.Column="0" Grid.Row="0" Margin="5,5,5,5" VerticalAlignment="Center" Text="VLC"  Grid.ColumnSpan="2" FontSize="14" FontWeight="Bold" />
+                <TextBlock Grid.Column="0" Grid.Row="0" Margin="5,5,5,5" VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_VLC}"  Grid.ColumnSpan="2" FontSize="14" FontWeight="Bold" />
                 <Image Height="16" Width="16" Source="/Images/32_info.png" Margin="5,2,5,0" Grid.Column="0" Grid.Row="1" VerticalAlignment="Top"/>
-                <TextBlock Grid.Column="1" Grid.Row="1" Margin="0,0,5,0" VerticalAlignment="Center" Text="VLC 2.2+ records recent files and timestamps by default (and disabling is an 'Advanced' option). Older versions do not support 'Resume from last position' functionality. The location of the VLC .ini file is usually something like C:\Users\username\AppData\Roaming\vlc\vlc-qt-interface.ini"  TextWrapping="Wrap" />
-                <usercontrols:HyperLinkStandard Grid.Column="1" Grid.Row="2" VerticalAlignment="Center" Margin="0,5,0,0" DisplayText="VLC Options"
+                <TextBlock Grid.Column="1" Grid.Row="1" Margin="0,0,5,0" VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_VLCNote}"  TextWrapping="Wrap" />
+                <usercontrols:HyperLinkStandard Grid.Column="1" Grid.Row="2" VerticalAlignment="Center" Margin="0,5,0,0" DisplayText="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_VLCOptions}"
                                                                         URL="{Resx ResxName=JMMClient.Properties.Resources, Key=Link_VLC}"/>
             </Grid>
         </Border>
@@ -181,20 +181,20 @@
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
-                <TextBlock Text="VLC INI Folder" VerticalAlignment="Center" Grid.Row="0" Grid.Column="0" Margin="10,10,0,0"/>
+                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_VLCFolder}" VerticalAlignment="Center" Grid.Row="0" Grid.Column="0" Margin="10,10,0,0"/>
                 <TextBlock Text="{Binding Source={x:Static local:UserSettingsVM.Instance},Path=VLCFolder}" Foreground="DarkGray" VerticalAlignment="Center" Margin="10,10,0,0" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="4"/>
 
                 <Button Name="btnChooseVLCLocation" Style="{DynamicResource RoundButtonStyle}" Margin="10,5,0,0" Grid.Row="2" Grid.Column="1">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                         <Image Height="16" Width="16" Source="/Images/32_Folder.png" Margin="0,0,5,0"/>
-                        <TextBlock VerticalAlignment="Center" Text="Select VLC INI Folder" Margin="0,0,5,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_VLCINI}" Margin="0,0,5,0"/>
                     </StackPanel>
                 </Button>
 
                 <Button Name="btnTestVLCLocation" Style="{DynamicResource RoundButtonStyle}" Margin="10,5,0,0" Grid.Row="2" Grid.Column="2">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                         <Image Height="16" Width="16" Source="/Images/16_Tick.png" Margin="0,0,5,0"/>
-                        <TextBlock VerticalAlignment="Center" Text="Test VLC INI File" Margin="0,0,5,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_VLCTest}" Margin="0,0,5,0"/>
                     </StackPanel>
                 </Button>
             </Grid>
@@ -221,7 +221,7 @@
 
 
 
-            <CheckBox Name="chkAutoSetWatched" Grid.Column="0" VerticalAlignment="Center" Grid.Row="0" Content="Automatically mark files as watched when the following percentage is watched" Margin="10,0,0,5"/>
+            <CheckBox Name="chkAutoSetWatched" Grid.Column="0" VerticalAlignment="Center" Grid.Row="0" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_AutoMark}" Margin="10,0,0,5"/>
 
             <extToolkit:IntegerUpDown Grid.Column="1" Grid.Row="0" Name="udWatchedPct" Minimum="1" Maximum="100" DefaultValue="85" VerticalAlignment="Center" Margin="5,0,0,5"
                                       Value="{Binding Source={x:Static local:UserSettingsVM.Instance},Path=VideoWatchedPct}" />

--- a/JMMClient/UserControls/Settings/WebCacheBasicSettings.xaml
+++ b/JMMClient/UserControls/Settings/WebCacheBasicSettings.xaml
@@ -68,7 +68,7 @@
 
         <!-- Trakt Links -->
         <StackPanel Orientation="Horizontal" Grid.Column="0" Grid.Row="3" Margin="0,5,15,0">
-            <TextBlock Text="Trakt Links" VerticalAlignment="Center"></TextBlock>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=WebCache_TraktLinks}" VerticalAlignment="Center"></TextBlock>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="3" Margin="0,5,5,0">

--- a/JMMClient/UserControls/SimilarAnimeControl.xaml
+++ b/JMMClient/UserControls/SimilarAnimeControl.xaml
@@ -44,7 +44,7 @@
                                 </TextBlock.ToolTip>
                             </TextBlock>
                             <StackPanel Orientation="Horizontal" Margin="0,5,0,5">
-                                <TextBlock Text="Approval" Foreground="DarkGreen" FontWeight="Medium" VerticalAlignment="Center"/>
+                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Approval}" Foreground="DarkGreen" FontWeight="Medium" VerticalAlignment="Center"/>
                                 <TextBlock Text="{Binding Path=ApprovalRating}" Foreground="Black" VerticalAlignment="Center" Margin="5,0,0,0"/>
                             </StackPanel>
 
@@ -84,7 +84,7 @@
                                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                         <Image Height="16" Width="16" Source="/Images/32_bookmark.png" Margin="1,0,1,0" ToolTipService.ShowDuration="60000">
                                             <Image.ToolTip>
-                                                <TextBlock Text="Bookmark this anime to download later"/>
+                                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Related_Bookmark}"/>
                                             </Image.ToolTip>
                                         </Image>
 
@@ -98,7 +98,7 @@
                                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                         <Image Height="16" Width="16" Source="/Images/24_download3.png" Margin="2,0,2,0">
                                             <Image.ToolTip>
-                                                <TextBlock Text="Search for downloads for this series"/>
+                                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Related_Search}"/>
                                             </Image.ToolTip>
                                         </Image>
                                     </StackPanel>

--- a/JMMClient/UserControls/TraktShoutsShowControl.xaml
+++ b/JMMClient/UserControls/TraktShoutsShowControl.xaml
@@ -60,7 +60,7 @@
                             <Button Style="{StaticResource RoundButtonStyle}" VerticalAlignment="Center"
                             Command="{StaticResource ViewCommentCommand}" CommandParameter="{Binding}">
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
-                                    <TextBlock Text="View"/>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=TraktShouts_View}"/>
 
                                 </StackPanel>
                             </Button>
@@ -88,7 +88,7 @@
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
 
-                        <TextBlock Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Margin="5,0,0,0" Text="From AniDB" FontSize="14" Foreground="DarkBlue" VerticalAlignment="Center" FontWeight="Bold"/>
+                        <TextBlock Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Margin="5,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=TraktShouts_FromAniDB}" FontSize="14" Foreground="DarkBlue" VerticalAlignment="Center" FontWeight="Bold"/>
 
                         <TextBlock Grid.Column="0" Grid.Row="1" Margin="5,0,0,0" Text="{Binding Path=UserID}" VerticalAlignment="Center" FontSize="14" FontWeight="Bold"
                                    Foreground="Black" ToolTipService.ShowDuration="60000">
@@ -107,7 +107,7 @@
                             <Button Style="{StaticResource RoundButtonStyle}" VerticalAlignment="Center"
                             Command="{StaticResource ViewCommentCommand}" CommandParameter="{Binding}">
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
-                                    <TextBlock Text="View"/>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=TraktShouts_View}"/>
 
                                 </StackPanel>
                             </Button>
@@ -155,7 +155,7 @@
 
                                 <Border BorderThickness="0" BorderBrush="Navy" Background="{StaticResource GreenGradientBrush}" Padding="6,3,3,3" CornerRadius="4">
                                     <StackPanel Orientation="Horizontal">
-                                        <TextBlock Text="Comment on Trakt" Foreground="White" FontWeight="Bold" FontSize="12" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SeriesSimple_CommentTrakt}" Foreground="White" FontWeight="Bold" FontSize="12" VerticalAlignment="Center"/>
                                         <Image Height="16" Width="16" Source="/Images/trakt-icon-shouts.png" Margin="10,0,4,0" VerticalAlignment="Center"/>
                                     </StackPanel>
 
@@ -165,7 +165,7 @@
 
                             <StackPanel Orientation="Horizontal" Margin="5">
                                 <CheckBox Name="chkSpoiler" VerticalAlignment="Center"/>
-                                <TextBlock Text="Spoiler" Foreground="Black" FontSize="12" VerticalAlignment="Center" Margin="5,0,0,0"/>
+                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=TraktShouts_Spoiler}" Foreground="Black" FontSize="12" VerticalAlignment="Center" Margin="5,0,0,0"/>
 
                             </StackPanel>
 
@@ -183,7 +183,7 @@
                 <Border Style="{DynamicResource ToolbarBorderControlStyle}" Margin="0,0,0,0" Background="#2D2D2D" Padding="6" BorderThickness="0" Grid.Row="1"
                 Visibility="{Binding Path=IsLoading, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:TraktCommentsShowControl}}, Converter={StaticResource BooleanToVisibilityConverter}}">
 
-                    <TextBlock VerticalAlignment="Center" Foreground="White" Text="Loading..." Margin="0,0,5,0"/>
+                    <TextBlock VerticalAlignment="Center" Foreground="White" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=TraktShouts_Loading}" Margin="0,0,5,0"/>
 
                 </Border>
 
@@ -194,7 +194,7 @@
 
                         <TextBlock VerticalAlignment="Center" Foreground="Black" Margin="7,0,5,0"
                            Text="{Binding Path=NumberOfShouts, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:TraktCommentsShowControl}}}" />
-                        <TextBlock VerticalAlignment="Center" Foreground="Black" Text="Comments" Margin="0,0,5,0"/>
+                        <TextBlock VerticalAlignment="Center" Foreground="Black" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=TraktShouts_Comments}" Margin="0,0,5,0"/>
 
                         <!-- Refresh -->
                         <Button Name="btnRefresh" Margin="12,2,2,2" Style="{DynamicResource RoundButtonStyle}">

--- a/JMMClient/UserControls/TvDBAndOtherLinks.xaml
+++ b/JMMClient/UserControls/TvDBAndOtherLinks.xaml
@@ -52,7 +52,7 @@
 
                         <usercontrols:HyperLinkStandard DisplayText="{Binding Path=MALTitle}" VerticalAlignment="Center" URL="{Binding Path=SiteURL}" Margin="10,0,0,0"/>
 
-                        <TextBlock VerticalAlignment="Center" Text="Start:" Margin="10,0,0,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CommunityLinks_Start}" Margin="10,0,0,0"/>
                         <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=StartEpisodeTypeString}" Margin="5,0,0,0"/>
                         <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=StartEpisodeNumber}" Margin="5,0,0,0"/>
 
@@ -70,7 +70,7 @@
                                 Command="{DynamicResource EditMALLinkCommand}" CommandParameter="{Binding}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                                 <Image Height="16" Width="16" Source="/Images/16_switch.png" Margin="0,0,5,0"/>
-                                <TextBlock VerticalAlignment="Center" Text="Edit Details" Margin="0,0,5,0"/>
+                                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CommunityLinks_Edit}" Margin="0,0,5,0"/>
                             </StackPanel>
                         </Button>
 
@@ -94,11 +94,11 @@
 
                         <usercontrols:HyperLinkStandard DisplayText="{Binding Path=TvDBTitle}" VerticalAlignment="Center" URL="{Binding Path=SeriesURL}" Margin="5,0,0,0"/>
 
-                        <TextBlock VerticalAlignment="Center" Text="AniDB Start:" Margin="10,0,0,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CommunityLinks_AniDBStart}" Margin="10,0,0,0"/>
                         <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=AniDBStartEpisodeTypeString}" Margin="5,0,0,0"/>
                         <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=AniDBStartEpisodeNumber}" Margin="5,0,0,0"/>
 
-                        <TextBlock VerticalAlignment="Center" Text="TvDB: " Margin="10,0,0,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CommunityLinks_TvDB}" Margin="10,0,0,0"/>
                         <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=TvDBSeasonNumberString}" Margin="5,0,0,0"/>
                         <TextBlock VerticalAlignment="Center" Text="/" Margin="5,0,0,0"/>
                         <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=TvDBStartEpisodeNumberString}" Margin="5,0,0,0"/>
@@ -106,8 +106,8 @@
                         <!-- delete link button -->
                         <Button Margin="8,0,2,2" Style="{DynamicResource RoundButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                                 Command="{StaticResource DeleteTvDBLinkCommand}" CommandParameter="{Binding}"
-                                ToolTip="{usercontrols:Info Title=Delete, 
-                                Body=Delete this Link}">
+                                ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_DeleteTitle}, 
+                                Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_DeleteInfo}}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                                 <Image Height="16" Width="16" Source="/Images/32_delete.png" Margin="0,0,0,0"/>
                             </StackPanel>
@@ -116,8 +116,8 @@
                         <!-- Edit TvDB Details button -->
                         <Button Margin="5,0,2,2" Style="{DynamicResource RoundButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                                 Command="{StaticResource EditTvDBLinkCommand}" CommandParameter="{Binding}"
-                                ToolTip="{usercontrols:Info Title=Edit, 
-                                Body=Edit the details of this Link}">
+                                ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_EditTitle}, 
+                                Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_EditInfo}}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                                 <Image Height="16" Width="16" Source="/Images/16_switch.png" Margin="0,0,0,0"/>
                             </StackPanel>
@@ -126,8 +126,8 @@
                         <!-- Update TvDB Info button -->
                         <Button Margin="5,0,2,2" Style="{DynamicResource RoundButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                                 Command="{StaticResource UpdateTvDBLinkCommand}" CommandParameter="{Binding}"
-                                ToolTip="{usercontrols:Info Title=Update, 
-                                Body=Download fresh data from The TvDB and update the local database}">
+                                ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_UpdateTitle}, 
+                                Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_UpdateTvDB}}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                                 <Image Height="16" Width="16" Source="/Images/32_import.png" Margin="0,0,0,0"/>
                             </StackPanel>
@@ -136,8 +136,8 @@
                         <!-- Report incorrect links -->
                         <Button Margin="5,0,2,2" Style="{DynamicResource RoundButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                             Command="{StaticResource ReportTvDBLinkCommand}" CommandParameter="{Binding}"  Visibility="Collapsed"
-                            ToolTip="{usercontrols:Info Title=Report Linking Error, 
-                            Body=If this is linked to the wrong series click here to let the developers know}">
+                            ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_ReportLinkTitle}, 
+                            Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_ReportLinkInfo}}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                                 <Image Height="16" Width="16" Source="/Images/vote_down2.png" Margin="0,0,0,0"/>
                             </StackPanel>
@@ -164,11 +164,11 @@
 
                         <usercontrols:HyperLinkStandard DisplayText="{Binding Path=TraktTitle}" VerticalAlignment="Center" URL="{Binding Path=ShowURL}" Margin="5,0,0,0"/>
 
-                        <TextBlock VerticalAlignment="Center" Text="AniDB Start:" Margin="10,0,0,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CommunityLinks_AniDBStart}" Margin="10,0,0,0"/>
                         <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=AniDBStartEpisodeTypeString}" Margin="5,0,0,0"/>
                         <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=AniDBStartEpisodeNumber}" Margin="5,0,0,0"/>
 
-                        <TextBlock VerticalAlignment="Center" Text="Trakt: " Margin="10,0,0,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CommunityLinks_Trakt}" Margin="10,0,0,0"/>
                         <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=TraktSeasonNumberString}" Margin="5,0,0,0"/>
                         <TextBlock VerticalAlignment="Center" Text="/" Margin="5,0,0,0"/>
                         <TextBlock VerticalAlignment="Center" FontWeight="Bold" Text="{Binding Path=TraktStartEpisodeNumberString}" Margin="5,0,0,0"/>
@@ -176,8 +176,8 @@
                         <!-- delete link button -->
                         <Button Margin="8,0,2,2" Style="{DynamicResource RoundButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                                 Command="{StaticResource DeleteTraktLinkCommand}" CommandParameter="{Binding}"
-                                ToolTip="{usercontrols:Info Title=Delete, 
-                                Body=Delete this Link}">
+                                ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_DeleteTitle}, 
+                                Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_DeleteInfo}}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                                 <Image Height="16" Width="16" Source="/Images/32_delete.png" Margin="0,0,0,0"/>
                             </StackPanel>
@@ -186,8 +186,8 @@
                         <!-- Edit Trakt Details button -->
                         <Button Margin="5,0,2,2" Style="{DynamicResource RoundButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                                 Command="{StaticResource EditTraktLinkCommand}" CommandParameter="{Binding}"
-                                ToolTip="{usercontrols:Info Title=Edit, 
-                                Body=Edit the details of this Link}">
+                                ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_EditTitle}, 
+                                Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_EditInfo}}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                                 <Image Height="16" Width="16" Source="/Images/16_switch.png" Margin="0,0,0,0"/>
                             </StackPanel>
@@ -196,8 +196,8 @@
                         <!-- Update Trakt Info button -->
                         <Button Margin="5,0,2,2" Style="{DynamicResource RoundButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                                 Command="{StaticResource UpdateTraktLinkCommand}" CommandParameter="{Binding}"
-                                ToolTip="{usercontrols:Info Title=Update, 
-                                Body=Download fresh data from Trakt and update the local database}">
+                                ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_UpdateTitle}, 
+                                Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_UpdateTrakt}}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                                 <Image Height="16" Width="16" Source="/Images/32_import.png" Margin="0,0,0,0"/>
                             </StackPanel>
@@ -206,8 +206,8 @@
                         <!-- Sync Trakt Info button -->
                         <Button Margin="5,0,2,2" Style="{DynamicResource RoundButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                                 Command="{StaticResource SyncTraktLinkCommand}" CommandParameter="{Binding}"
-                                ToolTip="{usercontrols:Info Title=Sync, 
-                                Body=Sync your collection and history data with Trakt}">
+                                ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_SyncTitle}, 
+                                Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_SyncTrakt}}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                                 <Image Height="16" Width="16" Source="/Images/32_sync.png" Margin="0,0,0,0"/>
                             </StackPanel>
@@ -216,8 +216,8 @@
                         <!-- Report incorrect links -->
                         <Button Margin="5,0,2,2" Style="{DynamicResource RoundButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                             Command="{StaticResource ReportTraktLinkCommand}" CommandParameter="{Binding}" Visibility="Collapsed"
-                            ToolTip="{usercontrols:Info Title=Report Linking Error, 
-                            Body=If this is linked to the wrong series click here to let the developers know}">
+                            ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_ReportLinkTitle}, 
+                            Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_ReportLinkInfo}}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                                 <Image Height="16" Width="16" Source="/Images/vote_down2.png" Margin="0,0,0,0"/>
                             </StackPanel>
@@ -296,11 +296,11 @@
                     <Button Name="btnTvDBAutoLinkEnable" Margin="5,0,2,2" Style="{DynamicResource FlatButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                             Command="{StaticResource ToggleAutoLinkTvDBCommand}" CommandParameter="{Binding}"
                             Visibility="{Binding Path=IsTvDBLinkDisabled, Converter={StaticResource BooleanToVisibilityConverter}}" 
-                            ToolTip="{usercontrols:Info Title=Auto Linking Disabled, 
-                            Body=Auto linking from this anime to a TvDB series is currently disabled}">
+                            ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkDisabledTitle}, 
+                            Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkDisabledTvDB}}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                             <Image Height="16" Width="16" Source="/Images/32_cancel.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Auto Link" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CommunityLinks_AutoLink}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
 
@@ -308,11 +308,11 @@
                     <Button Name="btnTvDBAutoLinkDisable" Margin="5,0,2,2" Style="{DynamicResource FlatButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                             Command="{StaticResource ToggleAutoLinkTvDBCommand}" CommandParameter="{Binding}"
                             Visibility="{Binding Path=IsTvDBLinkEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
-                            ToolTip="{usercontrols:Info Title=Auto Linking Enabled, 
-                            Body=Auto linking from this anime to a TvDB series is currently enabled. If JMM Server finds a close match or community recommendation it will automatically create a link}">
+                            ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkEnabledTitle}, 
+                            Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkEnabledTvDB}}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                             <Image Height="16" Width="16" Source="/Images/16_Tick.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Auto Link" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CommunityLinks_AutoLink}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
 
@@ -357,11 +357,11 @@
             <Button Name="btnTvDBAutoLinkEnable2" Margin="5,0,2,2" Style="{DynamicResource FlatButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                             Command="{StaticResource ToggleAutoLinkTvDBCommand}" CommandParameter="{Binding}"
                             Visibility="{Binding Path=IsTvDBLinkDisabled, Converter={StaticResource BooleanToVisibilityConverter}}" 
-                            ToolTip="{usercontrols:Info Title=Auto Linking Disabled, 
-                            Body=Auto linking from this anime to a TvDB series is currently disabled}">
+                            ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkDisabledTitle}, 
+                            Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkDisabledTvDB}}">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                     <Image Height="16" Width="16" Source="/Images/32_cancel.png" Margin="0,0,5,0"/>
-                    <TextBlock VerticalAlignment="Center" Text="Auto Link" Margin="0,0,5,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CommunityLinks_AutoLink}" Margin="0,0,5,0"/>
                 </StackPanel>
             </Button>
 
@@ -369,11 +369,11 @@
             <Button Name="btnTvDBAutoLinkDisable2" Margin="5,0,2,2" Style="{DynamicResource FlatButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                             Command="{StaticResource ToggleAutoLinkTvDBCommand}" CommandParameter="{Binding}"
                             Visibility="{Binding Path=IsTvDBLinkEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
-                            ToolTip="{usercontrols:Info Title=Auto Linking Enabled, 
-                            Body=Auto linking from this anime to a TvDB series is currently enabled. If JMM Server finds a close match or community recommendation it will automatically create a link}">
+                            ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkEnabledTitle}, 
+                            Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkEnabledTvDB}}">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                     <Image Height="16" Width="16" Source="/Images/16_Tick.png" Margin="0,0,5,0"/>
-                    <TextBlock VerticalAlignment="Center" Text="Auto Link" Margin="0,0,5,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CommunityLinks_AutoLink}" Margin="0,0,5,0"/>
                 </StackPanel>
             </Button>
 
@@ -398,7 +398,7 @@
                 <StackPanel Orientation="Horizontal">
 
                     <Image Height="16" Width="16" Source="/Images/trakttv.ico" Margin="0,0,10,2" VerticalAlignment="Center"/>
-                    <TextBlock Text="Trakt TV" Width="120" VerticalAlignment="Center"/>
+                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CommunityLinks_TraktTV}" Width="120" VerticalAlignment="Center"/>
                     <Image Height="16" Width="16" Source="/Images/16_tick.png" Margin="0,0,0,2" VerticalAlignment="Center"/>
 
                     <!-- search button -->
@@ -413,11 +413,11 @@
                     <Button Name="btnTraktAutoLinkEnable" Margin="5,0,2,2" Style="{DynamicResource FlatButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                                     Command="{StaticResource ToggleAutoLinkTraktCommand}" CommandParameter="{Binding}"
                                     Visibility="{Binding Path=IsTraktLinkDisabled, Converter={StaticResource BooleanToVisibilityConverter}}" 
-                                    ToolTip="{usercontrols:Info Title=Auto Linking Disabled, 
-                                    Body=Auto linking from this anime to a Trakt series is currently disabled}">
+                                    ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkDisabledTitle}, 
+                                    Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkDisabledTrakt}}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                             <Image Height="16" Width="16" Source="/Images/32_cancel.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Auto Link" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=ComminityLinks_AutoLink}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
 
@@ -425,11 +425,11 @@
                     <Button Name="btnTraktAutoLinkDisable" Margin="5,0,2,2" Style="{DynamicResource FlatButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                                     Command="{StaticResource ToggleAutoLinkTraktCommand}" CommandParameter="{Binding}"
                                     Visibility="{Binding Path=IsTraktLinkEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                    ToolTip="{usercontrols:Info Title=Auto Linking Enabled, 
-                                    Body=Auto linking from this anime to a Trakt series is currently enabled. If JMM Server finds a close match or community recommendation it will automatically create a link}">
+                                    ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkEnabledTitle}, 
+                                    Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkEnabledTrakt}}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                             <Image Height="16" Width="16" Source="/Images/16_Tick.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Auto Link" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CommunityLinks_AutoLink}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
 
@@ -459,7 +459,7 @@
         <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="10,10,0,0" VerticalAlignment="Center" 
                     Visibility="{Binding Path=AniDB_AnimeCrossRefs.TraktCrossRefMissing, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:TvDBAndOtherLinks}}, Converter={StaticResource BooleanToVisibilityConverter}}">
             <Image Height="16" Width="16" Source="/Images/trakttv.ico" Margin="0,0,10,2" VerticalAlignment="Center"/>
-            <TextBlock Text="Trakt TV" Width="120" VerticalAlignment="Center"/>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CommunityLinks_TraktTV}" Width="120" VerticalAlignment="Center"/>
             <Image Height="16" Width="16" Source="/Images/32_warning.png" Margin="0,0,0,2" VerticalAlignment="Center"/>
 
             <!-- search button -->
@@ -474,11 +474,11 @@
             <Button Name="btnTraktAutoLinkEnable2" Margin="5,0,2,2" Style="{DynamicResource FlatButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                             Command="{StaticResource ToggleAutoLinkTraktCommand}" CommandParameter="{Binding}"
                             Visibility="{Binding Path=IsTraktLinkDisabled, Converter={StaticResource BooleanToVisibilityConverter}}" 
-                            ToolTip="{usercontrols:Info Title=Auto Linking Disabled, 
-                            Body=Auto linking from this anime to a Trakt series is currently disabled}">
+                            ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkDisabledTitle}, 
+                            Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkDisabledTrakt}}">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                     <Image Height="16" Width="16" Source="/Images/32_cancel.png" Margin="0,0,5,0"/>
-                    <TextBlock VerticalAlignment="Center" Text="Auto Link" Margin="0,0,5,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CommunityLinks_AutoLink}" Margin="0,0,5,0"/>
                 </StackPanel>
             </Button>
 
@@ -486,11 +486,11 @@
             <Button Name="btnTraktAutoLinkDisable2" Margin="5,0,2,2" Style="{DynamicResource FlatButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                             Command="{StaticResource ToggleAutoLinkTraktCommand}" CommandParameter="{Binding}"
                             Visibility="{Binding Path=IsTraktLinkEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
-                            ToolTip="{usercontrols:Info Title=Auto Linking Enabled, 
-                            Body=Auto linking from this anime to a Trakt series is currently enabled. If JMM Server finds a close match or community recommendation it will automatically create a link}">
+                            ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkEnabledTitle}, 
+                            Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkEnabledTrakt}}">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                     <Image Height="16" Width="16" Source="/Images/16_Tick.png" Margin="0,0,5,0"/>
-                    <TextBlock VerticalAlignment="Center" Text="Auto Link" Margin="0,0,5,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CommunityLinks_AutoLink}" Margin="0,0,5,0"/>
                 </StackPanel>
             </Button>
 
@@ -514,7 +514,7 @@
             <StackPanel Orientation="Vertical">
                 <StackPanel Orientation="Horizontal">
                     <Image Height="16" Width="16" Source="/Images/myanimelist.ico" Margin="0,0,10,2" VerticalAlignment="Center"/>
-                    <TextBlock Text="MyAnimeList" Width="120" VerticalAlignment="Center"/>
+                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CommunityLinks_MAL}" Width="120" VerticalAlignment="Center"/>
                     <Image Height="16" Width="16" Source="/Images/16_tick.png" Margin="0,0,0,2" VerticalAlignment="Center"/>
 
                     <!-- search button -->
@@ -529,11 +529,11 @@
                     <Button Name="btnMALAutoLinkEnable" Margin="5,0,2,2" Style="{DynamicResource FlatButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                             Command="{StaticResource ToggleAutoLinkMALCommand}" CommandParameter="{Binding}"
                             Visibility="{Binding Path=IsMALLinkDisabled, Converter={StaticResource BooleanToVisibilityConverter}}" 
-                            ToolTip="{usercontrols:Info Title=Auto Linking Disabled, 
-                            Body=Auto linking from this anime to a MAL series is currently disabled}">
+                            ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkDisabledTitle}, 
+                            Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkDisabledMAL}}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                             <Image Height="16" Width="16" Source="/Images/32_cancel.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Auto Link" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CommunityLinks_AutoLink}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
 
@@ -541,11 +541,11 @@
                     <Button Name="btnMALAutoLinkDisable" Margin="5,0,2,2" Style="{DynamicResource FlatButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                             Command="{StaticResource ToggleAutoLinkMALCommand}" CommandParameter="{Binding}"
                             Visibility="{Binding Path=IsMALLinkEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
-                            ToolTip="{usercontrols:Info Title=Auto Linking Enabled, 
-                            Body=Auto linking from this anime to a MAL series is currently enabled. If JMM Server finds a close match or community recommendation it will automatically create a link}">
+                            ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkEnabledTitle}, 
+                            Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkEnabledMAL}}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                             <Image Height="16" Width="16" Source="/Images/16_Tick.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Auto Link" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CommunityLinks_AutoLink}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
 
@@ -566,7 +566,7 @@
         <StackPanel Grid.Row="4" Orientation="Horizontal" Margin="10,10,0,0" VerticalAlignment="Center" 
                     Visibility="{Binding Path=AniDB_AnimeCrossRefs.MALCrossRefMissing, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:TvDBAndOtherLinks}}, Converter={StaticResource BooleanToVisibilityConverter}}">
             <Image Height="16" Width="16" Source="/Images/myanimelist.ico" Margin="0,0,10,2" VerticalAlignment="Center"/>
-            <TextBlock Text="MyAnimeList" Width="120" VerticalAlignment="Center"/>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CommunityLinks_MAL}" Width="120" VerticalAlignment="Center"/>
             <Image Height="16" Width="16" Source="/Images/32_warning.png" Margin="0,0,0,2" VerticalAlignment="Center"/>
 
             <!-- search button -->
@@ -627,11 +627,11 @@
                     <Button Name="btnMovieDBAutoLinkEnable" Margin="5,0,2,2" Style="{DynamicResource FlatButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                             Command="{StaticResource ToggleAutoLinkMovieDBCommand}" CommandParameter="{Binding}"
                             Visibility="{Binding Path=IsMovieDBLinkDisabled, Converter={StaticResource BooleanToVisibilityConverter}}" 
-                            ToolTip="{usercontrols:Info Title=Auto Linking Disabled, 
-                            Body=Auto linking from this anime to a MovieDB series is currently disabled}">
+                            ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkDisabledTitle}, 
+                            Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkDisabledTMDb}}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                             <Image Height="16" Width="16" Source="/Images/32_cancel.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Auto Link" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CommunityLinks_AutoLink}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
 
@@ -639,11 +639,11 @@
                     <Button Name="btnMovieDBAutoLinkDisable" Margin="5,0,2,2" Style="{DynamicResource FlatButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                             Command="{StaticResource ToggleAutoLinkMovieDBCommand}" CommandParameter="{Binding}"
                             Visibility="{Binding Path=IsMovieDBLinkEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
-                            ToolTip="{usercontrols:Info Title=Auto Linking Enabled, 
-                            Body=Auto linking from this anime to a MovieDB series is currently enabled. If JMM Server finds a close match or community recommendation it will automatically create a link}">
+                            ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkEnabledTitle}, 
+                            Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkEnabledTMDb}}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                             <Image Height="16" Width="16" Source="/Images/16_Tick.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Auto Link" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CommunityLinks_AutoLink}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
 
@@ -651,11 +651,11 @@
                     <Button Margin="5,0,2,2" Style="{DynamicResource FlatButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                     Command="{DynamicResource ShowWebCacheAdminCommand}" CommandParameter="{Binding}"
                     Visibility="{Binding Source={x:Static local:JMMServerVM.Instance}, Path=ShowCommunity, Converter={StaticResource BooleanToVisibilityConverter}}"
-                    ToolTip="{usercontrols:Info Title=Community Admin, 
-                    Body=Go to the Community admin tab and edit the recommended links for this anime}">
+                    ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_CommunityAdminTitle}, 
+                    Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_CommunityAdminInfo}}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                             <Image Height="16" Width="16" Source="/Images/16_Star.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Community Admin" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_CommunityAdminTitle}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
 
@@ -683,11 +683,11 @@
             <Button Name="btnMovieDBAutoLinkEnable2" Margin="5,0,2,2" Style="{DynamicResource FlatButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                             Command="{StaticResource ToggleAutoLinkMovieDBCommand}" CommandParameter="{Binding}"
                             Visibility="{Binding Path=IsMovieDBLinkDisabled, Converter={StaticResource BooleanToVisibilityConverter}}" 
-                            ToolTip="{usercontrols:Info Title=Auto Linking Disabled, 
-                            Body=Auto linking from this anime to a TvDB series is currently disabled}">
+                            ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkDisabledTitle}, 
+                            Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkDisabledTMDb}}">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                     <Image Height="16" Width="16" Source="/Images/32_cancel.png" Margin="0,0,5,0"/>
-                    <TextBlock VerticalAlignment="Center" Text="Auto Link" Margin="0,0,5,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CommunityLinks_AutoLink}" Margin="0,0,5,0"/>
                 </StackPanel>
             </Button>
 
@@ -695,11 +695,11 @@
             <Button Name="btnMovieDBAutoLinkDisable2" Margin="5,0,2,2" Style="{DynamicResource FlatButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                             Command="{StaticResource ToggleAutoLinkMovieDBCommand}" CommandParameter="{Binding}"
                             Visibility="{Binding Path=IsMovieDBLinkEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
-                            ToolTip="{usercontrols:Info Title=Auto Linking Enabled, 
-                            Body=Auto linking from this anime to a TvDB series is currently enabled. If JMM Server finds a close match or community recommendation it will automatically create a link}">
+                            ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkEnabledTitle}, 
+                            Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_AutoLinkEnabledTMDb}}">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                     <Image Height="16" Width="16" Source="/Images/16_Tick.png" Margin="0,0,5,0"/>
-                    <TextBlock VerticalAlignment="Center" Text="Auto Link" Margin="0,0,5,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=CommunityLinks_AutoLink}" Margin="0,0,5,0"/>
                 </StackPanel>
             </Button>
 
@@ -713,11 +713,11 @@
             <!-- Community Admin -->
             <Button Margin="5,0,2,2" Style="{DynamicResource FlatButtonStyle}" HorizontalAlignment="Left" VerticalAlignment="Center"
                             Command="{DynamicResource ShowWebCacheAdminCommand}" CommandParameter="{Binding}"
-                            ToolTip="{usercontrols:Info Title=Community Admin, 
-                            Body=Go to the Community admin tab and edit the recommended links for this anime}">
+                            ToolTip="{usercontrols:Info Title={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_CommunityAdminTitle}, 
+                            Body={Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_CommunityAdminInfo}}">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                     <Image Height="16" Width="16" Source="/Images/16_Star.png" Margin="0,0,5,0"/>
-                    <TextBlock VerticalAlignment="Center" Text="Community Admin" Margin="0,0,5,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_CommunityAdminTitle}" Margin="0,0,5,0"/>
                 </StackPanel>
             </Button>
         </StackPanel>

--- a/JMMClient/UserControls/UnrecognisedVideos.xaml
+++ b/JMMClient/UserControls/UnrecognisedVideos.xaml
@@ -76,7 +76,7 @@
                                 Command="{DynamicResource RescanFileCommand}" CommandParameter="{Binding}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                                 <Image Height="16" Width="16" Source="/Images/32_sync.png" Margin="0,0,5,0"/>
-                                <TextBlock VerticalAlignment="Center" Text="Rescan" Margin="0,0,5,0"/>
+                                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Unrecognized_Rescan}" Margin="0,0,5,0"/>
                             </StackPanel>
                         </Button>
                         
@@ -159,10 +159,10 @@
                                 Command="{StaticResource RescanFileCommand}" CommandParameter="{Binding}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                                 <Image Height="16" Width="16" Source="/Images/32_sync.png" Margin="0,0,5,0"/>
-                                <TextBlock VerticalAlignment="Center" Text="Rescan" Margin="0,0,5,0"/>
+                                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Unrecognized_Rescan}" Margin="0,0,5,0"/>
                             </StackPanel>
                             <Button.ToolTip>
-                                <TextBlock Text="Force update information from AniDB"/>
+                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Unrecognize_ForceAniDB}"/>
                             </Button.ToolTip>
                         </Button>
 
@@ -199,10 +199,10 @@
                     <TextBlock Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Text="{Binding Path=FileDirectory}" Margin="3" />
                     <TextBlock Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Text="{Binding Path=FormattedFileSize}" Margin="3" />
 
-                    <TextBlock Grid.Row="4" Grid.Column="0" Text="Hash" Margin="3" FontWeight="DemiBold" />
+                    <TextBlock Grid.Row="4" Grid.Column="0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Unrecognized_Hash}" Margin="3" FontWeight="DemiBold" />
                     <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding Path=Hash}" Margin="10,3,3,3" />
 
-                    <TextBlock Grid.Row="5" Grid.Column="0" Text="CRC32" Margin="3" FontWeight="DemiBold" />
+                    <TextBlock Grid.Row="5" Grid.Column="0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Unrecognized_CRC32}" Margin="3" FontWeight="DemiBold" />
                     <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding Path=CRC32}" Margin="10,3,3,3" />
 
                 </Grid>
@@ -280,7 +280,7 @@
                     <Button Name="btnRehash" Margin="10,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                             <Image Height="16" Width="16" Source="/Images/32_redo.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Re-hash All" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Unrecognized_Rehash}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
 
@@ -288,7 +288,7 @@
                     <Button Name="btnLogs" Margin="20,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                             <Image Height="16" Width="16" Source="/Images/32_folder.png" Margin="0,0,5,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="Logs" Margin="0,0,5,0"/>
+                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Unrecognized_Logs}" Margin="0,0,5,0"/>
                         </StackPanel>
                     </Button>
 
@@ -361,7 +361,7 @@
                 <!-- single series and episode -->
                 <StackPanel Orientation="Horizontal" Grid.Column="0" Grid.Row="1" Margin="0,0,0,5">
                     <Image Source="/Images/16_television.png" Width="16" Height="16" Margin="5,0,0,0" VerticalAlignment="Center" ></Image>
-                    <TextBlock Name="txtSelectedSeriesDetails" Margin="5,0,0,0"  Text="NA"  VerticalAlignment="Center"/>
+                    <TextBlock Name="txtSelectedSeriesDetails" Margin="5,0,0,0"  Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Unrecognized_NA}"  VerticalAlignment="Center"/>
                 </StackPanel>
 
 
@@ -392,7 +392,7 @@
                         <Button  Name="btnRefreshSeriesList" Margin="20,2,2,2" Style="{DynamicResource FlatButtonStyle}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                 <Image Height="16" Width="16" Source="/Images/16_refresh.png" Margin="0,0,3,0"/>
-                                <TextBlock VerticalAlignment="Center" Text="Refresh Series List" Margin="0,0,0,0"/>
+                                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Unrecognized_RefreshSeries}" Margin="0,0,0,0"/>
                             </StackPanel>
                         </Button>
                     </StackPanel>
@@ -434,7 +434,7 @@
                     <StackPanel Orientation="Horizontal"
                                 Visibility="{Binding Path=MultipleTypeRange, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:UnrecognisedVideos}}, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <TextBox Name="txtStartEpNum" Margin="5,0,0,0" Width="40" VerticalAlignment="Center" Text="1"/>
-                        <TextBlock Margin="5,0,0,0" VerticalAlignment="Center" Text="to"/>
+                        <TextBlock Margin="5,0,0,0" VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Unrecognized_To}"/>
                         <TextBlock Name="txtEndEpNum" Margin="5,0,0,0" VerticalAlignment="Center" Text="??" FontWeight="Bold"
                                    Visibility="{Binding Path=MultipleVideosSelected, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type usercontrols:UnrecognisedVideos}}, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                         <TextBox Name="txtEndEpNumSingle" Margin="5,0,0,0" Width="40" VerticalAlignment="Center" Text="1"

--- a/JMMClient/UserControls/UpdateAniDBDataControl.xaml
+++ b/JMMClient/UserControls/UpdateAniDBDataControl.xaml
@@ -29,7 +29,7 @@
         <!-- Styles -->
 
         <Border BorderBrush="LightGray" BorderThickness="1" Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Background="#FFE9ECEF" Margin="0,0,0,5">
-            <TextBlock Text="Update Local AniDB File Data" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
+            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=UpdateAniDB_UpdateLocal}" Margin="5,0,0,0" Padding="3" FontWeight="Bold" VerticalAlignment="Center"></TextBlock>
         </Border>
 
         <Border Style="{DynamicResource ToolbarBorderControlStyle}" Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2" Background="FloralWhite" Margin="0,0,0,5" Padding="5">
@@ -44,7 +44,7 @@
                 </Grid.ColumnDefinitions>
 
                 <Image Height="16" Width="16" Source="/Images/32_info.png" Margin="5,2,5,0" Grid.Column="0" VerticalAlignment="Top"/>
-                <TextBlock VerticalAlignment="Center" Text="Data relating to files is downloaded from AniDB and then stored in your local database when you first import a file. In some cases this data may not be complete when you first download it. Or extra data may be downloaded but newer versions of JMM. This utility will allow you to get a fresh copy of that information from AniDB" Margin="0,0,5,0" TextWrapping="Wrap" Grid.Column="1"/>
+                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=UpdateAniDB_Info1}" Margin="0,0,5,0" TextWrapping="Wrap" Grid.Column="1"/>
             </Grid>
         </Border>
 
@@ -61,7 +61,7 @@
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
-            <CheckBox Name="chkMissingInfo" Grid.Column="0" Grid.Row="0" Content="Update Files with Missing Info" Margin="10,0,0,5"/>
+            <CheckBox Name="chkMissingInfo" Grid.Column="0" Grid.Row="0" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=UpdateAniDB_MissingInfo}" Margin="10,0,0,5"/>
             <Border Style="{DynamicResource ToolbarBorderControlStyle}" Grid.Column="0" Grid.Row="1"  Background="FloralWhite" Margin="30,0,0,5" Padding="5">
                 <Grid>
                     <Grid.RowDefinitions>
@@ -72,12 +72,12 @@
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
 
-                    <TextBlock VerticalAlignment="Center" Text="Missing data usually relates to missing codec and resolution information. You may see Resolution: 0x0 next to these files" Margin="0,0,5,0" TextWrapping="Wrap" Grid.Column="1"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=UpdateAniDB_Info2}" Margin="0,0,5,0" TextWrapping="Wrap" Grid.Column="1"/>
                 </Grid>
             </Border>
 
 
-            <CheckBox Name="chkOutofDate" Grid.Column="0" Grid.Row="2" Content="Update files to Internal Version 2" Margin="10,0,0,5"/>
+            <CheckBox Name="chkOutofDate" Grid.Column="0" Grid.Row="2" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=UpdateAniDB_Version}" Margin="10,0,0,5"/>
             <Border Style="{DynamicResource ToolbarBorderControlStyle}" Grid.Column="0" Grid.Row="3"  Background="FloralWhite" Margin="30,0,0,5" Padding="5">
                 <Grid>
                     <Grid.RowDefinitions>
@@ -88,7 +88,7 @@
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
 
-                    <TextBlock VerticalAlignment="Center" Text="Internal Version 2 added the following information - File version (v2, v3 etc), Is Censored, Is Deprecated" Margin="0,0,5,0" TextWrapping="Wrap" Grid.Column="1"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=UpdateAniDB_Info3}" Margin="0,0,5,0" TextWrapping="Wrap" Grid.Column="1"/>
                 </Grid>
             </Border>
         </Grid>
@@ -105,7 +105,7 @@
                 </Grid.ColumnDefinitions>
 
                 <Image Height="16" Width="16" Source="/Images/16_exclamation.png" Margin="5,2,5,0" Grid.Column="0" VerticalAlignment="Top"/>
-                <TextBlock VerticalAlignment="Center" Text="Sending too many commands to AniDB, may cause a temporary ban. Use at your own risk." Margin="0,0,5,0" TextWrapping="Wrap" Grid.Column="1"/>
+                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=UpdateAniDB_Info4}" Margin="0,0,5,0" TextWrapping="Wrap" Grid.Column="1"/>
             </Grid>
         </Border>
 
@@ -113,13 +113,13 @@
             <Button Name="btnEstimate" Margin="10,2,5,2" Style="{DynamicResource RoundButtonStyle}" >
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                     <Image Height="16" Width="16" Source="/Images/32_help.png" Margin="0,0,5,0"/>
-                    <TextBlock VerticalAlignment="Center" Text="How Many Commands Will Be Queued?" Margin="0,0,5,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=UpdateAniDB_HowManyQueued}" Margin="0,0,5,0"/>
                 </StackPanel>
             </Button>
             <Button Name="btnQueueCommands" Margin="10,2,5,2" Style="{DynamicResource RoundButtonStyle}" >
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                     <Image Height="16" Width="16" Source="/Images/16_tick.png" Margin="0,0,5,0"/>
-                    <TextBlock VerticalAlignment="Center" Text="Queue Commands" Margin="0,0,5,0"/>
+                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=UpdateAniDB_Queued}" Margin="0,0,5,0"/>
                 </StackPanel>
             </Button>
         </StackPanel >

--- a/JMMClient/UserControls/UserAdminControl.xaml
+++ b/JMMClient/UserControls/UserAdminControl.xaml
@@ -131,7 +131,7 @@
                                    Text="{Resx ResxName=JMMClient.Properties.Resources, Key=User_EditSettings}"/>
                         <CheckBox Grid.Row="4" Grid.Column="1" Name="chkEditSettings" VerticalAlignment="Center" />
 
-                        <TextBlock Grid.Row="5" Grid.Column="0" VerticalAlignment="Center" FontWeight="Bold" Margin="0,5,15,0" Text="Hide Tags"/>
+                        <TextBlock Grid.Row="5" Grid.Column="0" VerticalAlignment="Center" FontWeight="Bold" Margin="0,5,15,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=User_HideTags}"/>
                         <TextBox Grid.Row="5" Grid.Column="1" HorizontalAlignment="Left"  VerticalAlignment="Center" Width="300" Margin="0,5,0,0" Text="{Binding Path=SortName}" Name="txtTags"/>
 
 
@@ -159,7 +159,7 @@
                         <Button Name="btnChangePassword" Margin="10,2,2,2" Style="{DynamicResource RoundButtonStyle}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
                                 <Image Height="16" Width="16" Source="/Images/16_key.png" Margin="0,0,3,0"/>
-                                <TextBlock VerticalAlignment="Center" Text="Change Password" Margin="0,0,0,0"/>
+                                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=User_ChangePassword}" Margin="0,0,0,0"/>
                             </StackPanel>
                         </Button>
 

--- a/JMMClient/UserCulture.cs
+++ b/JMMClient/UserCulture.cs
@@ -30,9 +30,13 @@ namespace JMMClient
 
 				userLanguages.Add(new UserCulture("en", "English (US)", @"Images/Flags/us.gif"));
 				userLanguages.Add(new UserCulture("en-gb", "English (United Kingdom)", @"Images/Flags/uk_unitedkingdom.gif"));
-				userLanguages.Add(new UserCulture("de", "German", @"Images/Flags/de_germany.gif"));
+                userLanguages.Add(new UserCulture("fr", "French", @"Images/Flags/fr.gif"));
+                userLanguages.Add(new UserCulture("de", "German", @"Images/Flags/de_germany.gif"));
+                userLanguages.Add(new UserCulture("it", "Italian", @"Images/Flags/it.gif"));
+                userLanguages.Add(new UserCulture("ru", "Russian", @"Images/Flags/ru.gif"));
+                userLanguages.Add(new UserCulture("es", "Spanish", @"Images/Flags/es.gif"));
 
-				return userLanguages;
+                return userLanguages;
 			}
 		}
 


### PR DESCRIPTION
Replaced all hardcoded text in .xaml files with Resx strings allowing users to change the display language. German, Italian, French, Russian and Spanish are now supported and have been completely machine translated. 

The only problem at the moment is hardcoded text in .cs files, from my understanding its a static resource that cant be changed via Resx. Check screenshot for example. 
![jmmdesktop_2016-02-22_00-56-43](https://cloud.githubusercontent.com/assets/9443295/13214391/40756944-d904-11e5-8118-da1720cf45ce.png)
