### PR TITLE
Fixes #309

### DIFF
--- a/JMMClient/MainWindow.xaml
+++ b/JMMClient/MainWindow.xaml
@@ -358,13 +358,9 @@
                         </Border>
                     </StackPanel>
 
-                    <!--Allows scrolling through filter results. However it breaks the scrolling for series and episodes. -->
-                    <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" Name="ScrollerGroupFilterAdmin" Margin="0" Grid.Column="2" Grid.Row="1">
-                        <ContentControl VerticalAlignment="Stretch"  Name="ccDetail" Width="{Binding ElementName=ScrollerGroupFilterAdmin, Path=ViewportWidth}"
-                                        ContentTemplateSelector="{StaticResource myDataTemplateSelector}" >
-
-                        </ContentControl>
-                    </ScrollViewer>
+                    <ContentControl VerticalAlignment="Stretch"  Name="ccDetail" HorizontalAlignment="Stretch"
+                                    ContentTemplateSelector="{StaticResource myDataTemplateSelector}" Grid.Column="2" Grid.Row="1">
+                    </ContentControl>
 
                     <!--<ContentControl HorizontalAlignment="Stretch" VerticalAlignment="Stretch"  Name="ccDetail" Grid.Column="2" Grid.Row="1"
                                     ContentTemplateSelector="{StaticResource myDataTemplateSelector}" >
@@ -432,14 +428,9 @@
                   Width="2" Background="#FFBCBCBC" Grid.RowSpan="1" />
 
 
-
-                    <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Name="ScrollerPlaylist" Grid.Column="2" Grid.Row="0" Padding="0,0,0,0" >
-                        <ContentControl HorizontalAlignment="Stretch" VerticalAlignment="Stretch"  Name="ccPlaylist" ContentTemplate="{DynamicResource Playlist_DetailTemplate}"
-                                        Width="{Binding Source={x:Static local:MainListHelperVM.Instance},Path=PlaylistScrollerWidth}" >
-
-                        </ContentControl>
-
-                    </ScrollViewer>
+                    <ContentControl HorizontalAlignment="Stretch" VerticalAlignment="Stretch"  Name="ccPlaylist" ContentTemplate="{DynamicResource Playlist_DetailTemplate}"
+                                    Grid.Column="2" Grid.Row="0">
+                    </ContentControl>
 
                     <DockPanel Grid.Row="0" Grid.RowSpan="1">
                         <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Background="#F1F1F1">
@@ -468,9 +459,6 @@
 
                         </ListBox>
                     </DockPanel>
-
-
-
 
                 </Grid>
 

--- a/JMMClient/MainWindow.xaml.cs
+++ b/JMMClient/MainWindow.xaml.cs
@@ -545,22 +545,18 @@ namespace JMMClient
                 if (tempHeight > 0)
                     MainListHelperVM.Instance.FullScrollerHeight = tempHeight;
 
-
-                tempWidth = ScrollerPlaylist.ViewportWidth - 8;
+                tempWidth = ccPlaylist.ActualWidth - 8;
                 if (tempWidth > 0)
-                    MainListHelperVM.Instance.PlaylistScrollerWidth = tempWidth;
+                    MainListHelperVM.Instance.PlaylistWidth = tempWidth;
 
                 tempWidth = tabcDownloads.ActualWidth - 130;
                 if (tempWidth > 0)
                     MainListHelperVM.Instance.DownloadRecScrollerWidth = tempWidth;
-
-
             }
             catch (Exception ex)
             {
-                logger.ErrorException(ex.ToString(), ex);
+                logger.Error(ex, ex.ToString());
             }
-
         }
 
         void tabFileManager_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/JMMClient/Resources/MainListContent.xaml
+++ b/JMMClient/Resources/MainListContent.xaml
@@ -8,13 +8,7 @@
         <DataTemplate.Resources>
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
         </DataTemplate.Resources>
-        <StackPanel Orientation="Vertical">
-            <usercontrols:GroupFilterAdmin Content="{Binding}"/>
-
-        </StackPanel>
-
-        
-
+        <usercontrols:GroupFilterAdmin Content="{Binding}"/>
     </DataTemplate >
 
     <!-- groupDetailTemplate-->

--- a/JMMClient/UserControls/AnimeGroupControl.xaml
+++ b/JMMClient/UserControls/AnimeGroupControl.xaml
@@ -20,318 +20,315 @@
         <CommandBinding Command="{StaticResource ToggleWatchedStatusCommand}" Executed="CommandBinding_ToggleWatchedStatus" />
     </UserControl.CommandBindings>
 
-    <usercontrols:ContentAwareScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" x:Name="ScrollerAnimeGroup" Grid.Column="0" Grid.Row="0" Margin="0,0,0,0">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        
+        <!-- panelGroupReadOnlyToolbar -->
+        <Border Name="panelGroupReadOnlyToolbar" Style="{DynamicResource ToolbarBorderControlStyle}" 
+                Visibility="{Binding Path=IsReadOnly, Converter={StaticResource BooleanToVisibilityConverter}}" Grid.Row="0">
+            <StackPanel Orientation="Horizontal"  VerticalAlignment="Center" Margin="0,0,0,0" Background="#F1F1F1">
 
-        <StackPanel Orientation="Vertical" Width="{Binding Source={x:Static local:MainListHelperVM.Instance},Path=MainScrollerWidth}">
-
-            <!-- panelGroupReadOnlyToolbar -->
-            <Border Name="panelGroupReadOnlyToolbar" Style="{DynamicResource ToolbarBorderControlStyle}" 
-                    Visibility="{Binding Path=IsReadOnly, Converter={StaticResource BooleanToVisibilityConverter}}">
-                <StackPanel Orientation="Horizontal"  VerticalAlignment="Center" Margin="0,0,0,0" Background="#F1F1F1">
-
-                    <!-- Edit Group -->
-                    <Button Name="btnEditGroup" Margin="10,2,2,2" Style="{DynamicResource FlatButtonStyle}" Command="{DynamicResource EditCommand}" CommandParameter="{Binding}">
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
-                            <Image Height="16" Width="16" Source="/Images/32_edit.png" Margin="0,0,3,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Edit}" Margin="0,0,0,0"/>
-                        </StackPanel>
-                    </Button>
-                    <!-- Delete Group -->
-                    <Button Name="btnDeleteGroup" Margin="10,2,2,2" Style="{DynamicResource FlatButtonStyle}" Command="{DynamicResource DeleteGroupCommand}" CommandParameter="{Binding}">
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
-                            <Image Height="16" Width="16" Source="/Images/32_edit_delete.png" Margin="0,0,3,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Delete}" Margin="0,0,0,0"/>
-                        </StackPanel>
-                    </Button>
-                    <!-- add sub group -->
-                    <Button  Name="btnAddSubGroup" Margin="3,2,2,2" Style="{DynamicResource FlatButtonStyle}" Command="{DynamicResource AddSubGroupCommand}" CommandParameter="{Binding}">
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
-                            <Image Height="16" Width="16" Source="/Images/24_folder_group.png" Margin="0,0,3,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=AddSubGroup}" Margin="0,0,0,0"/>
-                        </StackPanel>
-                    </Button>
-                    <!-- select default series -->
-                    <Button  Name="btnSelectDefaultSeries" Margin="3,2,2,2" Style="{DynamicResource FlatButtonStyle}">
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
-                            <Image Height="16" Width="16" Source="/Images/16_heart.png" Margin="0,0,3,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=DefaultSeries_Select}" Margin="0,0,0,0"/>
-                        </StackPanel>
-                    </Button>
-                    <!-- remove default series -->
-                    <Button  Name="btnRemoveDefaultSeries" Margin="3,2,2,2" Style="{DynamicResource FlatButtonStyle}" 
-                             Visibility="{Binding Path=HasDefaultSeries, Converter={StaticResource BooleanToVisibilityConverter}}">
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
-                            <Image Height="16" Width="16" Source="/Images/16_heart_break.png" Margin="0,0,3,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=RemoveDefaultSeries}" Margin="0,0,0,0"/>
-                        </StackPanel>
-                    </Button>
+                <!-- Edit Group -->
+                <Button Name="btnEditGroup" Margin="10,2,2,2" Style="{DynamicResource FlatButtonStyle}" Command="{DynamicResource EditCommand}" CommandParameter="{Binding}">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
+                        <Image Height="16" Width="16" Source="/Images/32_edit.png" Margin="0,0,3,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Edit}" Margin="0,0,0,0"/>
+                    </StackPanel>
+                </Button>
+                <!-- Delete Group -->
+                <Button Name="btnDeleteGroup" Margin="10,2,2,2" Style="{DynamicResource FlatButtonStyle}" Command="{DynamicResource DeleteGroupCommand}" CommandParameter="{Binding}">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
+                        <Image Height="16" Width="16" Source="/Images/32_edit_delete.png" Margin="0,0,3,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Delete}" Margin="0,0,0,0"/>
+                    </StackPanel>
+                </Button>
+                <!-- add sub group -->
+                <Button  Name="btnAddSubGroup" Margin="3,2,2,2" Style="{DynamicResource FlatButtonStyle}" Command="{DynamicResource AddSubGroupCommand}" CommandParameter="{Binding}">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
+                        <Image Height="16" Width="16" Source="/Images/24_folder_group.png" Margin="0,0,3,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=AddSubGroup}" Margin="0,0,0,0"/>
+                    </StackPanel>
+                </Button>
+                <!-- select default series -->
+                <Button  Name="btnSelectDefaultSeries" Margin="3,2,2,2" Style="{DynamicResource FlatButtonStyle}">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
+                        <Image Height="16" Width="16" Source="/Images/16_heart.png" Margin="0,0,3,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=DefaultSeries_Select}" Margin="0,0,0,0"/>
+                    </StackPanel>
+                </Button>
+                <!-- remove default series -->
+                <Button  Name="btnRemoveDefaultSeries" Margin="3,2,2,2" Style="{DynamicResource FlatButtonStyle}" 
+                            Visibility="{Binding Path=HasDefaultSeries, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
+                        <Image Height="16" Width="16" Source="/Images/16_heart_break.png" Margin="0,0,3,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=RemoveDefaultSeries}" Margin="0,0,0,0"/>
+                    </StackPanel>
+                </Button>
                     
