### PR TITLE
Initial zoom player video player support

### DIFF
--- a/JMMClient/AppSettings.cs
+++ b/JMMClient/AppSettings.cs
@@ -2653,6 +2653,44 @@ namespace JMMClient
             }
         }
 
+        public static bool ZoomPlayerTCPControlIntegration
+        {
+            get
+            {
+                NameValueCollection appSettings = ConfigurationManager.AppSettings;
+                string stringValue = appSettings["ZoomPlayerTCPControlIntegration"];
+                bool booleanValue = false;
+                bool.TryParse(stringValue, out booleanValue);
+
+                return booleanValue;
+            }
+            set
+            {
+                UpdateSetting("ZoomPlayerTCPControlIntegration", value.ToString());
+            }
+        }
+        public static string ZoomPlayerTCPControlPort
+        {
+            get
+            {
+                NameValueCollection appSettings = ConfigurationManager.AppSettings;
+
+                string value = appSettings["ZoomPlayerTCPControlPort"];
+                if (string.IsNullOrEmpty(value))
+                {
+                    // default value
+                    value = "4769";
+                    UpdateSetting("ZoomPlayerTCPControlPort", value);
+                }
+                return value;
+            }
+            set
+            {
+                UpdateSetting("ZoomPlayerTCPControlPort", value);
+            }
+        }
+
+
         public static void DebugSettingsToLog()
         {
             #region System Info

--- a/JMMClient/Enums.cs
+++ b/JMMClient/Enums.cs
@@ -508,6 +508,7 @@ namespace JMMClient
         PotPlayer = 2,
         VLC = 3,
         ExternalMPV = 4,
+        ZoomPlayer = 5,
         WindowsDefault = 999
     }
 

--- a/JMMClient/JMMForWindows.csproj
+++ b/JMMClient/JMMForWindows.csproj
@@ -415,6 +415,7 @@
     <Compile Include="VideoPlayers\PotVideoPlayer.cs" />
     <Compile Include="VideoPlayers\VideoInfo.cs" />
     <Compile Include="VideoPlayers\VLCVideoPlayer.cs" />
+    <Compile Include="VideoPlayers\ZoomPlayerVideoPlayer.cs" />
     <Compile Include="ViewModel\AniDB_CharacterVM.cs" />
     <Compile Include="ViewModel\AniDB_SeiyuuVM.cs" />
     <Compile Include="ViewModel\AnimeEpisodeDisplayVM.cs" />

