### PR TITLE
Fixed MLHVM.UpdateAll change processing bug

### DIFF
--- a/JMMClient/ViewModel/AnimeSeriesVM.cs
+++ b/JMMClient/ViewModel/AnimeSeriesVM.cs
@@ -428,8 +428,9 @@ namespace JMMClient
                 // Check for group name
                 if (Heirarchy.Count == 0)
                 {
-                    AnimeGroupVM grp = MainListHelperVM.Instance.AllGroupsDictionary[AnimeGroupID];
-                    if (grp != null)
+                    AnimeGroupVM grp;
+
+                    if (MainListHelperVM.Instance.AllGroupsDictionary.TryGetValue(AnimeGroupID, out grp))
                     {
                         GroupName = grp.GroupName;
                     }


### PR DESCRIPTION
Modified MainListHelperVM.UpdateAll so that it processes Groups/Series
in the correct order.
When UpdateAll was called due to executing "Recreate All Groups" it was
processing Series changes before Group changes. This resulted in
KeyNotFoundException being thrown because the AnimeSeriesVM was
referencing AllGroupsDictionary, which was out of date.

This change makes it so that Group changes are processed first so that AllGroupsDictionary is up to date before processing the Series changes.

(I also removed a few redundant dictionary lookups with just Remove/TryGetValue)