-                    <!-- Random Episode -->
-                    <Button Name="btnRandomEpisode" Margin="10,2,2,2" Style="{DynamicResource FlatButtonStyle}" >
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
-                            <Image Height="16" Width="16" Source="/Images/32_dice.png" Margin="0,0,3,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=AnimeGroup_Random}" Margin="0,0,0,0"/>
-                        </StackPanel>
-                    </Button>
-
-                </StackPanel>
-            </Border>
-
-            <!-- panelGroupReadOnly -->
-            <StackPanel Orientation="Horizontal" Name="panelGroupReadOnly" VerticalAlignment="Center" Margin="10,10,0,10" 
-                        Visibility="{Binding Path=IsReadOnly, Converter={StaticResource BooleanToVisibilityConverter}}">
-                <Button Name="btnToggleFave2" Margin="1,1,1,1" Style="{DynamicResource FlatButtonStyle}" Command="{DynamicResource ToggleFaveCommand}" CommandParameter="{Binding}"
-                        Visibility="{Binding Path=BIsFave, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <Canvas Width="20" Height="20">
-                        <Image Source="/Images/16_star.png" Height="20" Width="20" Canvas.Left="0" Canvas.Top="0"/>
-                    </Canvas>
+                <!-- Random Episode -->
+                <Button Name="btnRandomEpisode" Margin="10,2,2,2" Style="{DynamicResource FlatButtonStyle}" >
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
+                        <Image Height="16" Width="16" Source="/Images/32_dice.png" Margin="0,0,3,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=AnimeGroup_Random}" Margin="0,0,0,0"/>
+                    </StackPanel>
                 </Button>
-                <Button Name="btnToggleFave2Not" Margin="1,1,1,1" Style="{DynamicResource FlatButtonStyle}" Command="{DynamicResource ToggleFaveCommand}" CommandParameter="{Binding}"
-                        Visibility="{Binding Path=BIsNotFave, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <Canvas Width="20" Height="20">
-                        <Image Source="/Images/16_blankstar.png" Margin="0,0,3,0" Height="20" Width="20" Canvas.Left="0" Canvas.Top="0"/>
-                    </Canvas>
-                </Button>
-                <TextBlock Margin="6,3,0,0" Text="{Binding GroupName}" FontSize="18" FontWeight="Bold" Name="labelGroupName" />
-                <TextBlock Margin="10,3,0,0" Text="{Binding GroupType}" FontSize="18" Foreground="LightGray" />
-                <TextBlock Margin="10,3,0,0" VerticalAlignment="Center" Text="{Binding Path=AnimeGroupID}" FontSize="10" />
-
 
             </StackPanel>
+        </Border>
 
-            <!-- panelGroupEditingToolbar -->
-            <Border Name="panelGroupEditingToolbar" Style="{DynamicResource ToolbarBorderControlStyle}" 
-                    Visibility="{Binding Path=IsBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}">
-                <StackPanel Orientation="Horizontal"  Margin="0,0,0,0"  Background="FloralWhite">
-
-                    <!-- Save Group -->
-                    <Button Name="btnSaveGroup" Margin="10,2,2,2" Style="{DynamicResource FlatButtonStyle}" Command="{DynamicResource SaveCommand}" CommandParameter="{Binding}">
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
-                            <Image Height="16" Width="16" Source="/Images/16_save.png" Margin="0,0,3,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Save}" Margin="0,0,0,0"/>
-                        </StackPanel>
-                    </Button>
-                    <!-- Cancel -->
-                    <Button Name="btnCancel" Margin="10,2,2,2" Style="{DynamicResource FlatButtonStyle}" Command="{DynamicResource CancelCommand}" CommandParameter="{Binding}">
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
-                            <Image Height="16" Width="16" Source="/Images/16_cancel.png" Margin="0,0,3,0"/>
-                            <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Cancel}" Margin="0,0,0,0"/>
-                        </StackPanel>
-                    </Button>
-                </StackPanel>
-            </Border>
-
-            <!-- panelGroupEditing -->
-            <StackPanel Orientation="Horizontal" Name="panelGroupEditing" Margin="10,10,0,10"
+        <!-- panelGroupEditingToolbar -->
+        <Border Name="panelGroupEditingToolbar" Style="{DynamicResource ToolbarBorderControlStyle}" 
                         Visibility="{Binding Path=IsBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}">
-                <Button Name="btnToggleFave" Margin="1,1,1,1" Style="{DynamicResource FlatButtonStyle}" Command="{DynamicResource ToggleFaveCommand}" CommandParameter="{Binding}"
-                        Visibility="{Binding Path=BIsFave, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <Canvas Width="20" Height="20">
-                        <Image Source="/Images/16_star.png" Height="20" Width="20" Canvas.Left="0" Canvas.Top="0"/>
-                    </Canvas>
+            <StackPanel Orientation="Horizontal"  Margin="0,0,0,0"  Background="FloralWhite">
+
+                <!-- Save Group -->
+                <Button Name="btnSaveGroup" Margin="10,2,2,2" Style="{DynamicResource FlatButtonStyle}" Command="{DynamicResource SaveCommand}" CommandParameter="{Binding}">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
+                        <Image Height="16" Width="16" Source="/Images/16_save.png" Margin="0,0,3,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Save}" Margin="0,0,0,0"/>
+                    </StackPanel>
                 </Button>
-
-                <Button Name="btnToggleFaveNot" Margin="1,1,1,1" Style="{DynamicResource FlatButtonStyle}" Command="{DynamicResource ToggleFaveCommand}" CommandParameter="{Binding}"
-                        Visibility="{Binding Path=BIsNotFave, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <Canvas Width="20" Height="20">
-                        <Image Source="/Images/16_blankstar.png" Height="20" Width="20" Canvas.Left="0" Canvas.Top="0"/>
-                    </Canvas>
+                <!-- Cancel -->
+                <Button Name="btnCancel" Margin="10,2,2,2" Style="{DynamicResource FlatButtonStyle}" Command="{DynamicResource CancelCommand}" CommandParameter="{Binding}">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
+                        <Image Height="16" Width="16" Source="/Images/16_cancel.png" Margin="0,0,3,0"/>
+                        <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Cancel}" Margin="0,0,0,0"/>
+                    </StackPanel>
                 </Button>
-
-                <TextBox Margin="6,0,0,0" Text="{Binding GroupName}" FontSize="16" Padding="5" MinWidth="200" FontWeight="Bold" Name="txtGroupName" />
-                <TextBlock Margin="10,0,0,0" Text="{Binding GroupType}" FontSize="18" Padding="5" Foreground="LightGray" />
-
-
             </StackPanel>
+        </Border>
 
+        <usercontrols:ContentAwareScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" x:Name="ScrollerAnimeGroup"
+                                               Grid.Row="1" Margin="0,0,0,0">
+            <StackPanel Orientation="Vertical">
+                <!-- panelGroupReadOnly -->
+                <StackPanel Orientation="Horizontal" Name="panelGroupReadOnly" VerticalAlignment="Center" Margin="10,10,0,10" 
+                            Visibility="{Binding Path=IsReadOnly, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <Button Name="btnToggleFave2" Margin="1,1,1,1" Style="{DynamicResource FlatButtonStyle}" Command="{DynamicResource ToggleFaveCommand}" CommandParameter="{Binding}"
+                            Visibility="{Binding Path=BIsFave, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <Canvas Width="20" Height="20">
+                            <Image Source="/Images/16_star.png" Height="20" Width="20" Canvas.Left="0" Canvas.Top="0"/>
+                        </Canvas>
+                    </Button>
+                    <Button Name="btnToggleFave2Not" Margin="1,1,1,1" Style="{DynamicResource FlatButtonStyle}" Command="{DynamicResource ToggleFaveCommand}" CommandParameter="{Binding}"
+                            Visibility="{Binding Path=BIsNotFave, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <Canvas Width="20" Height="20">
+                            <Image Source="/Images/16_blankstar.png" Margin="0,0,3,0" Height="20" Width="20" Canvas.Left="0" Canvas.Top="0"/>
+                        </Canvas>
+                    </Button>
+                    <TextBlock Margin="6,3,0,0" Text="{Binding GroupName}" FontSize="18" FontWeight="Bold" Name="labelGroupName" />
+                    <TextBlock Margin="10,3,0,0" Text="{Binding GroupType}" FontSize="18" Foreground="LightGray" />
+                    <TextBlock Margin="10,3,0,0" VerticalAlignment="Center" Text="{Binding Path=AnimeGroupID}" FontSize="10" />
+                </StackPanel>
 