--- a/JMMClient/Properties/Resources.Designer.cs
+++ b/JMMClient/Properties/Resources.Designer.cs
@@ -5893,6 +5893,15 @@ namespace JMMClient.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to http://inmatrix.com/zplayer/options_system.shtml.
+        /// </summary>
+        public static string Link_ZoomPlayer {
+            get {
+                return ResourceManager.GetString("Link_ZoomPlayer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Loading....
         /// </summary>
         public static string Loading {
@@ -12817,6 +12826,51 @@ namespace JMMClient.Properties {
         public static string VideoPlayer_VLCTest {
             get {
                 return ResourceManager.GetString("VideoPlayer_VLCTest", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Zoom Player.
+        /// </summary>
+        public static string VideoPlayer_ZoomPlayer {
+            get {
+                return ResourceManager.GetString("VideoPlayer_ZoomPlayer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Requires TCP web control port to be enabled in Zoom Player for position retrieval..
+        /// </summary>
+        public static string VideoPlayer_ZoomPlayerNote {
+            get {
+                return ResourceManager.GetString("VideoPlayer_ZoomPlayerNote", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Zoom Player not found.
+        /// </summary>
+        public static string VideoPlayer_ZoomPlayerNotFound {
+            get {
+                return ResourceManager.GetString("VideoPlayer_ZoomPlayerNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Zoom Player setup instructions, check &quot;Enable External TCP Control (port)&quot; chapter.
+        /// </summary>
+        public static string VideoPlayer_ZoomPlayerSetupInstructions {
+            get {
+                return ResourceManager.GetString("VideoPlayer_ZoomPlayerSetupInstructions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Zoom Player TCP control port.
+        /// </summary>
+        public static string VideoPlayer_ZoomPlayerTCPControlPort {
+            get {
+                return ResourceManager.GetString("VideoPlayer_ZoomPlayerTCPControlPort", resourceCulture);
             }
         }
         

--- a/JMMClient/Properties/Resources.en-gb.resx
+++ b/JMMClient/Properties/Resources.en-gb.resx
@@ -4459,4 +4459,16 @@ Unlike the other supported media players, MPV is the fastest when it comes to st
   <data name="ImportFolder_SelectImportFolder" xml:space="preserve">
     <value>Select Import Folder...</value>
   </data>
+  <data name="VideoPlayer_ZoomPlayer" xml:space="preserve">
+    <value>Zoom Player</value>
+  </data>
+  <data name="VideoPlayer_ZoomPlayerNote" xml:space="preserve">
+    <value>Requires TCP web control port to be enabled in Zoom Player for position retrieval.</value>
+  </data>
+  <data name="VideoPlayer_ZoomPlayerNotFound" xml:space="preserve">
+    <value>Zoom Player not found</value>
+  </data>
+  <data name="VideoPlayer_ZoomPlayerTCPControlPort" xml:space="preserve">
+    <value>Zoom Player TCP control port</value>
+  </data>
 </root>

--- a/JMMClient/Properties/Resources.resx
+++ b/JMMClient/Properties/Resources.resx
@@ -4461,4 +4461,22 @@ Unlike the other supported media players, MPV is the fastest when it comes to st
   <data name="ImportFolder_SelectImportFolder" xml:space="preserve">
     <value>Select Import Folder...</value>
   </data>
+  <data name="VideoPlayer_ZoomPlayer" xml:space="preserve">
+    <value>Zoom Player</value>
+  </data>
+  <data name="VideoPlayer_ZoomPlayerNote" xml:space="preserve">
+    <value>Requires TCP web control port to be enabled in Zoom Player for position retrieval.</value>
+  </data>
+  <data name="VideoPlayer_ZoomPlayerNotFound" xml:space="preserve">
+    <value>Zoom Player not found</value>
+  </data>
+  <data name="VideoPlayer_ZoomPlayerTCPControlPort" xml:space="preserve">
+    <value>Zoom Player TCP control port</value>
+  </data>
+  <data name="Link_ZoomPlayer" xml:space="preserve">
+    <value>http://inmatrix.com/zplayer/options_system.shtml</value>
+  </data>
+  <data name="VideoPlayer_ZoomPlayerSetupInstructions" xml:space="preserve">
+    <value>Zoom Player setup instructions, check "Enable External TCP Control (port)" chapter</value>
+  </data>
 </root>

--- a/JMMClient/UserControls/Settings/VideoPlayerSettingsControl.xaml
+++ b/JMMClient/UserControls/Settings/VideoPlayerSettingsControl.xaml
@@ -412,7 +412,7 @@
                            Grid.ColumnSpan="2" FontSize="14" FontWeight="Bold" />
                 <TextBlock Grid.Column="3" Visibility="{Binding Source={x:Static local:UserSettingsVM.Instance},Path=IsMPVInstalled}" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_Installed}" Foreground="Green" Margin="10,5,10,5" VerticalAlignment="Top" HorizontalAlignment="Right" />
                 <TextBlock Grid.Column="3" Visibility="{Binding Source={x:Static local:UserSettingsVM.Instance},Path=IsMPVNotInstalled}" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_NotInstalled}" Foreground="Red" Margin="10,5,10,5" VerticalAlignment="Top" HorizontalAlignment="Right" />
-                 <Image Height="16" Width="16" Source="/Images/32_info.png" Margin="5,2,4,0" Grid.Column="0"
+                <Image Height="16" Width="16" Source="/Images/32_info.png" Margin="5,2,4,0" Grid.Column="0"
                        Grid.Row="1" VerticalAlignment="Top" />
                 <TextBlock Grid.Column="1" Grid.Row="1" Margin="0,0,5,0" VerticalAlignment="Center"
                            Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_MPVNote}"
@@ -423,8 +423,47 @@
                                                 URL="{Resx ResxName=JMMClient.Properties.Resources, Key=Link_MPV}" />
             </Grid>
         </Border>
+        <Border Style="{DynamicResource ToolbarBorderControlStyle}" Grid.Column="0" Grid.Row="11" Grid.ColumnSpan="3"
+        	Background="FloralWhite" Margin="0,0,0,215" Padding="5">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
 
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="25" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <TextBlock Grid.Column="0" Grid.Row="0" Margin="5,5,5,5" VerticalAlignment="Center"
+        			Text="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_ZoomPlayer}"
+        			Grid.ColumnSpan="2" FontSize="14" FontWeight="Bold" />
+                <TextBlock Grid.Column="3" Visibility="{Binding IsZoomPlayerInstalled, Source={x:Static local:UserSettingsVM.Instance}}" Text="{Resx Key=VideoPlayer_Installed, ResxName=JMMClient.Properties.Resources}" Foreground="Green" Margin="10,5,10,5" VerticalAlignment="Top" HorizontalAlignment="Right" />
+                <TextBlock Grid.Column="3" Visibility="{Binding IsZoomPlayerNotInstalled, Source={x:Static local:UserSettingsVM.Instance}}" Text="{Resx Key=VideoPlayer_NotInstalled, ResxName=JMMClient.Properties.Resources}" Foreground="Red" Margin="10,5,10,5" VerticalAlignment="Top" HorizontalAlignment="Right" />
+                <Image Height="16" Width="16" Source="/JMMDesktop;component/Images/32_info.png" Margin="5,2,4,0" Grid.Column="0"
+        			Grid.Row="1" VerticalAlignment="Top" />
+                <TextBlock Grid.Column="1" Grid.Row="1" Margin="0,0,5,0" VerticalAlignment="Center"
+        			Text="{Resx Key=VideoPlayer_ZoomPlayerNote, ResxName=JMMClient.Properties.Resources}"
+        			TextWrapping="Wrap" />
+                <usercontrols:HyperLinkStandard Grid.Row="2" VerticalAlignment="Center"
+                                                Margin="5,4,20,3"
+                                                DisplayText="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_ZoomPlayerSetupInstructions}"
+                                                URL="{Resx ResxName=JMMClient.Properties.Resources, Key=Link_ZoomPlayer}" Grid.ColumnSpan="2" />
+            </Grid>
+        </Border>
+        <Border Style="{DynamicResource ToolbarBorderControlStyle}" Grid.Column="0" Grid.Row="11" Grid.ColumnSpan="3"
+        	Background="#F1F1F1" Margin="0,87,0,138" Padding="5">
+            <Grid>
+                <TextBox Grid.Column="1" HorizontalAlignment="Left" Height="20" Margin="10,37,0,-42" Grid.Row="3"
+                         TextWrapping="Wrap"
+                         Text="{Binding Source={x:Static local:UserSettingsVM.Instance},Path=ZoomPlayerTCPControlPort}"
+                         VerticalAlignment="Top" Width="50" />
+                <CheckBox x:Name="chkZoomPlayerTCPControlIntegration"
+                          Content="{Resx ResxName=JMMClient.Properties.Resources, Key=VideoPlayer_ZoomPlayerTCPControlPort}"
+                          HorizontalAlignment="Left" Margin="10,10,0,0" Grid.Column="0" VerticalAlignment="Top"/>
+            </Grid>
+        </Border>
     </Grid>
-
-
 </UserControl>

--- a/JMMClient/UserControls/Settings/VideoPlayerSettingsControl.xaml.cs
+++ b/JMMClient/UserControls/Settings/VideoPlayerSettingsControl.xaml.cs
@@ -46,12 +46,16 @@ namespace JMMClient.UserControls
             chkMpcIniIntegration.Click += new RoutedEventHandler(chkMpcIniIntegration_Click);
             chkMpcWebUiIntegration.Click += new RoutedEventHandler(chkMpcWebUiIntegration_Click);
 
+            chkZoomPlayerTCPControlIntegration.IsChecked = UserSettingsVM.Instance.ZoomPlayerTCPControlIntegration;
+            chkZoomPlayerTCPControlIntegration.Click += new RoutedEventHandler(chkZoomPlayerTCPControlIntegration_Click);
+
             cboDefaultPlayer.Items.Clear();
             cboDefaultPlayer.Items.Add("Internal MPV");
             cboDefaultPlayer.Items.Add("MPC");
             cboDefaultPlayer.Items.Add("PotPlayer");
             cboDefaultPlayer.Items.Add("VLC");
             cboDefaultPlayer.Items.Add("External MPV");
+            cboDefaultPlayer.Items.Add("Zoom Player");
             switch (AppSettings.DefaultPlayer_GroupList)
             {
                 case (int)VideoPlayer.MPV:
@@ -60,16 +64,17 @@ namespace JMMClient.UserControls
                 case (int)VideoPlayer.MPC:
                     cboDefaultPlayer.SelectedIndex = 1;
                     break;
-
                 case (int)VideoPlayer.PotPlayer:
                     cboDefaultPlayer.SelectedIndex = 2;
                     break;
-
                 case (int)VideoPlayer.VLC:
                     cboDefaultPlayer.SelectedIndex = 3;
                     break;
                 case (int)VideoPlayer.ExternalMPV:
                     cboDefaultPlayer.SelectedIndex = 4;
+                    break;
+                case (int)VideoPlayer.ZoomPlayer:
+                    cboDefaultPlayer.SelectedIndex = 5;
                     break;
                 default:
                     cboDefaultPlayer.SelectedIndex = 0;
@@ -106,6 +111,7 @@ namespace JMMClient.UserControls
                 case 2: UserSettingsVM.Instance.DefaultPlayer_GroupList = (int)VideoPlayer.PotPlayer; break;
                 case 3: UserSettingsVM.Instance.DefaultPlayer_GroupList = (int)VideoPlayer.VLC; break;
                 case 4: UserSettingsVM.Instance.DefaultPlayer_GroupList = (int)VideoPlayer.ExternalMPV; break;
+                case 5: UserSettingsVM.Instance.DefaultPlayer_GroupList = (int)VideoPlayer.ZoomPlayer; break;
             }
             RefreshConfigured();
         }
@@ -115,7 +121,6 @@ namespace JMMClient.UserControls
             TextDefaultConfigured.Visibility = DefaultConfigured;
             TextDefaultConfigured.Text = JMMClient.Properties.Resources.VideoPlayer_Configured + " (" + ActivePlayer + ")";
             TextDefaultNotConfigured.Visibility = DefaultNotConfigured;
-
         }
 
         void chkAutoSetWatched_Click(object sender, RoutedEventArgs e)
@@ -358,6 +363,13 @@ namespace JMMClient.UserControls
         void btnClearVLCLocation_Click(object sender, RoutedEventArgs e)
         {
             UserSettingsVM.Instance.VLCFolder = string.Empty;
+        }
+
+
+        private void chkZoomPlayerTCPControlIntegration_Click(object sender, RoutedEventArgs e)
+        {
+            UserSettingsVM.Instance.ZoomPlayerTCPControlIntegration = chkZoomPlayerTCPControlIntegration.IsChecked.Value;
+            MainWindow.videoHandler.Init();
         }
 
         private void UserControl_Loaded(object sender, RoutedEventArgs e)

--- a/JMMClient/VideoPlayers/VideoHandler.cs
+++ b/JMMClient/VideoPlayers/VideoHandler.cs
@@ -36,7 +36,6 @@ namespace JMMClient.VideoPlayers
         public List<IVideoPlayer> Players=new List<IVideoPlayer>();
 
 
-
         public VideoHandler()
         {
             AddTempPathToSubtilePaths();
@@ -49,6 +48,8 @@ namespace JMMClient.VideoPlayers
             Players.Add(new PotVideoPlayer());
             Players.Add(new VLCVideoPlayer());
             Players.Add(new ExternalMPVVideoPlayer());
+            Players.Add(new ZoomPlayerVideoPlayer());
+
             foreach (IVideoPlayer v in Players)
             {
                 v.FilePositionsChange += FindChangedFiles;
@@ -96,9 +97,7 @@ namespace JMMClient.VideoPlayers
         protected void OnVideoWatchedEvent(VideoWatchedEventArgs ev)
         {
             VideoWatchedEvent?.Invoke(ev);
-        }
-
-      
+        }   
 
         private void AddTempPathToSubtilePaths()
         {
@@ -273,8 +272,6 @@ namespace JMMClient.VideoPlayers
                 {
                     v.Init();
                 }
-
-
             }
             catch (Exception ex)
             {

--- a/JMMClient/VideoPlayers/ZoomPlayerVideoPlayer.cs
+++ b/JMMClient/VideoPlayers/ZoomPlayerVideoPlayer.cs
@@ -103,8 +103,6 @@ namespace JMMClient.VideoPlayers
             {
                 if (firstStart)
                 {
-                    bool startupDelayEnabled = true;
-
                     // Wait for process to start and skip short playbacks
                     var startupDelay = TimeSpan.FromSeconds(5);
                     Thread.Sleep(startupDelay);
@@ -117,7 +115,7 @@ namespace JMMClient.VideoPlayers
                     }
                 }
 
-                var tc = new ZPConnection("localhost", 4769);
+                var tc = new ZPConnection("localhost", int.Parse(AppSettings.ZoomPlayerTCPControlPort));
                 var playerInactive = false;
                 char[] charSeparator = {' '};
                 var videoDuration = "";

--- a/JMMClient/VideoPlayers/ZoomPlayerVideoPlayer.cs
+++ b/JMMClient/VideoPlayers/ZoomPlayerVideoPlayer.cs
@@ -1,0 +1,378 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using JMMClient.Utilities;
+using Microsoft.Win32;
+
+namespace JMMClient.VideoPlayers
+{
+    public class ZoomPlayerVideoPlayer : BaseVideoPlayer, IVideoPlayer
+    {
+        private bool _monitoringPositions;
+
+        public VideoPlayer Player => VideoPlayer.ZoomPlayer;
+
+        public override void Init()
+        {
+            string installDir = (string)Registry.GetValue(@"HKEY_CURRENT_USER\Software\VirtuaMedia\ZoomPlayer", "InstallDirectory", null);
+            if (installDir != null)
+            {
+                PlayerPath = string.Format("{0}\\zplayer.exe", installDir);
+            }
+
+            if (string.IsNullOrEmpty(PlayerPath) || !File.Exists(PlayerPath))
+            {
+                Active = false;
+                return;
+            }
+
+            Active = true;
+        }
+
+        public override void Play(VideoInfo video)
+        {
+            if (IsPlaying)
+                return;
+            Task.Factory.StartNew(() =>
+            {
+                Process process;
+                if (video.IsPlaylist)
+                    process = Process.Start(PlayerPath, '"' + video.Uri + '"');
+                else
+                {
+                    string init = '"' + video.Uri + '"';
+                    if (video.ResumePosition > 0)
+                    {
+                        // Convert to seconds and timespan format
+                        Debug.WriteLine($"Server resume position in ms: {video.ResumePosition}");
+                        string resumeTimeSpan = TimeSpan.FromSeconds(video.ResumePosition / 1000).ToString(@"hh\:mm\:ss");
+                        Debug.WriteLine($"Resume position in timespan format: {resumeTimeSpan}");
+                        init += " /Seek:" + resumeTimeSpan;
+                        Debug.WriteLine(video.Uri);
+                        Debug.WriteLine(init);
+                    }
+
+                    // Only subtitle track is supported via command line
+                    /*
+                    if (video.SubtitlePaths != null && video.SubtitlePaths.Count > 0)
+                    {
+                        foreach (string s in video.SubtitlePaths)
+                        {
+                            init += " /sub:\"" + s + "\"";
+                        }
+                    }*/
+
+                    process = Process.Start(PlayerPath, init);
+                }
+                if (process != null)
+                {
+                    IsPlaying = true;
+
+                    if (AppSettings.ZoomPlayerTCPControlIntegration)
+                    {
+                        Thread t = new Thread(() => StartPlayPositionRetrieval(video.Uri, true));
+                        t.IsBackground = true;
+                        t.Start();
+                    }
+
+                    process.WaitForExit();
+                    IsPlaying = false;
+                }
+            });
+        }
+
+        internal override void FileChangeEvent(string filePath)
+        {
+            // Not used
+        }
+
+        // Process Zoom player TCP control commands
+        private void StartPlayPositionRetrieval(string fileName, bool firstStart = false)
+        {
+            double postitionTimeCodeMs = 0;
+
+            try
+            {
+                if (firstStart)
+                {
+                    bool startupDelayEnabled = true;
+
+                    // Wait for process to start and skip short playbacks
+                    var startupDelay = TimeSpan.FromSeconds(5);
+                    Thread.Sleep(startupDelay);
+
+                    // Check if still running
+                    if (!IsPlaying)
+                    {
+                        Debug.WriteLine("After waiting 5 seconds ZP was no longer running, stopping playback record.");
+                        return;
+                    }
+                }
+
+                var tc = new ZPConnection("localhost", 4769);
+                var playerInactive = false;
+                char[] charSeparator = {' '};
+                var videoDuration = "";
+
+                // Disable live reporting
+                if (tc.IsConnected)
+                {
+                    tc.Write("1100 0" + Environment.NewLine);
+                }
+                else
+                {
+                    Debug.WriteLine("No connection could be made to zoom player API using port 4769 to store time code!");
+                    return;
+                }
+
+                while (tc.IsConnected && IsPlaying)
+                {
+                    try
+                    {
+                        // Check if playing
+                        tc.Write("1000" + Environment.NewLine);
+
+                        var playing = tc.Read();
+
+                        if (playing.StartsWith("1000 "))
+                        {
+                            if (playing.Contains(" "))
+                            {
+                                var playingSplit = playing.Split(charSeparator);
+                                playing = playingSplit[1].Trim();
+
+                                if (playing != "3")
+                                {
+                                    playerInactive = true;
+                                    //Debug.WriteLine("Zoom player is paused");
+                                }
+                                else
+                                {
+                                    playerInactive = false;
+                                    //Debug.WriteLine("Zoom player is running");
+                                }
+                            }
+                        }
+                        Thread.Sleep(100);
+
+                        if (!playerInactive)
+                        {
+                            tc.Write("1110" + Environment.NewLine);
+                            videoDuration = tc.Read();
+                            if (string.IsNullOrEmpty(videoDuration.Trim()) || videoDuration.ToLower().Contains("seek") ||
+                                videoDuration.ToLower().StartsWith("2200") ||
+                                videoDuration.ToLower().Contains("derived"))
+                            {
+                                continue;
+                            }
+                            Thread.Sleep(100);
+
+                            tc.Write("1120" + Environment.NewLine);
+
+                            var timecode = tc.Read();
+
+                            if (timecode.StartsWith("1120 "))
+                            {
+                                try
+                                {
+                                    if (videoDuration.Contains(" "))
+                                    {
+                                        var videoDurationSplit = videoDuration.Split(charSeparator);
+                                        var timeCodeSplit = timecode.Split(charSeparator);
+                                        videoDuration = videoDurationSplit[1].Trim();
+                                        timecode = timeCodeSplit[1].Trim();
+
+                                        double videoDurationMS = 0;
+                                        var successfullyParsedVideoDuration = double.TryParse(videoDuration,
+                                            out videoDurationMS);
+                                        var successfullyParsedTimeCode = double.TryParse(timecode,
+                                            out postitionTimeCodeMs);
+
+                                        if (successfullyParsedVideoDuration && successfullyParsedTimeCode)
+                                        {
+                                            tc.Write("1800" + Environment.NewLine);
+                                            var videoFilenameRetrieved = tc.Read();
+
+                                            if (videoFilenameRetrieved.StartsWith("1800 "))
+                                            {
+                                                var videoFilenameReadOut =
+                                                    videoFilenameRetrieved.Replace("1800 ", string.Empty).Trim();
+
+                                                if (!string.IsNullOrEmpty(videoFilenameReadOut) &&
+                                                    videoFilenameReadOut.ToLower() != fileName.ToLower())
+                                                {
+                                                    Debug.WriteLine("Video filename didn't match original: " +
+                                                                    videoFilenameReadOut);
+                                                    return;
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                catch (Exception)
+                                {
+                                }
+                            }
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        Thread.Sleep(1000);
+
+                        if (!IsPlaying)
+                        {
+                            Thread.Sleep(250);
+                            Debug.WriteLine("[Position retrieval] Zoom player - no longer running");
+                            UpdateFilePosition(fileName, postitionTimeCodeMs);
+                        }
+                        else
+                        {
+                            Thread.Sleep(250);
+                            Debug.WriteLine("[Position retrieval] Zoom player - error occured");
+                            Debug.WriteLine(e.Message);
+
+                            StartPlayPositionRetrieval(fileName);
+                        }
+                    }
+                }
+                UpdateFilePosition(fileName, postitionTimeCodeMs);
+            }
+            catch (Exception)
+            {
+                Thread.Sleep(1000);
+
+                if (!IsPlaying)
+                {
+                    UpdateFilePosition(fileName, postitionTimeCodeMs);
+                }
+                else
+                {
+                    StartPlayPositionRetrieval(fileName);
+                }
+            }
+        }
+
+        private void UpdateFilePosition(string fileName, double position)
+        {
+            Debug.WriteLine("Zoom player - updating timecode (ms): " + position);
+
+            Dictionary<string, long> filePositions = new Dictionary<string, long>();
+            filePositions.Add(fileName, (long)position);
+            OnPositionChangeEvent(filePositions);
+        }
+
+        internal enum Verbs
+        {
+            WILL = 251,
+            WONT = 252,
+            DO = 253,
+            DONT = 254,
+            IAC = 255
+        }
+
+        internal enum Options
+        {
+            SGA = 3
+        }
+
+        internal class ZPConnection
+        {
+            private readonly TcpClient tcpSocket;
+
+            private int TimeOutMs = 100;
+
+            public ZPConnection(string Hostname, int Port)
+            {
+                try
+                {
+                    tcpSocket = new TcpClient(Hostname, Port);
+                }
+                catch (Exception)
+                {
+                    Debug.WriteLine("No connection could be made to client");
+                }
+            }
+
+            public bool IsConnected
+            {
+                get { return tcpSocket.Connected; }
+            }
+
+            public void WriteLine(string cmd)
+            {
+                Write(cmd + "\n");
+            }
+
+            public void Write(string cmd)
+            {
+                if (!tcpSocket.Connected) return;
+                var buf = Encoding.ASCII.GetBytes(cmd.Replace("\0xFF", "\0xFF\0xFF"));
+                tcpSocket.GetStream().Write(buf, 0, buf.Length);
+            }
+
+            public string Read()
+            {
+                if (!tcpSocket.Connected) return null;
+                var sb = new StringBuilder();
+                do
+                {
+                    ParseCommmand(sb);
+                    Thread.Sleep(TimeOutMs);
+                } while (tcpSocket.Available > 0);
+                return sb.ToString();
+            }
+
+            private void ParseCommmand(StringBuilder sb)
+            {
+                while (tcpSocket.Available > 0)
+                {
+                    var input = tcpSocket.GetStream().ReadByte();
+                    switch (input)
+                    {
+                        case -1:
+                            break;
+                        case (int)Verbs.IAC:
+                            // interpret as command
+                            var inputverb = tcpSocket.GetStream().ReadByte();
+                            if (inputverb == -1) break;
+                            switch (inputverb)
+                            {
+                                case (int)Verbs.IAC:
+                                    //literal IAC = 255 escaped, so append char 255 to string
+                                    sb.Append(inputverb);
+                                    break;
+                                case (int)Verbs.DO:
+                                case (int)Verbs.DONT:
+                                case (int)Verbs.WILL:
+                                case (int)Verbs.WONT:
+                                    // reply to all commands with "WONT", unless it is SGA (suppres go ahead)
+                                    var inputoption = tcpSocket.GetStream().ReadByte();
+                                    if (inputoption == -1) break;
+                                    tcpSocket.GetStream().WriteByte((byte)Verbs.IAC);
+                                    if (inputoption == (int)Options.SGA)
+                                        tcpSocket.GetStream().WriteByte(inputverb == (int)Verbs.DO ? (byte)Verbs.WILL : (byte)Verbs.DO);
+                                    else
+                                        tcpSocket.GetStream().WriteByte(inputverb == (int)Verbs.DO ? (byte)Verbs.WONT : (byte)Verbs.DONT);
+                                    tcpSocket.GetStream().WriteByte((byte)inputoption);
+                                    break;
+                                default:
+                                    break;
+                            }
+                            break;
+                        default:
+                            sb.Append((char)input);
+                            break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/JMMClient/ViewModel/UserSettingsVM.cs
+++ b/JMMClient/ViewModel/UserSettingsVM.cs
@@ -1219,6 +1219,29 @@ namespace JMMClient
             }
         }
 
+        public bool ZoomPlayerTCPControlIntegration
+        {
+            get
+            {
+                return AppSettings.ZoomPlayerTCPControlIntegration;
+            }
+            set
+            {
+                AppSettings.ZoomPlayerTCPControlIntegration = value;
+                OnPropertyChanged(new PropertyChangedEventArgs("ZoomPlayerTCPControlIntegration"));
+            }
+        }
+
+        public string ZoomPlayerTCPControlPort
+        {
+            get { return AppSettings.ZoomPlayerTCPControlPort; }
+            set
+            {
+                AppSettings.ZoomPlayerTCPControlPort = value;
+                OnPropertyChanged(new PropertyChangedEventArgs("ZoomPlayerTCPControlPort"));
+            }
+        }
+
         public int VideoWatchedPct
         {
             get { return AppSettings.VideoWatchedPct; }
@@ -1600,7 +1623,8 @@ namespace JMMClient
         public Visibility IsVLCNotInstalled => MainWindow.videoHandler.IsActive(VideoPlayer.VLC) ? Visibility.Hidden : Visibility.Visible;
         public Visibility IsPotInstalled => MainWindow.videoHandler.IsActive(VideoPlayer.PotPlayer) ? Visibility.Visible : Visibility.Hidden;
         public Visibility IsPotNotInstalled => MainWindow.videoHandler.IsActive(VideoPlayer.PotPlayer) ? Visibility.Hidden : Visibility.Visible;
-       
+        public Visibility IsZoomPlayerInstalled => MainWindow.videoHandler.IsActive(VideoPlayer.ZoomPlayer) ? Visibility.Visible : Visibility.Hidden;
+        public Visibility IsZoomPlayerNotInstalled => MainWindow.videoHandler.IsActive(VideoPlayer.ZoomPlayer) ? Visibility.Hidden : Visibility.Visible;
 
         public void EnableDisableDashboardMetroSection(DashboardMetroProcessType swid, bool enabled)
         {


### PR DESCRIPTION
Couple of side notes:

- Zoom Player only allows seeking for local / network files but not http streams as it detects the stream time code afterwards during testing a couple of files.

- By default there's a 5s delay before it starts position tracking to allow for complete player startup (including its TCP server).

- Video Player setup window looks a bit awkward with the new Zoom Player there (too high) and MPC web UI port will now pop-under another element, also VS2015 will freeze up a lot during XAML editing with up to a minute for minor changes but that have seen that before with XAML editor.

- It will report Zoom Player as installed correctly however when selecting it from the pull down menu it will report not configured while there are no options to configure, no clue why and double checked / compared settings but can't find the cause :(
However it will work fine even with that warning but will need checking.

- Optionally we can always enable the TCP control option if Zoom Player is selected from the menu as it will check in ZoomPlayer player code if the control port is accessible.

- Includes English text resources so we would need some translators for the non-english ones.