### PR TITLE
fix issue #31 (further improvements)

### DIFF
--- a/JMMClient/ViewModel/JMMServerVM.cs
+++ b/JMMClient/ViewModel/JMMServerVM.cs
@@ -1451,6 +1451,9 @@ namespace JMMClient
 
         private bool isRelationInExclusion(string relation)
         {
+            if (AutoGroupSeriesRelationExclusions == null)
+                return false;
+
             foreach (string a in AutoGroupSeriesRelationExclusions.Split('|'))
             {
                 // relation will always be lowercase, but a may not be yet

--- a/JMMClient/ViewModel/MainListHelperVM.cs
+++ b/JMMClient/ViewModel/MainListHelperVM.cs
@@ -82,11 +82,12 @@ namespace JMMClient
             }
         }
 
-        public int LastAnimeGroupID { get; set; }
-        public int LastAnimeSeriesID { get; set; }
-        public int LastGroupFilterID { get; set; }
+        //public int LastAnimeGroupID { get; set; }
+        //public int LastAnimeSeriesID { get; set; }
+        //public int LastGroupFilterID { get; set; }
+        public string CurrentOpenGroupFilter { get; set; }
 
-        public Dictionary<int, int> LastGroupForGF { get; set; } // GroupFilterID, position in list of last selected group
+        public Dictionary<string, int> LastGroupForGF { get; set; } // GroupFilterID, position in list of last selected group
 
         public GroupFilterVM AllGroupFilter
         {
@@ -319,10 +320,11 @@ namespace JMMClient
 
             BreadCrumbs = new ObservableCollection<MainListWrapper>();
 
-            LastAnimeGroupID = 0;
-            LastAnimeSeriesID = 0;
-            LastGroupFilterID = 0;
-            LastGroupForGF = new Dictionary<int, int>();
+            //LastAnimeGroupID = 0;
+            //LastAnimeSeriesID = 0;
+            //LastGroupFilterID = 0;
+            CurrentOpenGroupFilter = "";
+            LastGroupForGF = new Dictionary<string, int>();
             LastEpisodeForSeries = new Dictionary<int, int>();
         }
 
@@ -481,20 +483,28 @@ namespace JMMClient
                 CurrentWrapperIsGroup = wrapper is GroupFilterVM;
                 CurrentListWrapperIsGroup = wrapper is AnimeGroupVM;
 
-                if (wrapper is AnimeGroupVM) LastAnimeGroupID = ((AnimeGroupVM)wrapper).AnimeGroupID.Value;
+                if (wrapper is AnimeGroupVM)
+                {
+                    //LastAnimeGroupID = ((AnimeGroupVM)wrapper).AnimeGroupID.Value;
+                    MainListHelperVM.Instance.CurrentOpenGroupFilter = "AnimeGroupVM|" + ((AnimeGroupVM)wrapper).AnimeGroupID.Value;
+                }
                 if (wrapper is GroupFilterVM)
                 {
                     CurrentGroupFilter = (GroupFilterVM)wrapper;
-                    LastGroupFilterID = ((GroupFilterVM)wrapper).GroupFilterID.Value;
+                    //LastGroupFilterID = ((GroupFilterVM)wrapper).GroupFilterID.Value;
+
+                    MainListHelperVM.Instance.CurrentOpenGroupFilter = "GroupFilterVM|" + ((GroupFilterVM)wrapper).GroupFilterID.Value;
                 }
                 if (wrapper is AnimeSeriesVM)
                 {
                     CurrentSeries = wrapper as AnimeSeriesVM;
-                    LastAnimeSeriesID = ((AnimeSeriesVM)wrapper).AnimeSeriesID.Value;
+                    //LastAnimeSeriesID = ((AnimeSeriesVM)wrapper).AnimeSeriesID.Value;
+
+                    MainListHelperVM.Instance.CurrentOpenGroupFilter = "NoGroup";
                 }
 
-
-
+                if (wrapper == null)
+                    MainListHelperVM.Instance.CurrentOpenGroupFilter = "Init";
 
 
                 System.Windows.Application.Current.Dispatcher.Invoke(System.Windows.Threading.DispatcherPriority.Normal, (Action)delegate ()


### PR DESCRIPTION
change the whole thing to use the 

MainListHelperVM.Instance.LastGroupForGF[MainListHelperVM.Instance.CurrentOpenGroupFilter]
system.

That was only half used and I just extended a little bit with my initial commit, now it only uses this system.

Now you should be able to navigate forward/backward and refreshing all you want and it should remember its position all the time.