-
-
-            <Grid Margin="10,0,0,10">
-                <Grid.RowDefinitions>
-                    <RowDefinition MaxHeight="30" Height="Auto"/>
-                    <RowDefinition MaxHeight="30" Height="Auto"/>
-                    <RowDefinition MaxHeight="30" Height="Auto"/>
-                    <RowDefinition MaxHeight="30" Height="Auto"/>
-                    <RowDefinition MaxHeight="30" Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-
-                <!-- Poster/Fanart Image -->
-
-                <Rectangle Margin="0,0,10,0" Grid.Row="0" Grid.Column="0" Grid.RowSpan="6" HorizontalAlignment="Center" VerticalAlignment="Top"
-                                    Visibility="{Binding Path=UseFanartOnSeries, Converter={StaticResource BooleanToVisibilityConverter}}"
-                           RadiusX="5" RadiusY="5" Width="{Binding Source={x:Static local:UserSettingsVM.Instance},Path=SeriesGroup_Image_Width}" 
-                                   Height="{Binding Source={x:Static local:UserSettingsVM.Instance},Path=SeriesGroup_Image_Height}">
-                    <Rectangle.Effect>
-                        <DropShadowEffect Opacity="0.5"/>
-                    </Rectangle.Effect>
-                    <Rectangle.Fill>
-                        <ImageBrush ImageSource="{Binding Path=FanartPathThenPosterPath}"/>
-                    </Rectangle.Fill>
-                </Rectangle>
-
-                <Image Height="{Binding Source={x:Static local:UserSettingsVM.Instance},Path=SeriesGroup_Image_Height}" 
-                       Source="{Binding Path=FanartPathThenPosterPath}" x:Name="myImage"
-                               Margin="4,0,10,0" Grid.Row="0" Grid.Column="0" Grid.RowSpan="6" HorizontalAlignment="Center" VerticalAlignment="Top"
-                               Visibility="{Binding Path=UsePosterOnSeries, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <Image.ToolTip>
-                        <Image Stretch="Fill" HorizontalAlignment="Center" Height="400" Source="{Binding FanartPathThenPosterPath}">
-                        </Image>
-                    </Image.ToolTip>
-                    <Image.Effect>
-                        <DropShadowEffect Opacity="0.5"/>
-                    </Image.Effect>
-                </Image>
-
-                <!-- Image size Buttons -->
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Top" Grid.Row="0" Grid.Column="0" Margin="10,10,0,0"
-                                    Visibility="{Binding Path=IsBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}">
-
-                    <Button Margin="0,0,0,0" Style="{DynamicResource FlatButtonStyle}" Command="{DynamicResource IncrementSeriesImageSizeCommand}">
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
-                            <Image Height="16" Width="16" Source="/Images/16_add.png" Margin="0,0,0,0"/>
-                        </StackPanel>
+                <!-- panelGroupEditing -->
+                <StackPanel Orientation="Horizontal" Name="panelGroupEditing" Margin="10,10,0,10"
+                            Visibility="{Binding Path=IsBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <Button Name="btnToggleFave" Margin="1,1,1,1" Style="{DynamicResource FlatButtonStyle}" Command="{DynamicResource ToggleFaveCommand}" CommandParameter="{Binding}"
+                            Visibility="{Binding Path=BIsFave, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <Canvas Width="20" Height="20">
+                            <Image Source="/Images/16_star.png" Height="20" Width="20" Canvas.Left="0" Canvas.Top="0"/>
+                        </Canvas>
                     </Button>
 
-                    <Button Margin="0,0,0,0" Style="{DynamicResource FlatButtonStyle}"  Command="{DynamicResource DecrementSeriesImageSizeCommand}">
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
-                            <Image Height="16" Width="16" Source="/Images/16_minus.png" Margin="0,0,0,0"/>
-                        </StackPanel>
+                    <Button Name="btnToggleFaveNot" Margin="1,1,1,1" Style="{DynamicResource FlatButtonStyle}" Command="{DynamicResource ToggleFaveCommand}" CommandParameter="{Binding}"
+                            Visibility="{Binding Path=BIsNotFave, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <Canvas Width="20" Height="20">
+                            <Image Source="/Images/16_blankstar.png" Height="20" Width="20" Canvas.Left="0" Canvas.Top="0"/>
+                        </Canvas>
                     </Button>
+
+                    <TextBox Margin="6,0,0,0" Text="{Binding GroupName}" FontSize="16" Padding="5" MinWidth="200" FontWeight="Bold" Name="txtGroupName" />
+                    <TextBlock Margin="10,0,0,0" Text="{Binding GroupType}" FontSize="18" Padding="5" Foreground="LightGray" />
                 </StackPanel>
 
-                <!-- Sort Name -->
-                <StackPanel Orientation="Horizontal" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,5">
-                    <TextBlock FontWeight="Bold" Margin="0,0,5,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SortName}"/>
-                    <TextBlock Text="{Binding Path=SortName}" Name="tbGroupSortName"
-                               Visibility="{Binding Path=IsReadOnly, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                    <TextBox  MinWidth="200" Text="{Binding Path=SortName}" Name="txtGroupSortName"
-                             Visibility="{Binding Path=IsBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                </StackPanel>
+                <Grid Margin="10,0,0,10">
+                    <Grid.RowDefinitions>
+                        <RowDefinition MaxHeight="30" Height="Auto"/>
+                        <RowDefinition MaxHeight="30" Height="Auto"/>
+                        <RowDefinition MaxHeight="30" Height="Auto"/>
+                        <RowDefinition MaxHeight="30" Height="Auto"/>
+                        <RowDefinition MaxHeight="30" Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
 
-                <!-- Rating -->
-                <StackPanel Orientation="Horizontal" Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,5">
-                    <usercontrols:VisualRating Rating="{Binding Path=AniDBRating}" VerticalAlignment="Center">
-                    </usercontrols:VisualRating>
-                    <TextBlock Text="{Binding Path=AniDBRatingFormatted}" Margin="5,0,0,0" VerticalAlignment="Center">
-                            <TextBlock.ToolTip>
-                                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=AniDBRating}"></TextBlock>
-                            </TextBlock.ToolTip>
-                        </TextBlock>
-                </StackPanel>
+                    <!-- Poster/Fanart Image -->
 
-                <!-- Episode Counts -->
-                <StackPanel Orientation="Horizontal" Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,5">
-                    <Image Name="imgAnimeType" Height="16" Width="16" Margin="0,0,5,0" Source="../Images/32_television.png" VerticalAlignment="Center">
+                    <Rectangle Margin="0,0,10,0" Grid.Row="0" Grid.Column="0" Grid.RowSpan="6" HorizontalAlignment="Center" VerticalAlignment="Top"
+                                        Visibility="{Binding Path=UseFanartOnSeries, Converter={StaticResource BooleanToVisibilityConverter}}"
+                               RadiusX="5" RadiusY="5" Width="{Binding Source={x:Static local:UserSettingsVM.Instance},Path=SeriesGroup_Image_Width}" 
+                                       Height="{Binding Source={x:Static local:UserSettingsVM.Instance},Path=SeriesGroup_Image_Height}">
+                        <Rectangle.Effect>
+                            <DropShadowEffect Opacity="0.5"/>
+                        </Rectangle.Effect>
+                        <Rectangle.Fill>
+                            <ImageBrush ImageSource="{Binding Path=FanartPathThenPosterPath}"/>
+                        </Rectangle.Fill>
+                    </Rectangle>
+
+                    <Image Height="{Binding Source={x:Static local:UserSettingsVM.Instance},Path=SeriesGroup_Image_Height}" 
+                           Source="{Binding Path=FanartPathThenPosterPath}" x:Name="myImage"
+                                   Margin="4,0,10,0" Grid.Row="0" Grid.Column="0" Grid.RowSpan="6" HorizontalAlignment="Center" VerticalAlignment="Top"
+                                   Visibility="{Binding Path=UsePosterOnSeries, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <Image.ToolTip>
+                            <Image Stretch="Fill" HorizontalAlignment="Center" Height="400" Source="{Binding FanartPathThenPosterPath}">
+                            </Image>
+                        </Image.ToolTip>
+                        <Image.Effect>
+                            <DropShadowEffect Opacity="0.5"/>
+                        </Image.Effect>
                     </Image>
 
-                    <TextBlock Grid.Row="1" Grid.Column="2" Padding="5" Text="{Binding Path=EpisodeCountFormatted}" VerticalAlignment="Center"/>
-                </StackPanel>
+                    <!-- Image size Buttons -->
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Top" Grid.Row="0" Grid.Column="0" Margin="10,10,0,0"
+                                        Visibility="{Binding Path=IsBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}">
 
-                <!-- Unwatched Episode Counts , has unwatched files  -->
-                <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,5"
-                            Visibility="{Binding Path=HasUnwatchedFiles, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <Image Height="16" Width="16" Source="../Images/32_eye2.png" Margin="0,0,0,0" VerticalAlignment="Center"/>
-                    <TextBlock Margin="5,0,0,0" Text="{Binding Path=UnwatchedEpisodeCount}"  VerticalAlignment="Center"/>
-                    <TextBlock Margin="5,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Unwatched}" VerticalAlignment="Center" />
-                    <StackPanel Orientation="Horizontal" Margin="15,0,0,0" Visibility="{Binding Path=AnyFilesWatched, Converter={StaticResource BooleanToVisibilityConverter}}">
-                        <Image Height="16" Width="16" Source="/Images/24_calendar.png" Margin="0,0,5,0" VerticalAlignment="Center"/>
-                        <TextBlock Margin="0,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=LastWatched}" VerticalAlignment="Center" />
-                        <TextBlock Margin="5,0,0,0" Text="{Binding Path=LastWatchedDescription}" FontWeight="Bold" VerticalAlignment="Center"/>
+                        <Button Margin="0,0,0,0" Style="{DynamicResource FlatButtonStyle}" Command="{DynamicResource IncrementSeriesImageSizeCommand}">
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
+                                <Image Height="16" Width="16" Source="/Images/16_add.png" Margin="0,0,0,0"/>
+                            </StackPanel>
+                        </Button>
+
+                        <Button Margin="0,0,0,0" Style="{DynamicResource FlatButtonStyle}"  Command="{DynamicResource DecrementSeriesImageSizeCommand}">
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
+                                <Image Height="16" Width="16" Source="/Images/16_minus.png" Margin="0,0,0,0"/>
+                            </StackPanel>
+                        </Button>
                     </StackPanel>
-                </StackPanel>
 
-                <!-- Unwatched Episode Counts , all files watched  -->
-                <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,5"
-                            Visibility="{Binding Path=AllFilesWatched, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <Image Height="16" Width="16" Source="/Images/16_tick.png" Margin="0,0,0,0" VerticalAlignment="Center"/>
-                    <TextBlock Margin="5,0,0,0" Text="{Binding Path=UnwatchedEpisodeCount}"  VerticalAlignment="Center"/>
-                    <TextBlock Margin="5,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Unwatched}" VerticalAlignment="Center" />
-                    <StackPanel Orientation="Horizontal" Margin="15,0,0,0" Visibility="{Binding Path=AnyFilesWatched, Converter={StaticResource BooleanToVisibilityConverter}}">
-                        <Image Height="16" Width="16" Source="/Images/24_calendar.png" Margin="0,0,5,0" VerticalAlignment="Center"/>
-                        <TextBlock Margin="5,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=LastWatched}" VerticalAlignment="Center" />
-                        <TextBlock Margin="5,0,0,0" Text="{Binding Path=LastWatchedDescription}" FontWeight="Bold" VerticalAlignment="Center"/>
+                    <!-- Sort Name -->
+                    <StackPanel Orientation="Horizontal" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,5">
+                        <TextBlock FontWeight="Bold" Margin="0,0,5,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=SortName}"/>
+                        <TextBlock Text="{Binding Path=SortName}" Name="tbGroupSortName"
+                                   Visibility="{Binding Path=IsReadOnly, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                        <TextBox  MinWidth="200" Text="{Binding Path=SortName}" Name="txtGroupSortName"
+                                 Visibility="{Binding Path=IsBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                     </StackPanel>
-                </StackPanel>
 
-                <!-- Missing Episodes  -->
-                <StackPanel Orientation="Horizontal" Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,5"
-                                Visibility="{Binding Path=HasMissingEpisodesAny, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <StackPanel Orientation="Horizontal" Margin="0,0,10,0"
-                                    Visibility="{Binding Path=HasMissingEpisodesGroups, Converter={StaticResource BooleanToVisibilityConverter}}">
-                        <Image Height="16" Width="16" Source="/Images/16_exclamation.png" Margin="0,0,0,0" VerticalAlignment="Center">
-                            <Image.ToolTip>
-                                <TextBlock Margin="5,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_MissingEpsGroups}" VerticalAlignment="Center" />
-                            </Image.ToolTip>
+                    <!-- Rating -->
+                    <StackPanel Orientation="Horizontal" Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,5">
+                        <usercontrols:VisualRating Rating="{Binding Path=AniDBRating}" VerticalAlignment="Center">
+                        </usercontrols:VisualRating>
+                        <TextBlock Text="{Binding Path=AniDBRatingFormatted}" Margin="5,0,0,0" VerticalAlignment="Center">
+                                <TextBlock.ToolTip>
+                                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=AniDBRating}"></TextBlock>
+                                </TextBlock.ToolTip>
+                            </TextBlock>
+                    </StackPanel>
+
+                    <!-- Episode Counts -->
+                    <StackPanel Orientation="Horizontal" Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,5">
+                        <Image Name="imgAnimeType" Height="16" Width="16" Margin="0,0,5,0" Source="../Images/32_television.png" VerticalAlignment="Center">
                         </Image>
-                        <TextBlock Margin="5,0,0,0" Text="{Binding Path=MissingEpisodeCountGroups}"  VerticalAlignment="Center"/>
-                        <TextBlock Margin="5,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Missing}" VerticalAlignment="Center" />
-                    </StackPanel>
-                    <StackPanel Orientation="Horizontal" Margin="0,0,10,0"
-                                    Visibility="{Binding Path=HasMissingEpisodesAllDifferentToGroups, Converter={StaticResource BooleanToVisibilityConverter}}">
-                        <Image Height="16" Width="16" Source="/Images/16_warning.png" Margin="0,0,0,0" VerticalAlignment="Center">
-                            <Image.ToolTip>
-                                <TextBlock Margin="5,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_MissingEps}" VerticalAlignment="Center" />
-                            </Image.ToolTip>
-                        </Image>
-                        <TextBlock Margin="5,0,0,0" Text="{Binding Path=MissingEpisodeCount}"  VerticalAlignment="Center"/>
-                        <TextBlock Margin="5,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Missing}" VerticalAlignment="Center" />
+
+                        <TextBlock Grid.Row="1" Grid.Column="2" Padding="5" Text="{Binding Path=EpisodeCountFormatted}" VerticalAlignment="Center"/>
                     </StackPanel>
 
-                </StackPanel>
-
-                <!-- Play Next Episode Header -->
-                <Border Style="{DynamicResource ToolbarBorderControlStyle}" Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="3" Padding="6" Margin="-10,10,0,0" Background="#F1F1F1">
-                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=PlayNextEpisode}" FontSize="16" Foreground="DarkGray"/>
-                </Border>
-
-                <!-- Play Next Episode -->
-                <usercontrols:PlayNextEpisodeControl x:Name="ucNextEpisode" Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="7" Margin="0,10,0,0"/>
-
-                <!-- All Series Header -->
-                <Border Style="{DynamicResource ToolbarBorderControlStyle}" Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="3" Padding="6" Background="#F1F1F1" Margin="-10,10,0,0">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=AnimeGroup_AllSeries}" FontSize="16" Foreground="DarkGray" VerticalAlignment="Bottom"/>
-                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=AnimeGroup_DoubleClick}" FontSize="10" Foreground="DarkGray" Margin="20,0,0,0" VerticalAlignment="Bottom"/>
+                    <!-- Unwatched Episode Counts , has unwatched files  -->
+                    <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,5"
+                                Visibility="{Binding Path=HasUnwatchedFiles, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <Image Height="16" Width="16" Source="../Images/32_eye2.png" Margin="0,0,0,0" VerticalAlignment="Center"/>
+                        <TextBlock Margin="5,0,0,0" Text="{Binding Path=UnwatchedEpisodeCount}"  VerticalAlignment="Center"/>
+                        <TextBlock Margin="5,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Unwatched}" VerticalAlignment="Center" />
+                        <StackPanel Orientation="Horizontal" Margin="15,0,0,0" Visibility="{Binding Path=AnyFilesWatched, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <Image Height="16" Width="16" Source="/Images/24_calendar.png" Margin="0,0,5,0" VerticalAlignment="Center"/>
+                            <TextBlock Margin="0,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=LastWatched}" VerticalAlignment="Center" />
+                            <TextBlock Margin="5,0,0,0" Text="{Binding Path=LastWatchedDescription}" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
                     </StackPanel>
-                </Border>
 
-                <ListBox Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="3" BorderThickness="0" HorizontalAlignment="Stretch" ScrollViewer.HorizontalScrollBarVisibility="Disabled" Margin="10,10,0,5"
-                 VirtualizingStackPanel.IsVirtualizing="True" ScrollViewer.CanContentScroll="True" Name="lbSeriesList"
-                 ItemsSource="{Binding Path=AllAnimeSeriesFiltered}" 
-                 Background="Transparent"  VerticalAlignment="Stretch" >
-                    <ListBox.Template>
-                        <ControlTemplate>
-                            <ItemsPresenter />
-                        </ControlTemplate>
-                    </ListBox.Template>
-                    <ListBox.ItemTemplate>
-                        <DataTemplate>
-                            <usercontrols:SeriesPosterView/>
-                        </DataTemplate>
-                    </ListBox.ItemTemplate>
-                    <ListBox.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <WrapPanel/>
-                        </ItemsPanelTemplate>
-                    </ListBox.ItemsPanel>
-                </ListBox>
-            </Grid>
+                    <!-- Unwatched Episode Counts , all files watched  -->
+                    <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,5"
+                                Visibility="{Binding Path=AllFilesWatched, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <Image Height="16" Width="16" Source="/Images/16_tick.png" Margin="0,0,0,0" VerticalAlignment="Center"/>
+                        <TextBlock Margin="5,0,0,0" Text="{Binding Path=UnwatchedEpisodeCount}"  VerticalAlignment="Center"/>
+                        <TextBlock Margin="5,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Unwatched}" VerticalAlignment="Center" />
+                        <StackPanel Orientation="Horizontal" Margin="15,0,0,0" Visibility="{Binding Path=AnyFilesWatched, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <Image Height="16" Width="16" Source="/Images/24_calendar.png" Margin="0,0,5,0" VerticalAlignment="Center"/>
+                            <TextBlock Margin="5,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=LastWatched}" VerticalAlignment="Center" />
+                            <TextBlock Margin="5,0,0,0" Text="{Binding Path=LastWatchedDescription}" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </StackPanel>
 
-            
+                    <!-- Missing Episodes  -->
+                    <StackPanel Orientation="Horizontal" Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,5"
+                                    Visibility="{Binding Path=HasMissingEpisodesAny, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,10,0"
+                                        Visibility="{Binding Path=HasMissingEpisodesGroups, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <Image Height="16" Width="16" Source="/Images/16_exclamation.png" Margin="0,0,0,0" VerticalAlignment="Center">
+                                <Image.ToolTip>
+                                    <TextBlock Margin="5,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_MissingEpsGroups}" VerticalAlignment="Center" />
+                                </Image.ToolTip>
+                            </Image>
+                            <TextBlock Margin="5,0,0,0" Text="{Binding Path=MissingEpisodeCountGroups}"  VerticalAlignment="Center"/>
+                            <TextBlock Margin="5,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Missing}" VerticalAlignment="Center" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,10,0"
+                                        Visibility="{Binding Path=HasMissingEpisodesAllDifferentToGroups, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <Image Height="16" Width="16" Source="/Images/16_warning.png" Margin="0,0,0,0" VerticalAlignment="Center">
+                                <Image.ToolTip>
+                                    <TextBlock Margin="5,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Tooltip_MissingEps}" VerticalAlignment="Center" />
+                                </Image.ToolTip>
+                            </Image>
+                            <TextBlock Margin="5,0,0,0" Text="{Binding Path=MissingEpisodeCount}"  VerticalAlignment="Center"/>
+                            <TextBlock Margin="5,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Missing}" VerticalAlignment="Center" />
+                        </StackPanel>
 
-        </StackPanel>
+                    </StackPanel>
 
+                    <!-- Play Next Episode Header -->
+                    <Border Style="{DynamicResource ToolbarBorderControlStyle}" Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="3" Padding="6" Margin="-10,10,0,0" Background="#F1F1F1">
+                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=PlayNextEpisode}" FontSize="16" Foreground="DarkGray"/>
+                    </Border>
 
-    </usercontrols:ContentAwareScrollViewer>
+                    <!-- Play Next Episode -->
+                    <usercontrols:PlayNextEpisodeControl x:Name="ucNextEpisode" Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="7" Margin="0,10,0,0"/>
+
+                    <!-- All Series Header -->
+                    <Border Style="{DynamicResource ToolbarBorderControlStyle}" Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="3" Padding="6" Background="#F1F1F1" Margin="-10,10,0,0">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=AnimeGroup_AllSeries}" FontSize="16" Foreground="DarkGray" VerticalAlignment="Bottom"/>
+                            <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=AnimeGroup_DoubleClick}" FontSize="10" Foreground="DarkGray" Margin="20,0,0,0" VerticalAlignment="Bottom"/>
+                        </StackPanel>
+                    </Border>
+
+                    <ListBox Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="3" BorderThickness="0" HorizontalAlignment="Stretch" ScrollViewer.HorizontalScrollBarVisibility="Disabled" Margin="10,10,0,5"
+                     VirtualizingStackPanel.IsVirtualizing="True" ScrollViewer.CanContentScroll="True" Name="lbSeriesList"
+                     ItemsSource="{Binding Path=AllAnimeSeriesFiltered}" 
+                     Background="Transparent"  VerticalAlignment="Stretch" >
+                        <ListBox.Template>
+                            <ControlTemplate>
+                                <ItemsPresenter />
+                            </ControlTemplate>
+                        </ListBox.Template>
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <usercontrols:SeriesPosterView/>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                        <ListBox.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapPanel/>
+                            </ItemsPanelTemplate>
+                        </ListBox.ItemsPanel>
+                    </ListBox>
+                </Grid>
+            </StackPanel>
+        </usercontrols:ContentAwareScrollViewer>
+    </Grid>
 </UserControl>

--- a/JMMClient/UserControls/GroupFilterAdmin.xaml
+++ b/JMMClient/UserControls/GroupFilterAdmin.xaml
@@ -7,11 +7,8 @@
              xmlns:usercontrols="clr-namespace:JMMClient.UserControls"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="600">
-
-    <StackPanel Orientation="Vertical">
-
-        <StackPanel.Resources>
-
+    <Grid>
+        <Grid.Resources>
             <ResourceDictionary>
                 <ResourceDictionary.MergedDictionaries>
                     <ResourceDictionary Source="/Resources/Styles.xaml" />
@@ -90,26 +87,15 @@
                 </DataTemplate>
 
             </ResourceDictionary>
-
-
-        </StackPanel.Resources>
-
-        <Grid Margin="0,0,0,0" Name="grdSeriesSerach">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
-
-
-        </Grid>
+        </Grid.Resources>
+        
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
 
         <!-- Toolbar when in read only mode -->
         <Border Grid.Column="0" Grid.Row="0" Name="panelGroupReadOnlyToolbar" Style="{DynamicResource ToolbarBorderControlStyle}"
@@ -153,26 +139,8 @@
             </StackPanel>
         </Border>
 
-        <!-- Filter name when not editing -->
-        <StackPanel Grid.Column="0" Grid.Row="1"  Orientation="Vertical" Name="panelGroupFilterReadOnly" VerticalAlignment="Center" Margin="10,10,0,10" 
-                    Visibility="{Binding Path=IsNotBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}">
-            <TextBlock Margin="0,0,0,5" Text="{Binding FilterName}" FontSize="18" FontWeight="Bold" Name="labelGroupFilterName" />
-
-            <StackPanel Orientation="Horizontal" Margin="0,0,5,5">
-                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=GroupFilter_BaseCondition}" VerticalAlignment="Center" Margin="0,0,5,0"
-                           ToolTip="{usercontrols:Info Title=GroupFilter_BaseCondition, 
-                                                Body=Tooltip_GroupFilter_BaseCondition}"></TextBlock>
-                <ComboBox Grid.Row="0" Name="cboBaseCondition" VerticalAlignment="Center" IsEnabled="False"></ComboBox>
-            </StackPanel>
-
-            <StackPanel Orientation="Horizontal" Margin="0,0,5,5">
-                <CheckBox Name="chkApplyToSeries" IsChecked="{Binding Path=IsApplyToSeries}" VerticalAlignment="Center" IsEnabled="False" />
-                <TextBlock Margin="10,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=GroupFilter_ApplyToSeries}" Name="lblApplyToSeries" />
-            </StackPanel>
-        </StackPanel>
-
         <!-- Toolbar when in editing mode -->
-        <Border Grid.Column="0" Grid.Row="2"  Name="panelEditingToolbar" Style="{DynamicResource ToolbarBorderControlStyle}" 
+        <Border Grid.Column="0" Grid.Row="0" Name="panelEditingToolbar" Style="{DynamicResource ToolbarBorderControlStyle}" 
                     Visibility="{Binding Path=IsBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}">
             <StackPanel Orientation="Horizontal"  VerticalAlignment="Center" Margin="0,0,0,0" Background="#F1F1F1">
 
@@ -194,112 +162,123 @@
             </StackPanel>
         </Border>
 
-        <!-- Filter name when in editing mode -->
-        <StackPanel Grid.Column="0" Grid.Row="3"  Orientation="Vertical" Name="panelGroupFilterEditing" Margin="10,10,0,0"
-                    Visibility="{Binding Path=IsBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}">
+        <!-- Group Filter Conditions and Sorting  -->
+        <ScrollViewer Grid.Column="0" Grid.Row="1" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" Margin="0">
+            <StackPanel Orientation="Vertical">
+                <!-- Filter name when not editing -->
+                <StackPanel Orientation="Vertical" Name="panelGroupFilterReadOnly" VerticalAlignment="Center" Margin="10,10,0,10" 
+                    Visibility="{Binding Path=IsNotBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <TextBlock Margin="0,0,0,5" Text="{Binding FilterName}" FontSize="18" FontWeight="Bold" Name="labelGroupFilterName" />
 
-            <TextBlock Margin="0,0,0,5" Text="{Binding FilterName}" FontSize="18" FontWeight="Bold"
-                      Visibility="{Binding Path=IsSystemGroupFilter, Converter={StaticResource BooleanToVisibilityConverter}}" />
-            <TextBox Margin="0,0,10,5" Text="{Binding FilterName}" FontSize="16" Padding="5" MinWidth="200" FontWeight="Bold" Name="txtFilterName"
-                     Visibility="{Binding Path=IsNotSystemGroupFilter, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-
-            <StackPanel Orientation="Horizontal" Margin="0,0,5,5">
-                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=GroupFilter_BaseCondition}" VerticalAlignment="Center" Margin="0,0,5,0"
+                    <StackPanel Orientation="Horizontal" Margin="0,0,5,5">
+                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=GroupFilter_BaseCondition}" VerticalAlignment="Center" Margin="0,0,5,0"
                            ToolTip="{usercontrols:Info Title=GroupFilter_BaseCondition, 
                                                 Body=Tooltip_GroupFilter_BaseCondition}"></TextBlock>
-                <ComboBox Grid.Row="0" Name="cboBaseConditionEditing" VerticalAlignment="Center"></ComboBox>
-            </StackPanel>
+                        <ComboBox Grid.Row="0" Name="cboBaseCondition" VerticalAlignment="Center" IsEnabled="False"></ComboBox>
+                    </StackPanel>
 
-            <StackPanel Orientation="Horizontal" Margin="0,0,5,5">
-                <CheckBox Name="chkApplyToSeriesEditing" IsChecked="{Binding Path=IsApplyToSeries}" VerticalAlignment="Center"/>
-                <TextBlock Margin="10,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=GroupFilter_ApplyToSeries}" Name="lblApplyToSeriesEditing" />
-            </StackPanel>
-        </StackPanel>
-
-        <!-- Group Filter Conditions and Sorting  -->
-        <StackPanel Grid.Column="0" Grid.Row="4"  Orientation="Horizontal">
-
-            <!-- Group Filter Conditions-->
-            <StackPanel Orientation="Vertical">
-                <StackPanel Orientation="Horizontal">
-                    <Image Height="16" Width="16" Source="/Images/16_filter.png" Margin="10,0,0,0"/>
-                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=GroupFilterConditions}" Margin="5,10,0,10" FontWeight="DemiBold"></TextBlock>
+                    <StackPanel Orientation="Horizontal" Margin="0,0,5,5">
+                        <CheckBox Name="chkApplyToSeries" IsChecked="{Binding Path=IsApplyToSeries}" VerticalAlignment="Center" IsEnabled="False" />
+                        <TextBlock Margin="10,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=GroupFilter_ApplyToSeries}" Name="lblApplyToSeries" />
+                    </StackPanel>
                 </StackPanel>
 
+                <!-- Filter name when in editing mode -->
+                <StackPanel Orientation="Vertical" Name="panelGroupFilterEditing" Margin="10,10,0,0"
+                    Visibility="{Binding Path=IsBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}">
 
+                    <TextBlock Margin="0,0,0,5" Text="{Binding FilterName}" FontSize="18" FontWeight="Bold"
+                      Visibility="{Binding Path=IsSystemGroupFilter, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                    <TextBox Margin="0,0,10,5" Text="{Binding FilterName}" FontSize="16" Padding="5" MinWidth="200" FontWeight="Bold" Name="txtFilterName"
+                     Visibility="{Binding Path=IsNotSystemGroupFilter, Converter={StaticResource BooleanToVisibilityConverter}}"/>
 
-                <ListBox Margin="10,0,0,0" Name="lbFilterConditions" BorderThickness="0" Background="AntiqueWhite" Visibility="{Binding Path=IsNotBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                 HorizontalAlignment="Left" VerticalAlignment="Top" ItemTemplate="{DynamicResource FilterConditionTemplate}" ItemContainerStyle="{DynamicResource ListBoxItemStyleFolders}"
-                                 MaxWidth="500" ItemsSource="{Binding FilterConditions}">
-
-
-                </ListBox>
-                <ListBox Margin="10,0,0,0" Name="lbFilterConditions_Editing" BorderThickness="0" Background="AntiqueWhite" Visibility="{Binding Path=IsBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                 HorizontalAlignment="Left" VerticalAlignment="Top" ItemTemplate="{DynamicResource FilterConditionTemplate_Editing}" ItemContainerStyle="{DynamicResource ListBoxItemStyleFolders}"
-                                 MaxWidth="500" ItemsSource="{Binding FilterConditions}">
-
-
-                </ListBox>
-
-                <Border Margin="11,0,1,0" Style="{DynamicResource ToolbarBorderControlStyle}" Visibility="{Binding Path=IsBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <StackPanel Orientation="Horizontal"  Background="#F1F1F1">
-                        <Button HorizontalAlignment="Left" Name="btnAddCondition" Margin="5,5,5,5" Style="{DynamicResource FlatButtonStyle}" Width="Auto"
-                            Command="{DynamicResource NewFilterConditionCommand}" CommandParameter="{Binding}">
-                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
-                                <Image Height="16" Width="16" Source="/Images/16_add.png" Margin="0,0,5,0"/>
-                                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=New}" Margin="0,0,5,0"/>
-                            </StackPanel>
-                        </Button>
+                    <StackPanel Orientation="Horizontal" Margin="0,0,5,5">
+                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=GroupFilter_BaseCondition}" VerticalAlignment="Center" Margin="0,0,5,0"
+                           ToolTip="{usercontrols:Info Title=GroupFilter_BaseCondition, 
+                                                Body=Tooltip_GroupFilter_BaseCondition}"></TextBlock>
+                        <ComboBox Grid.Row="0" Name="cboBaseConditionEditing" VerticalAlignment="Center"></ComboBox>
                     </StackPanel>
-                </Border>
-            </StackPanel>
 
-            <!-- Sorting-->
-            <StackPanel Orientation="Vertical">
-                <StackPanel Orientation="Horizontal">
-                    <Image Height="16" Width="16" Source="/Images/32_sort.png" Margin="10,0,0,0"/>
-                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=GroupFilterSorting}" Margin="5,10,0,10" FontWeight="DemiBold"></TextBlock>
+                    <StackPanel Orientation="Horizontal" Margin="0,0,5,5">
+                        <CheckBox Name="chkApplyToSeriesEditing" IsChecked="{Binding Path=IsApplyToSeries}" VerticalAlignment="Center"/>
+                        <TextBlock Margin="10,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=GroupFilter_ApplyToSeries}" Name="lblApplyToSeriesEditing" />
+                    </StackPanel>
                 </StackPanel>
 
-
-
-                <ListBox Margin="10,0,0,0" Name="lbSorting" BorderThickness="0" Background="AntiqueWhite" Visibility="{Binding Path=IsNotBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                 HorizontalAlignment="Left" VerticalAlignment="Top" ItemTemplate="{DynamicResource SortingCriteriaTemplate}" ItemContainerStyle="{DynamicResource ListBoxItemStyleFolders}"
-                                 ItemsSource="{Binding SortCriteriaList}">
-
-
-                </ListBox>
-                <ListBox Margin="10,0,0,0" Name="lbSorting_Editing" BorderThickness="0" Background="AntiqueWhite" Visibility="{Binding Path=IsBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                 HorizontalAlignment="Left" VerticalAlignment="Top" ItemTemplate="{DynamicResource SortingCriteriaTemplate_Editing}" ItemContainerStyle="{DynamicResource ListBoxItemStyleFolders}"
-                                 ItemsSource="{Binding SortCriteriaList}">
-
-
-                </ListBox>
-
-                <Border Margin="11,0,1,0" Style="{DynamicResource ToolbarBorderControlStyle}" Visibility="{Binding Path=IsBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <StackPanel Orientation="Horizontal"  Background="#F1F1F1">
-                        <Button HorizontalAlignment="Left" Name="btnAddSorting" Margin="5,5,5,5" Style="{DynamicResource FlatButtonStyle}" Width="Auto"
-                                Command="{DynamicResource NewFilterSortingCommand}" CommandParameter="{Binding}">
-                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
-                                <Image Height="16" Width="16" Source="/Images/16_add.png" Margin="0,0,5,0"/>
-                                <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=New}" Margin="0,0,5,0"/>
-                            </StackPanel>
-                        </Button>
+                <!-- Group Filter Conditions-->
+                <StackPanel Orientation="Vertical">
+                    <StackPanel Orientation="Horizontal">
+                        <Image Height="16" Width="16" Source="/Images/16_filter.png" Margin="10,0,0,0"/>
+                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=GroupFilterConditions}" Margin="5,10,0,10" FontWeight="DemiBold"></TextBlock>
                     </StackPanel>
-                </Border>
 
+
+
+                    <ListBox Margin="10,0,0,0" Name="lbFilterConditions" BorderThickness="0" Background="AntiqueWhite" Visibility="{Binding Path=IsNotBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                        HorizontalAlignment="Left" VerticalAlignment="Top" ItemTemplate="{DynamicResource FilterConditionTemplate}" ItemContainerStyle="{DynamicResource ListBoxItemStyleFolders}"
+                                        MaxWidth="500" ItemsSource="{Binding FilterConditions}">
+
+
+                    </ListBox>
+                    <ListBox Margin="10,0,0,0" Name="lbFilterConditions_Editing" BorderThickness="0" Background="AntiqueWhite" Visibility="{Binding Path=IsBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                        HorizontalAlignment="Left" VerticalAlignment="Top" ItemTemplate="{DynamicResource FilterConditionTemplate_Editing}" ItemContainerStyle="{DynamicResource ListBoxItemStyleFolders}"
+                                        MaxWidth="500" ItemsSource="{Binding FilterConditions}">
+
+
+                    </ListBox>
+
+                    <Border Margin="11,0,1,0" Style="{DynamicResource ToolbarBorderControlStyle}" Visibility="{Binding Path=IsBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <StackPanel Orientation="Horizontal"  Background="#F1F1F1">
+                            <Button HorizontalAlignment="Left" Name="btnAddCondition" Margin="5,5,5,5" Style="{DynamicResource FlatButtonStyle}" Width="Auto"
+                                Command="{DynamicResource NewFilterConditionCommand}" CommandParameter="{Binding}">
+                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
+                                    <Image Height="16" Width="16" Source="/Images/16_add.png" Margin="0,0,5,0"/>
+                                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=New}" Margin="0,0,5,0"/>
+                                </StackPanel>
+                            </Button>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+
+                <!-- Sorting-->
+                <StackPanel Orientation="Vertical">
+                    <StackPanel Orientation="Horizontal">
+                        <Image Height="16" Width="16" Source="/Images/32_sort.png" Margin="10,0,0,0"/>
+                        <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=GroupFilterSorting}" Margin="5,10,0,10" FontWeight="DemiBold"></TextBlock>
+                    </StackPanel>
+
+                    <ListBox Margin="10,0,0,0" Name="lbSorting" BorderThickness="0" Background="AntiqueWhite" Visibility="{Binding Path=IsNotBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                        HorizontalAlignment="Left" VerticalAlignment="Top" ItemTemplate="{DynamicResource SortingCriteriaTemplate}" ItemContainerStyle="{DynamicResource ListBoxItemStyleFolders}"
+                                        ItemsSource="{Binding SortCriteriaList}">
+                    </ListBox>
+                    <ListBox Margin="10,0,0,0" Name="lbSorting_Editing" BorderThickness="0" Background="AntiqueWhite" Visibility="{Binding Path=IsBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                        HorizontalAlignment="Left" VerticalAlignment="Top" ItemTemplate="{DynamicResource SortingCriteriaTemplate_Editing}" ItemContainerStyle="{DynamicResource ListBoxItemStyleFolders}"
+                                        ItemsSource="{Binding SortCriteriaList}">
+                    </ListBox>
+
+                    <Border Margin="11,0,1,0" Style="{DynamicResource ToolbarBorderControlStyle}" Visibility="{Binding Path=IsBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <StackPanel Orientation="Horizontal"  Background="#F1F1F1">
+                            <Button HorizontalAlignment="Left" Name="btnAddSorting" Margin="5,5,5,5" Style="{DynamicResource FlatButtonStyle}" Width="Auto"
+                                    Command="{DynamicResource NewFilterSortingCommand}" CommandParameter="{Binding}">
+                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
+                                    <Image Height="16" Width="16" Source="/Images/16_add.png" Margin="0,0,5,0"/>
+                                    <TextBlock VerticalAlignment="Center" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=New}" Margin="0,0,5,0"/>
+                                </StackPanel>
+                            </Button>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+
+                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=PreviewFilter}" Margin="10,10,0,10" FontWeight="DemiBold"></TextBlock>
+
+                <ListBox BorderThickness="0" ScrollViewer.HorizontalScrollBarVisibility="Disabled" Margin="10,0,0,10"
+                         VirtualizingStackPanel.IsVirtualizing="True" ScrollViewer.CanContentScroll="True"
+                         ItemTemplate="{DynamicResource MainList_AnimeGroupSimpleTemplate}" 
+                         ItemContainerStyle="{DynamicResource ListBoxItemStyleFolders}"
+                         ItemsSource="{Binding Source={x:Static local:MainListHelperVM.Instance},Path=ViewGroupsForms}"
+                         Name="lbGroups" Background="AntiqueWhite" Width="Auto" MinWidth="300" HorizontalAlignment="Left"
+                         VerticalAlignment="Stretch" />
             </StackPanel>
-        </StackPanel>
-
-        <TextBlock Grid.Column="0" Grid.Row="5" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=PreviewFilter}" Margin="10,10,0,10" FontWeight="DemiBold"></TextBlock>
-
-        <ListBox Grid.Column="0" Grid.Row="6" BorderThickness="0" ScrollViewer.HorizontalScrollBarVisibility="Disabled" Margin="10,0,0,10"
-                 VirtualizingStackPanel.IsVirtualizing="True" ScrollViewer.CanContentScroll="True"
-                 ItemTemplate="{DynamicResource MainList_AnimeGroupSimpleTemplate}" 
-                 ItemContainerStyle="{DynamicResource ListBoxItemStyleFolders}"
-                 ItemsSource="{Binding Source={x:Static local:MainListHelperVM.Instance},Path=ViewGroupsForms}"
-                 Name="lbGroups" Background="AntiqueWhite" Width="Auto" MinWidth="300" HorizontalAlignment="Left"
-                 VerticalAlignment="Stretch" />
-
-    </StackPanel>
+        </ScrollViewer>
+    </Grid>
 </UserControl>

--- a/JMMClient/UserControls/PlaylistControl.xaml
+++ b/JMMClient/UserControls/PlaylistControl.xaml
@@ -10,11 +10,7 @@
              xmlns:local="clr-namespace:JMMClient"
              d:DesignHeight="300" d:DesignWidth="600">
     <UserControl.Resources>
-
-        
         <ResourceDictionary>
-
-            
             
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="/Resources/Styles.xaml" />
@@ -178,8 +174,6 @@
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
@@ -235,139 +229,138 @@
 
                 </StackPanel>
 
-
-
             </Border >
 
-            <Grid Margin="0,0,0,0" Grid.Row="1">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
+        <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" Grid.Row="1">
+            <StackPanel Orientation="Vertical">
+                <Grid Margin="0,0,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
 
-
-                <!-- Playlist details (locked) -->
-                <Border BorderThickness="1" BorderBrush="DarkGray" Background="FloralWhite" Padding="5" Margin="5" CornerRadius="4" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3"
-                        Visibility="{Binding Path=IsReadOnly, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <!-- Playlist details (locked) -->
+                    <Border BorderThickness="1" BorderBrush="DarkGray" Background="FloralWhite" Padding="5" Margin="5" CornerRadius="4" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3"
+                            Visibility="{Binding Path=IsReadOnly, Converter={StaticResource BooleanToVisibilityConverter}}">
                     
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Margin="5,0,10,0" Text="{Binding PlaylistName}" FontSize="18" FontWeight="Bold" VerticalAlignment="Center" />
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Margin="5,0,10,0" Text="{Binding PlaylistName}" FontSize="18" FontWeight="Bold" VerticalAlignment="Center" />
 
-                    <CheckBox Name="chkPlayWatchedLocked" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=Playlist_PlayWatched}" VerticalAlignment="Center" Margin="10,0,0,0" IsEnabled="False"
-                                  IsChecked="{Binding Path=PlayWatchedBool}"/>
+                        <CheckBox Name="chkPlayWatchedLocked" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=Playlist_PlayWatched}" VerticalAlignment="Center" Margin="10,0,0,0" IsEnabled="False"
+                                      IsChecked="{Binding Path=PlayWatchedBool}"/>
 
-                    <CheckBox Name="chkPlayUnwatchedLocked" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=Playlist_PlayUnwatched}" VerticalAlignment="Center" Margin="10,0,0,0" IsEnabled="False"
-                                  IsChecked="{Binding Path=PlayUnwatchedBool}"/>
+                        <CheckBox Name="chkPlayUnwatchedLocked" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=Playlist_PlayUnwatched}" VerticalAlignment="Center" Margin="10,0,0,0" IsEnabled="False"
+                                      IsChecked="{Binding Path=PlayUnwatchedBool}"/>
 
-                    <TextBlock Margin="10,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Playlist_Default}" VerticalAlignment="Center" IsEnabled="False" Foreground="DarkGray"/>
+                        <TextBlock Margin="10,0,0,0" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Playlist_Default}" VerticalAlignment="Center" IsEnabled="False" Foreground="DarkGray"/>
 
-                        <ComboBox Grid.Row="0" Name="cboPlayOrderLocked" VerticalAlignment="Center" Margin="5,0,0,0" IsEnabled="False"/>
-                    </StackPanel>
-                </Border>
-
-                <!-- Playlist details (editing) -->
-                <Border BorderThickness="1" BorderBrush="DarkGray" Background="FloralWhite" Padding="5"  Margin="5" CornerRadius="4" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3"
-                        Visibility="{Binding Path=IsBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}">
-
-                    <StackPanel Orientation="Horizontal">
-                        <TextBox Margin="5,0,10,0" Text="{Binding PlaylistName}" FontSize="16"  MinWidth="200" FontWeight="Bold" Name="txtPlaylistName" VerticalAlignment="Center"/>
-
-                    <CheckBox Name="chkPlayWatchedEdit" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=Playlist_PlayWatched}" VerticalAlignment="Center" Margin="10,0,0,0"
-                                  IsChecked="{Binding Path=PlayWatchedBool}"/>
-
-                    <CheckBox Name="chkPlayUnwatchedEdit" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=Playlist_PlayUnwatched}" VerticalAlignment="Center" Margin="10,0,0,0"
-                                  IsChecked="{Binding Path=PlayUnwatchedBool}"/>
-
-                    <TextBlock Margin="10,0,0,2" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Playlist_Default}" VerticalAlignment="Center" />
-
-                        <ComboBox Grid.Row="0" Name="cboPlayOrderEdit" VerticalAlignment="Center" Margin="10,0,0,0" />
-                    </StackPanel>
-                </Border>
-
-
-
-                <!-- Poster/Fanart Image -->
-
-                <Rectangle Margin="10,10,10,10" Grid.Row="1" Grid.Column="1" Grid.RowSpan="3" HorizontalAlignment="Center" VerticalAlignment="Top" Name="imgFanart"
-                                    Visibility="{Binding Path=AniDB_Anime.UseFanartOnPlaylistHeader, Converter={StaticResource BooleanToVisibilityConverter}}" 
-                           RadiusX="5" RadiusY="5" Width="{Binding Source={x:Static local:UserSettingsVM.Instance},Path=PlaylistHeader_Image_Width}" 
-                                   Height="{Binding Source={x:Static local:UserSettingsVM.Instance},Path=PlaylistHeader_Image_Height}">
-                    <Rectangle.Effect>
-                        <DropShadowEffect Opacity="0.5"/>
-                    </Rectangle.Effect>
-                    <Rectangle.Fill>
-                        <ImageBrush ImageSource="{Binding Path=AniDB_Anime.FanartPathThenPosterPathForPlaylistHeader}">
-
-                        </ImageBrush>
-                    </Rectangle.Fill>
-                </Rectangle>
-
-                <Image Height="{Binding Source={x:Static local:UserSettingsVM.Instance},Path=PlaylistHeader_Image_Height}" 
-                               Source="{Binding Path=AniDB_Anime.FanartPathThenPosterPathForPlaylistHeader}" x:Name="myImage"
-                               Margin="10,10,10,10" Grid.Row="1" Grid.Column="1" Grid.RowSpan="3" HorizontalAlignment="Center" VerticalAlignment="Top"
-                               Visibility="{Binding Path=AniDB_Anime.UsePosterOnPlaylistHeader, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <Image.ToolTip>
-                        <Image Stretch="Fill" HorizontalAlignment="Center" Height="400" Source="{Binding AniDB_Anime.FanartPathThenPosterPathForPlaylistHeader}">
-                        </Image>
-                    </Image.ToolTip>
-                    <Image.Effect>
-                        <DropShadowEffect Opacity="0.5"/>
-                    </Image.Effect>
-                </Image>
-
-                <!-- Image size Buttons -->
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Top" Grid.Row="1" Grid.Column="1"  Margin="10,10,0,0"
-                                    Visibility="{Binding Path=IsBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}">
-
-                    <Button Margin="0,0,0,0" Style="{DynamicResource FlatButtonStyle}" Name="btnIncreaseHeaderImageSize">
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
-                            <Image Height="16" Width="16" Source="/Images/16_add.png" Margin="0,0,0,0"/>
+                            <ComboBox Grid.Row="0" Name="cboPlayOrderLocked" VerticalAlignment="Center" Margin="5,0,0,0" IsEnabled="False"/>
                         </StackPanel>
-                    </Button>
+                    </Border>
 
-                    <Button Margin="0,0,0,0" Style="{DynamicResource FlatButtonStyle}"  Name="btnDecreaseHeaderImageSize">
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
-                            <Image Height="16" Width="16" Source="/Images/16_minus.png" Margin="0,0,0,0"/>
+                    <!-- Playlist details (editing) -->
+                    <Border BorderThickness="1" BorderBrush="DarkGray" Background="FloralWhite" Padding="5"  Margin="5" CornerRadius="4" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3"
+                            Visibility="{Binding Path=IsBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}">
+
+                        <StackPanel Orientation="Horizontal">
+                            <TextBox Margin="5,0,10,0" Text="{Binding PlaylistName}" FontSize="16"  MinWidth="200" FontWeight="Bold" Name="txtPlaylistName" VerticalAlignment="Center"/>
+
+                        <CheckBox Name="chkPlayWatchedEdit" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=Playlist_PlayWatched}" VerticalAlignment="Center" Margin="10,0,0,0"
+                                      IsChecked="{Binding Path=PlayWatchedBool}"/>
+
+                        <CheckBox Name="chkPlayUnwatchedEdit" Content="{Resx ResxName=JMMClient.Properties.Resources, Key=Playlist_PlayUnwatched}" VerticalAlignment="Center" Margin="10,0,0,0"
+                                      IsChecked="{Binding Path=PlayUnwatchedBool}"/>
+
+                        <TextBlock Margin="10,0,0,2" Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Playlist_Default}" VerticalAlignment="Center" />
+
+                            <ComboBox Grid.Row="0" Name="cboPlayOrderEdit" VerticalAlignment="Center" Margin="10,0,0,0" />
                         </StackPanel>
-                    </Button>
-                </StackPanel>
+                    </Border>
 
-                <TextBlock VerticalAlignment="Top" Text="{Binding Path=Series.SeriesName}" FontWeight="Bold" FontSize="18" Margin="10,3,0,0" Grid.Row="1" Grid.Column="2" />
 
-                <!-- Play Next Episode -->
-                <usercontrols:PlayNextEpisodeControl x:Name="ucNextEpisodePlaylist" Grid.Row="2" Grid.Column="2" Grid.RowSpan="2" Margin="0,0,0,0" />
 
-            </Grid>
+                    <!-- Poster/Fanart Image -->
 
-            <!-- Header -->
-            <Border Style="{DynamicResource ToolbarBorderControlStyle}" Grid.Row="2" Grid.Column="0" Padding="6" Background="#F1F1F1">
+                    <Rectangle Margin="10,10,10,10" Grid.Row="1" Grid.Column="1" Grid.RowSpan="3" HorizontalAlignment="Center" VerticalAlignment="Top" Name="imgFanart"
+                                        Visibility="{Binding Path=AniDB_Anime.UseFanartOnPlaylistHeader, Converter={StaticResource BooleanToVisibilityConverter}}" 
+                               RadiusX="5" RadiusY="5" Width="{Binding Source={x:Static local:UserSettingsVM.Instance},Path=PlaylistHeader_Image_Width}" 
+                                       Height="{Binding Source={x:Static local:UserSettingsVM.Instance},Path=PlaylistHeader_Image_Height}">
+                        <Rectangle.Effect>
+                            <DropShadowEffect Opacity="0.5"/>
+                        </Rectangle.Effect>
+                        <Rectangle.Fill>
+                            <ImageBrush ImageSource="{Binding Path=AniDB_Anime.FanartPathThenPosterPathForPlaylistHeader}">
+
+                            </ImageBrush>
+                        </Rectangle.Fill>
+                    </Rectangle>
+
+                    <Image Height="{Binding Source={x:Static local:UserSettingsVM.Instance},Path=PlaylistHeader_Image_Height}" 
+                                   Source="{Binding Path=AniDB_Anime.FanartPathThenPosterPathForPlaylistHeader}" x:Name="myImage"
+                                   Margin="10,10,10,10" Grid.Row="1" Grid.Column="1" Grid.RowSpan="3" HorizontalAlignment="Center" VerticalAlignment="Top"
+                                   Visibility="{Binding Path=AniDB_Anime.UsePosterOnPlaylistHeader, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <Image.ToolTip>
+                            <Image Stretch="Fill" HorizontalAlignment="Center" Height="400" Source="{Binding AniDB_Anime.FanartPathThenPosterPathForPlaylistHeader}">
+                            </Image>
+                        </Image.ToolTip>
+                        <Image.Effect>
+                            <DropShadowEffect Opacity="0.5"/>
+                        </Image.Effect>
+                    </Image>
+
+                    <!-- Image size Buttons -->
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Top" Grid.Row="1" Grid.Column="1"  Margin="10,10,0,0"
+                                        Visibility="{Binding Path=IsBeingEdited, Converter={StaticResource BooleanToVisibilityConverter}}">
+
+                        <Button Margin="0,0,0,0" Style="{DynamicResource FlatButtonStyle}" Name="btnIncreaseHeaderImageSize">
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
+                                <Image Height="16" Width="16" Source="/Images/16_add.png" Margin="0,0,0,0"/>
+                            </StackPanel>
+                        </Button>
+
+                        <Button Margin="0,0,0,0" Style="{DynamicResource FlatButtonStyle}"  Name="btnDecreaseHeaderImageSize">
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
+                                <Image Height="16" Width="16" Source="/Images/16_minus.png" Margin="0,0,0,0"/>
+                            </StackPanel>
+                        </Button>
+                    </StackPanel>
+
+                    <TextBlock VerticalAlignment="Top" Text="{Binding Path=Series.SeriesName}" FontWeight="Bold" FontSize="18" Margin="10,3,0,0" Grid.Row="1" Grid.Column="2" />
+
+                    <!-- Play Next Episode -->
+                    <usercontrols:PlayNextEpisodeControl x:Name="ucNextEpisodePlaylist" Grid.Row="2" Grid.Column="2" Grid.RowSpan="2" Margin="0,0,0,0" />
+
+                </Grid>
+
+                <!-- Header -->
+                <Border Style="{DynamicResource ToolbarBorderControlStyle}" Padding="6" Background="#F1F1F1">
                 
-                <StackPanel Orientation="Horizontal">
-                <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Playlist_Items}" FontSize="16" Foreground="DarkGray" VerticalAlignment="Center"/>
+                    <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="{Resx ResxName=JMMClient.Properties.Resources, Key=Playlist_Items}" FontSize="16" Foreground="DarkGray" VerticalAlignment="Center"/>
 
                    
-                </StackPanel>
-            </Border>
+                    </StackPanel>
+                </Border>
 
-            <ListBox Name="lbPlaylistItems" BorderThickness="0" Grid.Row="3" Grid.Column="0" HorizontalAlignment="Stretch"  Margin="0" 
-                 VirtualizingStackPanel.IsVirtualizing="True" ScrollViewer.CanContentScroll="True"
-                 ItemsSource="{Binding PlaylistObjects}"  ItemTemplateSelector="{StaticResource PlaylistTemplateSelector}"
-                 Background="Transparent" ItemContainerStyle="{DynamicResource ListBoxItemStyle}"  VerticalAlignment="Stretch"
-                 dd:DragDrop.IsDragSource="True" dd:DragDrop.IsDropTarget="True" dd:DragDrop.DropHandler="{Binding}">
-            <ListBox.Template>
-                <ControlTemplate>
-                    <ItemsPresenter />
-                </ControlTemplate>
-            </ListBox.Template>
-        </ListBox>
-
-
-        </Grid>
+                <ListBox Name="lbPlaylistItems" BorderThickness="0" HorizontalAlignment="Stretch"  Margin="0" 
+                     VirtualizingStackPanel.IsVirtualizing="True" ScrollViewer.CanContentScroll="True"
+                     ItemsSource="{Binding PlaylistObjects}"  ItemTemplateSelector="{StaticResource PlaylistTemplateSelector}"
+                     Background="Transparent" ItemContainerStyle="{DynamicResource ListBoxItemStyle}"  VerticalAlignment="Stretch"
+                     dd:DragDrop.IsDragSource="True" dd:DragDrop.IsDropTarget="True" dd:DragDrop.DropHandler="{Binding}">
+                    <ListBox.Template>
+                        <ControlTemplate>
+                            <ItemsPresenter />
+                        </ControlTemplate>
+                    </ListBox.Template>
+                </ListBox>
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
 </UserControl>

--- a/JMMClient/ViewModel/MainListHelperVM.cs
+++ b/JMMClient/ViewModel/MainListHelperVM.cs
@@ -175,14 +175,14 @@ namespace JMMClient
             }
         }
 
-        private double playlistScrollerWidth = 10;
-        public double PlaylistScrollerWidth
+        private double playlistWidth = 10;
+        public double PlaylistWidth
         {
-            get { return playlistScrollerWidth; }
+            get { return playlistWidth; }
             set
             {
-                playlistScrollerWidth = value;
-                OnPropertyChanged(new PropertyChangedEventArgs("PlaylistScrollerWidth"));
+                playlistWidth = value;
+                OnPropertyChanged(new PropertyChangedEventArgs("PlaylistWidth"));
 
             }
         }


### PR DESCRIPTION
Modified control hierarchies to move ScrollViewers to appropriate
places to prevent tab bars from scrolling.

Removed a couple ScrollViewers from MainWindow/content and modified the following views:
* Anime Group
* Group Filter Admin
* Playlist